### PR TITLE
feat: Improve ACR edition criteria labels with accurate counts

### DIFF
--- a/src/components/acr/EditionSelector.tsx
+++ b/src/components/acr/EditionSelector.tsx
@@ -40,11 +40,29 @@ interface CriteriaProgress {
   status: CriteriaStatus;
 }
 
-function getCriteriaProgress(edition: AcrEdition): CriteriaProgress {
+function getCriteriaCountForEdition(edition: AcrEdition): number {
+  const code = (edition.code || '').toLowerCase();
+  const name = (edition.name || '').toLowerCase();
+  
+  if (code.includes('508') || name.includes('508')) {
+    return 39;
+  }
+  if (code.includes('int') || name.includes('international')) {
+    return 78;
+  }
+  if (code.includes('eu') || name.includes('eu') || name.includes('en 301')) {
+    return 52;
+  }
+  if (code.includes('wcag') || name.includes('wcag')) {
+    return 50;
+  }
+  
   const editionCode = edition.code as AcrEditionCode;
-  const total = DEFAULT_CRITERIA_COUNTS[editionCode] ?? 
-    edition.criteriaCount ?? 
-    (Array.isArray(edition.criteria) && edition.criteria.length > 0 ? edition.criteria.length : 50);
+  return DEFAULT_CRITERIA_COUNTS[editionCode] ?? 50;
+}
+
+function getCriteriaProgress(edition: AcrEdition): CriteriaProgress {
+  const total = getCriteriaCountForEdition(edition);
   
   let evaluated = 0;
   if (Array.isArray(edition.criteria)) {


### PR DESCRIPTION
 ## Summary
  Improved the ACR Edition Selection UI to show accurate criteria counts per VPAT edition instead of showing "0 criteria" or a generic count.

  ## Changes
  - Updated criteria labels from "0 criteria" to "N criteria to evaluate"
  - Added edition-specific criteria counts:
    - Section 508 Edition: 39 criteria
    - WCAG Edition: 50 criteria
    - EU Edition: 52 criteria
    - International Edition: 78 criteria
  - Added visual status indicators (gray/blue/green) for evaluation progress

  ## Before
  All editions showed "0 criteria" which was confusing to users.

  ## After
  Each edition shows accurate count: "39 criteria to evaluate", "50 criteria to evaluate", etc.

  ## Test Plan
  - [ ] Verify Section 508 shows "39 criteria to evaluate"
  - [ ] Verify WCAG shows "50 criteria to evaluate"
  - [ ] Verify EU shows "52 criteria to evaluate"
  - [ ] Verify International shows "78 criteria to evaluate"
  - [ ] Verify labels update correctly when criteria are evaluated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Editions now display progress indicators showing how many criteria have been evaluated.
  * Progress status is color-coded for enhanced visual clarity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->