### PR TITLE
fix: Use backend CloudFront URL for staging API (CORS fix)

### DIFF
--- a/.github/workflows/deploy-frontend-production.yml
+++ b/.github/workflows/deploy-frontend-production.yml
@@ -51,6 +51,8 @@ jobs:
       - name: Build production bundle
         run: npm run build
         env:
+          # TODO: Update with production CloudFront URL when available.
+          # Do NOT use ALB or API Gateway URLs directly - they cause CORS issues.
           VITE_API_URL: http://ninja-alb-prod-1427017841.ap-south-1.elb.amazonaws.com
           VITE_ENV: production
 

--- a/.github/workflows/deploy-frontend-staging.yml
+++ b/.github/workflows/deploy-frontend-staging.yml
@@ -29,7 +29,8 @@ jobs:
       - name: Build staging bundle
         run: npm run build
         env:
-          VITE_API_URL:  https://tl89m5ecxd.execute-api.ap-south-1.amazonaws.com/api/v1
+          # Backend CloudFront URL - required for CORS. Do NOT use API Gateway URL directly.
+          VITE_API_URL: https://d1ruc3qmc844x9.cloudfront.net/api/v1
           VITE_ENV: staging
 
       - name: Configure AWS credentials


### PR DESCRIPTION
 ## Summary
  Fix CORS errors by updating the staging frontend to use the backend CloudFront URL instead of API Gateway.

  ## Problem
  Login and API requests from CloudFront frontend were blocked by CORS because API Gateway wasn't forwarding the `Origin` header properly.

  ## Solution
  - Updated staging workflow to use backend CloudFront URL: `https://d1ruc3qmc844x9.cloudfront.net/api/v1`
  - Backend CloudFront has `CORS-S3Origin` policy that properly forwards Origin headers
  - Added TODO for production CloudFront setup

  ## Test Plan
  - [ ] Merge and deploy to staging
  - [ ] Test login at https://dhi5xqbewozlg.cloudfront.net/login
  - [ ] Verify no CORS errors in browser console

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration to improve API connectivity and resolve CORS-related issues across staging and production environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->