### PR TITLE
feat: presigned S3 URL upload for feedback attachments

### DIFF
--- a/src/services/feedback-attachment.service.ts
+++ b/src/services/feedback-attachment.service.ts
@@ -8,11 +8,56 @@ export const feedbackAttachmentService = {
   },
 
   async upload(feedbackId: string, files: File[]): Promise<FeedbackAttachment[]> {
-    const formData = new FormData();
-    files.forEach(file => formData.append('files', file));
+    const results: FeedbackAttachment[] = [];
 
-    const response = await api.post(`/feedback/${feedbackId}/attachments`, formData);
-    return response.data.data;
+    for (const file of files) {
+      try {
+        const presignResponse = await api.post(`/feedback/${feedbackId}/attachments/presign`, {
+          filename: file.name,
+          contentType: file.type || 'application/octet-stream',
+          size: file.size,
+        });
+
+        const { presignedUrl, s3Key, useDirectUpload } = presignResponse.data.data;
+
+        if (useDirectUpload) {
+          const formData = new FormData();
+          formData.append('files', file);
+          const response = await api.post(`/feedback/${feedbackId}/attachments`, formData);
+          if (response.data.data) {
+            results.push(...(Array.isArray(response.data.data) ? response.data.data : [response.data.data]));
+          }
+        } else {
+          const uploadResponse = await fetch(presignedUrl, {
+            method: 'PUT',
+            body: file,
+            headers: {
+              'Content-Type': file.type || 'application/octet-stream',
+            },
+          });
+
+          if (!uploadResponse.ok) {
+            throw new Error(`S3 upload failed: ${uploadResponse.status} ${uploadResponse.statusText}`);
+          }
+
+          const confirmResponse = await api.post(`/feedback/${feedbackId}/attachments/confirm`, {
+            s3Key,
+            originalName: file.name,
+            mimeType: file.type || 'application/octet-stream',
+            size: file.size,
+          });
+
+          if (confirmResponse.data.data) {
+            results.push(confirmResponse.data.data);
+          }
+        }
+      } catch (error) {
+        console.error(`Failed to upload ${file.name}:`, error);
+        throw error;
+      }
+    }
+
+    return results;
   },
 
   async getDownloadUrl(attachmentId: string): Promise<{ url: string }> {


### PR DESCRIPTION
Update attachment upload to use presigned S3 URLs to bypass CloudFront/WAF

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced file upload process with individual file handling and improved error management. Upload flow now processes each file separately with better reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->