### PR TITLE
feat: per-page timing instrumentation and timesheet UI extensions

### DIFF
--- a/src/components/bootstrap/ZoneReviewWorkspace.tsx
+++ b/src/components/bootstrap/ZoneReviewWorkspace.tsx
@@ -114,8 +114,13 @@ export default function ZoneReviewWorkspace({
   const autoAnnotateMutation = useAutoAnnotate(runId);
   const comparisonMutation = useRunComparison(runId);
 
-  // Annotation timer
-  const { recordDecision } = useAnnotationTimer(runId);
+  // Annotation timer — tracks per-page effort by syncing currentPage into sessionLog segments
+  const { recordDecision, setCurrentPage: setTimerPage } = useAnnotationTimer(runId);
+
+  // Sync page changes into the timer so per-page timing can be derived from sessionLog
+  useEffect(() => {
+    setTimerPage(currentPage);
+  }, [currentPage, setTimerPage]);
 
   // Correction reason
   const [correctionReason, setCorrectionReason] = useState('');

--- a/src/hooks/useAnnotationTimer.ts
+++ b/src/hooks/useAnnotationTimer.ts
@@ -6,6 +6,8 @@ interface SessionSegment {
   closedAt: string;
   activeMs: number;
   idleMs: number;
+  /** Page number the annotator was looking at during this segment (nullable for backward compat). */
+  pageNumber?: number | null;
 }
 
 interface TimerState {
@@ -17,6 +19,8 @@ interface TimerState {
   zonesConfirmed: number;
   zonesCorrected: number;
   zonesRejected: number;
+  /** Current page the annotator is viewing — captured into each new segment. */
+  currentPage: number | null;
 }
 
 const IDLE_THRESHOLD_MS = 2 * 60 * 1000;
@@ -39,11 +43,13 @@ export function useAnnotationTimer(runId: string) {
     zonesConfirmed: 0,
     zonesCorrected: 0,
     zonesRejected: 0,
+    currentPage: null,
   });
 
   const sessionIdRef = useRef<string | null>(null);
   const segmentStartRef = useRef<number | null>(null);
   const segmentOpenedAtRef = useRef<string | null>(null);
+  const segmentPageRef = useRef<number | null>(null);
   const idleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [isIdle, setIsIdle] = useState(false);
   const isIdleRef = useRef(false);
@@ -52,6 +58,7 @@ export function useAnnotationTimer(runId: string) {
     if (segmentStartRef.current !== null) return;
     segmentStartRef.current = Date.now();
     segmentOpenedAtRef.current = new Date().toISOString();
+    segmentPageRef.current = stateRef.current.currentPage;
   }, []);
 
   const closeSegment = useCallback(() => {
@@ -69,11 +76,30 @@ export function useAnnotationTimer(runId: string) {
       closedAt,
       activeMs: segActiveMs,
       idleMs: Math.max(0, segIdleMs),
+      pageNumber: segmentPageRef.current,
     });
 
     segmentStartRef.current = null;
     segmentOpenedAtRef.current = null;
+    segmentPageRef.current = null;
   }, []);
+
+  /**
+   * Update the current page being viewed. Closes the current timing segment and
+   * opens a new one so per-page effort can be aggregated from sessionLog.
+   */
+  const setCurrentPage = useCallback(
+    (pageNumber: number) => {
+      if (stateRef.current.currentPage === pageNumber) return;
+      const wasOpen = segmentStartRef.current !== null;
+      if (wasOpen) closeSegment();
+      stateRef.current.currentPage = pageNumber;
+      if (wasOpen && !stateRef.current.stopped && !document.hidden && !isIdleRef.current) {
+        startSegment();
+      }
+    },
+    [closeSegment, startSegment],
+  );
 
   const resetIdleTimer = useCallback(() => {
     if (stateRef.current.stopped) return;
@@ -180,6 +206,7 @@ export function useAnnotationTimer(runId: string) {
     idleMs: stateRef.current.idleMs,
     isIdle,
     recordDecision,
+    setCurrentPage,
     stop,
   };
 }

--- a/src/pages/calibration/AnnotationTimesheetPage.tsx
+++ b/src/pages/calibration/AnnotationTimesheetPage.tsx
@@ -66,9 +66,11 @@ export default function AnnotationTimesheetPage() {
   ];
 
   const reviewModeBadge = (mode: string | undefined) => {
+    if (mode === 'deep') return 'bg-green-100 text-green-800';
     if (mode === 'sampling') return 'bg-yellow-100 text-yellow-800';
     if (mode === 'unreviewed') return 'bg-gray-100 text-gray-500';
-    return 'bg-green-100 text-green-800';
+    // Unknown / missing — neutral so older reports without reviewMode aren't shown as deeply reviewed
+    return 'bg-gray-100 text-gray-500';
   };
 
   return (
@@ -256,7 +258,7 @@ export default function AnnotationTimesheetPage() {
                     <td className="py-2 pr-3 text-right text-red-600">{p.rejected ?? 0}</td>
                     <td className="py-2">
                       <span className={`px-2 py-0.5 text-xs font-medium rounded ${reviewModeBadge(p.reviewMode)}`}>
-                        {p.reviewMode ?? 'deep'}
+                        {p.reviewMode ?? '--'}
                       </span>
                     </td>
                   </tr>

--- a/src/pages/calibration/AnnotationTimesheetPage.tsx
+++ b/src/pages/calibration/AnnotationTimesheetPage.tsx
@@ -24,7 +24,7 @@ function fmtDate(d: string | null | undefined): string {
   });
 }
 
-type Tab = 'summary' | 'operators' | 'pages' | 'efficiency';
+type Tab = 'summary' | 'operators' | 'pages' | 'zoneTypes' | 'efficiency';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 export default function AnnotationTimesheetPage() {
@@ -54,14 +54,22 @@ export default function AnnotationTimesheetPage() {
   const ts = report.timeSummary ?? {};
   const operators: any[] = report.byOperator ?? [];
   const pages: any[] = report.byPage ?? [];
+  const zoneTypes: any[] = report.zoneTypeBreakdown ?? [];
   const efficiency = report.efficiency ?? {};
 
   const tabs: { key: Tab; label: string }[] = [
     { key: 'summary', label: 'Time Summary' },
     { key: 'operators', label: 'By Operator' },
     { key: 'pages', label: 'By Page' },
+    { key: 'zoneTypes', label: 'By Zone Type' },
     { key: 'efficiency', label: 'Efficiency' },
   ];
+
+  const reviewModeBadge = (mode: string | undefined) => {
+    if (mode === 'sampling') return 'bg-yellow-100 text-yellow-800';
+    if (mode === 'unreviewed') return 'bg-gray-100 text-gray-500';
+    return 'bg-green-100 text-green-800';
+  };
 
   return (
     <div className="max-w-7xl mx-auto space-y-6 p-6">
@@ -227,7 +235,8 @@ export default function AnnotationTimesheetPage() {
                   <th className="text-right py-2 pr-3">Zones/Min</th>
                   <th className="text-right py-2 pr-3">Confirmed</th>
                   <th className="text-right py-2 pr-3">Corrected</th>
-                  <th className="text-right py-2">Rejected</th>
+                  <th className="text-right py-2 pr-3">Rejected</th>
+                  <th className="text-left py-2">Review Mode</th>
                 </tr>
               </thead>
               <tbody>
@@ -235,15 +244,67 @@ export default function AnnotationTimesheetPage() {
                   <tr key={p.pageNumber ?? i} className="border-b last:border-0 hover:bg-gray-50">
                     <td className="py-2 pr-3">{p.pageNumber}</td>
                     <td className="py-2 pr-3 text-right">{p.zones}</td>
-                    <td className="py-2 pr-3 text-right">{fmtMs(p.timeSpentMs)}</td>
+                    <td className="py-2 pr-3 text-right">
+                      {fmtMs(p.timeSpentMs)}
+                      {p.timingSource === 'derived' && (
+                        <span className="ml-1 text-xs text-gray-400" title="Estimated from total active time">~</span>
+                      )}
+                    </td>
                     <td className="py-2 pr-3 text-right">{p.zonesPerMin?.toFixed(1) ?? '--'}</td>
                     <td className="py-2 pr-3 text-right text-green-600">{p.confirmed ?? 0}</td>
                     <td className="py-2 pr-3 text-right text-yellow-600">{p.corrected ?? 0}</td>
-                    <td className="py-2 text-right text-red-600">{p.rejected ?? 0}</td>
+                    <td className="py-2 pr-3 text-right text-red-600">{p.rejected ?? 0}</td>
+                    <td className="py-2">
+                      <span className={`px-2 py-0.5 text-xs font-medium rounded ${reviewModeBadge(p.reviewMode)}`}>
+                        {p.reviewMode ?? 'deep'}
+                      </span>
+                    </td>
                   </tr>
                 ))}
                 {pages.length === 0 && (
-                  <tr><td colSpan={7} className="py-8 text-center text-gray-400">No page data</td></tr>
+                  <tr><td colSpan={8} className="py-8 text-center text-gray-400">No page data</td></tr>
+                )}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+
+      {tab === 'zoneTypes' && (
+        <div className="bg-white rounded-lg shadow p-4">
+          <p className="text-xs text-gray-500 mb-3">
+            Correction rate by zone type — high <span className="text-yellow-600 font-medium">Correct%</span> indicates the AI is
+            mislabeling this type frequently and driving annotator workload.
+          </p>
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b text-xs text-gray-500">
+                  <th className="text-left py-2 pr-3">Zone Type</th>
+                  <th className="text-right py-2 pr-3">Total</th>
+                  <th className="text-right py-2 pr-3">Confirmed</th>
+                  <th className="text-right py-2 pr-3">Corrected</th>
+                  <th className="text-right py-2 pr-3">Rejected</th>
+                  <th className="text-right py-2 pr-3">Confirm %</th>
+                  <th className="text-right py-2 pr-3">Correct %</th>
+                  <th className="text-right py-2">Reject %</th>
+                </tr>
+              </thead>
+              <tbody>
+                {zoneTypes.map((z: any, i: number) => (
+                  <tr key={z.zoneType ?? i} className="border-b last:border-0 hover:bg-gray-50">
+                    <td className="py-2 pr-3 font-mono text-xs">{z.zoneType}</td>
+                    <td className="py-2 pr-3 text-right">{z.total}</td>
+                    <td className="py-2 pr-3 text-right text-green-600">{z.confirmed}</td>
+                    <td className="py-2 pr-3 text-right text-yellow-600">{z.corrected}</td>
+                    <td className="py-2 pr-3 text-right text-red-600">{z.rejected}</td>
+                    <td className="py-2 pr-3 text-right">{z.confirmPct != null ? `${(z.confirmPct * 100).toFixed(1)}%` : '--'}</td>
+                    <td className="py-2 pr-3 text-right">{z.correctPct != null ? `${(z.correctPct * 100).toFixed(1)}%` : '--'}</td>
+                    <td className="py-2 text-right">{z.rejectPct != null ? `${(z.rejectPct * 100).toFixed(1)}%` : '--'}</td>
+                  </tr>
+                ))}
+                {zoneTypes.length === 0 && (
+                  <tr><td colSpan={8} className="py-8 text-center text-gray-400">No zone type data</td></tr>
                 )}
               </tbody>
             </table>


### PR DESCRIPTION
## Summary
Frontend instrumentation that lets the backend timesheet report distinguish *measured* from *derived* per-page time, plus the new UI columns/tabs that surface phase-shift detection and zone-type correction breakdowns.

### Hook: `useAnnotationTimer.ts`
- `SessionSegment` gains an optional `pageNumber` field.
- `TimerState` tracks `currentPage`; new `setCurrentPage(pageNumber)` callback closes the open segment, updates the page, and reopens a fresh segment so per-page effort can be aggregated by the backend.
- Backwards-compatible: older sessions without `pageNumber` still aggregate via apportionment on the backend.

### Workspace: `ZoneReviewWorkspace.tsx`
- Wires `currentPage` from the workspace into the timer via `setTimerPage` so segment ownership tracks the PDF page the annotator is actually viewing.

### Page: `AnnotationTimesheetPage.tsx`
- New **Zone Types** tab — surfaces `zoneTypeBreakdown` with confirm/correct/reject percentages so reviewers can see which zone types drive the bulk of corrections.
- **Pages** tab gains a Review Mode badge column (`deep` / `sampling` / `unreviewed`) and a `~` tilde marker on time cells when `timingSource === 'derived'`, so derived rows are visually distinct from measured rows.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [ ] Open Zone Review on a calibration run, page through the document, end the session, and confirm the resulting timesheet shows real per-page variance instead of constant `ZonesPerMin`
- [ ] Open Annotation Timesheet → Pages tab and verify that pages with no segments still appear with a `~` tilde
- [ ] Switch to the new Zone Types tab and verify confirm/correct/reject percentages render

## Notes
Backend companion PR: s4cindia/ninja-backend#340 (`feat/timesheet-per-page-and-ai-rerun`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "By Zone Type" tab to calibration timesheet showing zone breakdown with performance percentages.
  * Added "Review Mode" column to pages table to surface review status.
  * Improved per-page timing and tracking so time is derived per page (timesheet shows "~" for derived values); zone review now updates page tracking for more accurate effort measurements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->