### PR TITLE
fix: track bulk Confirm All Green zones in session timer

### DIFF
--- a/src/components/bootstrap/ZoneReviewWorkspace.tsx
+++ b/src/components/bootstrap/ZoneReviewWorkspace.tsx
@@ -115,7 +115,7 @@ export default function ZoneReviewWorkspace({
   const comparisonMutation = useRunComparison(runId);
 
   // Annotation timer — tracks per-page effort by syncing currentPage into sessionLog segments
-  const { recordDecision, setCurrentPage: setTimerPage } = useAnnotationTimer(runId);
+  const { recordDecision, recordBulkDecision, setCurrentPage: setTimerPage } = useAnnotationTimer(runId);
 
   // Sync page changes into the timer so per-page timing can be derived from sessionLog
   useEffect(() => {
@@ -204,8 +204,14 @@ export default function ZoneReviewWorkspace({
   const handleDismiss = useCallback(() => setSelectedZoneId(null), []);
 
   const handleConfirmAllGreen = useCallback(() => {
-    confirmAllGreen.mutate();
-  }, [confirmAllGreen]);
+    confirmAllGreen.mutate(undefined, {
+      onSuccess: (data) => {
+        if (data?.confirmedCount) {
+          recordBulkDecision(data.confirmedCount, 'confirm');
+        }
+      },
+    });
+  }, [confirmAllGreen, recordBulkDecision]);
 
   // Keyboard shortcuts
   useEffect(() => {

--- a/src/hooks/useAnnotationTimer.ts
+++ b/src/hooks/useAnnotationTimer.ts
@@ -163,6 +163,15 @@ export function useAnnotationTimer(runId: string) {
     else if (type === 'reject') stateRef.current.zonesRejected++;
   }, []);
 
+  /** Batch-increment counters for bulk operations (e.g., Confirm All Green). */
+  const recordBulkDecision = useCallback((count: number, type: 'confirm' | 'correct' | 'reject') => {
+    if (count <= 0) return;
+    stateRef.current.zonesReviewed += count;
+    if (type === 'confirm') stateRef.current.zonesConfirmed += count;
+    else if (type === 'correct') stateRef.current.zonesCorrected += count;
+    else if (type === 'reject') stateRef.current.zonesRejected += count;
+  }, []);
+
   // Mount / unmount
   useEffect(() => {
     if (!runId) return;
@@ -206,6 +215,7 @@ export function useAnnotationTimer(runId: string) {
     idleMs: stateRef.current.idleMs,
     isIdle,
     recordDecision,
+    recordBulkDecision,
     setCurrentPage,
     stop,
   };


### PR DESCRIPTION
## Summary
- `handleConfirmAllGreen` bulk-confirmed all unreviewed GREEN-bucket zones via `updateMany` but never incremented the session timer counters. This caused the timesheet to undercount operator throughput (e.g., 1,665 zones verified but only 406 tracked on cmnpdryw).
- Added `recordBulkDecision(count, type)` to `useAnnotationTimer` and wired it into the mutation's `onSuccess` using the `confirmedCount` returned by the backend.

## Root cause
`ZoneReviewWorkspace.tsx:206-208` called `confirmAllGreen.mutate()` without calling `recordDecision()`. The backend `POST /runs/:runId/confirm-all-green` sets `verifiedBy` to the logged-in user on all GREEN zones, but the session timer never saw them — so the timesheet operator breakdown (which reads from `AnnotationSession` records, not the `Zone` table) showed 406 instead of 1,665.

## Changes
- `useAnnotationTimer.ts`: new `recordBulkDecision(count, type)` batch-increments `zonesReviewed` + the appropriate decision counter
- `ZoneReviewWorkspace.tsx`: `handleConfirmAllGreen` now passes an `onSuccess` callback that feeds `data.confirmedCount` into `recordBulkDecision`

## Test plan
- [x] `npm run type-check` clean
- [x] `npm run lint` clean
- [ ] Open Zone Review workspace, click "Confirm All Green", end the session, check timesheet — `zonesReviewed` should now include the bulk-confirmed count

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced tracking of bulk zone review decisions to accurately record confirmation counts and decision types when performing batch operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->