### PR TITLE
feat: annotation analysis UI with mark complete

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -87,6 +87,8 @@ import AnnotationTimesheetPage from '@/pages/calibration/AnnotationTimesheetPage
 import ComparisonReportPage from '@/pages/calibration/ComparisonReportPage';
 import AnnotationGuidePage from '@/pages/calibration/AnnotationGuidePage';
 import AggregateComparisonPage from '@/pages/calibration/AggregateComparisonPage';
+import AnnotationAnalysisPage from '@/pages/calibration/AnnotationAnalysisPage';
+import CorpusSummaryPage from '@/pages/calibration/CorpusSummaryPage';
 import AdminCorpusPage from '@/pages/admin/AdminCorpusPage';
 import AdminUsersPage from '@/pages/admin/AdminUsersPage';
 const queryClient = new QueryClient({
@@ -268,6 +270,8 @@ function AppRoutes() {
           <Route path="/bootstrap/lineage/:runId" element={<OperatorLineagePage />} />
           <Route path="/calibration/runs/:runId/annotation-report" element={<AnnotationReportPage />} />
           <Route path="/calibration/runs/:runId/timesheet" element={<AnnotationTimesheetPage />} />
+          <Route path="/calibration/runs/:runId/analysis" element={<AnnotationAnalysisPage />} />
+          <Route path="/calibration/corpus/summary" element={<CorpusSummaryPage />} />
           <Route path="/calibration/comparison-report/:runId" element={<ComparisonReportPage />} />
           <Route path="/calibration/annotation-guide/:runId" element={<AnnotationGuidePage />} />
           <Route path="/calibration/aggregate-report" element={<AggregateComparisonPage />} />

--- a/src/components/bootstrap/DocumentQueueView.tsx
+++ b/src/components/bootstrap/DocumentQueueView.tsx
@@ -251,13 +251,21 @@ export default function DocumentQueueView() {
         <p className="mt-1 text-sm text-gray-500">
           Review and annotate documents for ML zone detection training
         </p>
-        <button
-          onClick={handleReset}
-          disabled={resetting}
-          className="mt-2 px-3 py-1.5 text-xs font-medium rounded bg-red-600 text-white hover:bg-red-700 disabled:opacity-50 transition-colors"
-        >
-          {resetting ? 'Resetting...' : 'Reset Corpus'}
-        </button>
+        <div className="mt-2 flex items-center gap-2">
+          <button
+            onClick={handleReset}
+            disabled={resetting}
+            className="px-3 py-1.5 text-xs font-medium rounded bg-red-600 text-white hover:bg-red-700 disabled:opacity-50 transition-colors"
+          >
+            {resetting ? 'Resetting...' : 'Reset Corpus'}
+          </button>
+          <button
+            onClick={() => navigate('/calibration/corpus/summary')}
+            className="px-4 py-1.5 text-xs font-medium rounded bg-purple-600 text-white hover:bg-purple-700 transition-colors"
+          >
+            Corpus Summary
+          </button>
+        </div>
       </div>
 
       {/* Filter bar */}
@@ -429,6 +437,12 @@ export default function DocumentQueueView() {
                                     className="border border-gray-300 text-gray-600 text-xs px-3 py-1 rounded hover:bg-gray-50 transition-colors"
                                   >
                                     Timesheet
+                                  </button>
+                                  <button
+                                    onClick={() => navigate(`/calibration/runs/${doc.calibrationRuns![0].id}/analysis`)}
+                                    className="border border-purple-300 text-purple-600 text-xs px-3 py-1 rounded hover:bg-purple-50 transition-colors"
+                                  >
+                                    Analysis
                                   </button>
                                 </>
                               )}

--- a/src/components/bootstrap/ZoneReviewWorkspace.tsx
+++ b/src/components/bootstrap/ZoneReviewWorkspace.tsx
@@ -21,6 +21,7 @@ import type { AiAnnotationStatusResponse } from '@/services/zone-correction.serv
 import { useTaggedPdfUrl } from '@/hooks/useTaggedPdfUrl';
 import { useAnnotationTimer } from '@/hooks/useAnnotationTimer';
 import { api } from '@/services/api';
+import { annotationReportService } from '@/services/annotation-report.service';
 import { PageThumbnailNav } from './PageThumbnailNav';
 import ZonePdfPanel from './ZonePdfPanel';
 import ZoneComparisonDetailBar from './ZoneComparisonDetailBar';
@@ -75,6 +76,8 @@ export default function ZoneReviewWorkspace({
   const [aiProgress, setAiProgress] = useState<AiAnnotationStatusResponse | null>(null);
   const aiPollRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const [comparisonResult, setComparisonResult] = useState<ComparisonResult | null>(null);
+  const [completing, setCompleting] = useState(false);
+  const [completeBanner, setCompleteBanner] = useState<{ type: 'success' | 'error'; message: string } | null>(null);
 
   // Keep page input in sync with currentPage (arrow buttons, thumbnail clicks, etc.)
   useEffect(() => {
@@ -354,6 +357,21 @@ export default function ZoneReviewWorkspace({
     });
   }, [comparisonMutation]);
 
+  const handleMarkComplete = useCallback(async () => {
+    if (!runId) return;
+    if (!window.confirm('Mark annotation as complete and generate analysis report? This will set completedAt on the run.')) return;
+    setCompleting(true);
+    setCompleteBanner(null);
+    try {
+      await annotationReportService.markAnnotationComplete(runId);
+      setCompleteBanner({ type: 'success', message: 'Analysis report generated. View it from the Analysis button.' });
+    } catch (err) {
+      setCompleteBanner({ type: 'error', message: err instanceof Error ? err.message : 'Failed to generate analysis report' });
+    } finally {
+      setCompleting(false);
+    }
+  }, [runId]);
+
   return (
     <div className="flex flex-col h-[calc(100vh-64px)] bg-gray-50">
       {/* Toolbar */}
@@ -462,6 +480,23 @@ export default function ZoneReviewWorkspace({
                 </svg>
               )}
               {comparisonMutation.isPending ? 'Comparing...' : 'Compare'}
+            </button>
+          )}
+
+          {/* Mark Complete (hidden for OPERATOR) */}
+          {!isOperator && runId && (
+            <button
+              onClick={handleMarkComplete}
+              disabled={completing}
+              className="px-3 py-1.5 text-xs font-medium rounded bg-green-600 text-white hover:bg-green-700 disabled:opacity-50 disabled:cursor-not-allowed inline-flex items-center gap-1.5"
+            >
+              {completing && (
+                <svg className="animate-spin h-3.5 w-3.5" viewBox="0 0 24 24" fill="none">
+                  <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                  <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+                </svg>
+              )}
+              {completing ? 'Generating Analysis...' : 'Mark Complete'}
             </button>
           )}
 
@@ -652,6 +687,33 @@ export default function ZoneReviewWorkspace({
           <button
             onClick={() => setComparisonResult(null)}
             className="text-blue-600 hover:text-blue-800 text-lg leading-none"
+          >
+            &times;
+          </button>
+        </div>
+      )}
+
+      {/* Mark-complete banner */}
+      {completeBanner && (
+        <div className={`flex items-center justify-between px-4 py-2 border-b text-sm ${
+          completeBanner.type === 'success'
+            ? 'bg-green-50 border-green-200 text-green-800'
+            : 'bg-red-50 border-red-200 text-red-800'
+        }`}>
+          <span>
+            {completeBanner.message}
+            {completeBanner.type === 'success' && runId && (
+              <button
+                onClick={() => navigate(`/calibration/runs/${runId}/analysis`)}
+                className="ml-2 text-green-600 underline hover:text-green-800"
+              >
+                View Analysis &rarr;
+              </button>
+            )}
+          </span>
+          <button
+            onClick={() => setCompleteBanner(null)}
+            className={`text-lg leading-none ${completeBanner.type === 'success' ? 'text-green-600 hover:text-green-800' : 'text-red-600 hover:text-red-800'}`}
           >
             &times;
           </button>

--- a/src/components/bootstrap/ZoneReviewWorkspace.tsx
+++ b/src/components/bootstrap/ZoneReviewWorkspace.tsx
@@ -364,13 +364,14 @@ export default function ZoneReviewWorkspace({
     setCompleteBanner(null);
     try {
       await annotationReportService.markAnnotationComplete(runId);
+      queryClient.invalidateQueries({ queryKey: ['calibration', 'runs'] });
       setCompleteBanner({ type: 'success', message: 'Analysis report generated. View it from the Analysis button.' });
     } catch (err) {
       setCompleteBanner({ type: 'error', message: err instanceof Error ? err.message : 'Failed to generate analysis report' });
     } finally {
       setCompleting(false);
     }
-  }, [runId]);
+  }, [runId, queryClient]);
 
   return (
     <div className="flex flex-col h-[calc(100vh-64px)] bg-gray-50">

--- a/src/pages/calibration/AnnotationAnalysisPage.tsx
+++ b/src/pages/calibration/AnnotationAnalysisPage.tsx
@@ -1,0 +1,206 @@
+import { useState } from 'react';
+import { useParams, Link } from 'react-router-dom';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { annotationReportService } from '@/services/annotation-report.service';
+
+/* Minimal markdown-to-HTML: handles ##, |tables|, **bold**, - bullets, \n */
+function renderMarkdown(md: string): string {
+  return md
+    .split('\n')
+    .map((line) => {
+      if (line.startsWith('#### ')) return `<h4 class="text-sm font-semibold mt-3 mb-1">${line.slice(5)}</h4>`;
+      if (line.startsWith('### ')) return `<h3 class="text-base font-semibold mt-4 mb-2">${line.slice(4)}</h3>`;
+      if (line.startsWith('## ')) return `<h2 class="text-lg font-bold mt-6 mb-2">${line.slice(3)}</h2>`;
+      if (line.startsWith('# ')) return `<h1 class="text-xl font-bold mt-6 mb-3">${line.slice(2)}</h1>`;
+      if (line.startsWith('|')) {
+        const cells = line.split('|').filter(Boolean).map((c) => c.trim());
+        if (cells.every((c) => /^[-:]+$/.test(c))) return '';
+        return `<tr>${cells.map((c) => `<td class="border border-gray-200 px-2 py-1 text-sm">${c}</td>`).join('')}</tr>`;
+      }
+      if (line.trim().startsWith('- ')) {
+        const content = line.trim().slice(2);
+        return `<li class="text-sm text-gray-700 ml-4 list-disc">${content.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')}</li>`;
+      }
+      if (line.trim() === '') return '<br/>';
+      return `<p class="text-sm text-gray-700 mb-1">${line.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')}</p>`;
+    })
+    .join('\n');
+}
+
+interface AnalysisReport {
+  markdown: string;
+  generatedAt: string;
+  model: string;
+  tokenUsage: { promptTokens: number; completionTokens: number };
+}
+
+interface CostBreakdown {
+  aiAnnotationCostUsd: number;
+  aiReportCostUsd: number;
+  annotatorActiveHours: number;
+  annotatorCostInr: number;
+  totalCostInr: number;
+}
+
+interface AnalysisResult {
+  report: AnalysisReport;
+  costBreakdown: CostBreakdown;
+}
+
+const USD_TO_INR = 85;
+
+export default function AnnotationAnalysisPage() {
+  const { runId } = useParams<{ runId: string }>();
+  const queryClient = useQueryClient();
+  const [activeTab, setActiveTab] = useState<'report' | 'cost'>('report');
+  const [regenerating, setRegenerating] = useState(false);
+
+  const { data, isLoading, error } = useQuery<AnalysisResult>({
+    queryKey: ['analysis-report', runId],
+    queryFn: () => annotationReportService.getAnalysis(runId!),
+    enabled: !!runId,
+  });
+
+  const handleRegenerate = async () => {
+    if (!runId || !window.confirm('Regenerate the analysis report? This will overwrite the existing report.')) return;
+    setRegenerating(true);
+    try {
+      await annotationReportService.markAnnotationComplete(runId);
+      queryClient.invalidateQueries({ queryKey: ['analysis-report', runId] });
+    } finally {
+      setRegenerating(false);
+    }
+  };
+
+  const handleExportMarkdown = () => {
+    if (!data?.report.markdown) return;
+    const blob = new Blob([data.report.markdown], { type: 'text/markdown' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `analysis-report-${runId?.slice(0, 8)}.md`;
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center h-64">
+        <div className="text-gray-500">Loading analysis report...</div>
+      </div>
+    );
+  }
+
+  if (error || !data) {
+    return (
+      <div className="max-w-4xl mx-auto p-6">
+        <Link to="/bootstrap" className="text-sm text-gray-500 hover:text-gray-700 mb-4 inline-block">&larr; Back to Console</Link>
+        <div className="bg-red-50 border border-red-200 rounded p-4 text-red-700 text-sm">
+          {error instanceof Error ? error.message : 'No analysis report found. Click "Mark Complete" on the Zone Review page to generate one.'}
+        </div>
+      </div>
+    );
+  }
+
+  const { report, costBreakdown: cb } = data;
+
+  return (
+    <div className="max-w-5xl mx-auto p-6">
+      <Link to="/bootstrap" className="text-sm text-gray-500 hover:text-gray-700 mb-4 inline-block">&larr; Back to Console</Link>
+
+      <div className="flex items-center justify-between mb-4">
+        <h1 className="text-xl font-bold text-gray-900">Annotation Analysis Report</h1>
+        <div className="flex items-center gap-2">
+          <button
+            onClick={handleRegenerate}
+            disabled={regenerating}
+            className="px-3 py-1.5 text-xs font-medium rounded border border-gray-300 text-gray-600 hover:bg-gray-50 disabled:opacity-50 inline-flex items-center gap-1.5"
+          >
+            {regenerating && (
+              <svg className="animate-spin h-3.5 w-3.5" viewBox="0 0 24 24" fill="none">
+                <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+              </svg>
+            )}
+            {regenerating ? 'Regenerating...' : 'Regenerate'}
+          </button>
+          <button
+            onClick={handleExportMarkdown}
+            className="px-3 py-1.5 text-xs font-medium rounded border border-gray-300 text-gray-600 hover:bg-gray-50"
+          >
+            Export Markdown
+          </button>
+        </div>
+      </div>
+
+      {/* Tabs */}
+      <div className="flex border-b border-gray-200 mb-4">
+        {(['report', 'cost'] as const).map((tab) => (
+          <button
+            key={tab}
+            onClick={() => setActiveTab(tab)}
+            className={`px-4 py-2 text-sm font-medium border-b-2 -mb-px ${
+              activeTab === tab
+                ? 'border-purple-600 text-purple-600'
+                : 'border-transparent text-gray-500 hover:text-gray-700'
+            }`}
+          >
+            {tab === 'report' ? 'Analysis Report' : 'Cost Breakdown'}
+          </button>
+        ))}
+      </div>
+
+      {activeTab === 'report' && (
+        <div className="bg-white rounded-lg border border-gray-200 p-6">
+          <div
+            className="prose prose-sm max-w-none [&_table]:w-full [&_table]:border-collapse [&_tr]:border-b [&_tr]:border-gray-100"
+            dangerouslySetInnerHTML={{ __html: renderMarkdown(report.markdown) }}
+          />
+          <div className="mt-6 pt-4 border-t border-gray-200 text-xs text-gray-400 flex gap-4">
+            <span>Generated: {new Date(report.generatedAt).toLocaleString()}</span>
+            <span>Model: {report.model}</span>
+            <span>Tokens: {report.tokenUsage.promptTokens} in / {report.tokenUsage.completionTokens} out</span>
+          </div>
+        </div>
+      )}
+
+      {activeTab === 'cost' && (
+        <div className="grid grid-cols-2 gap-4">
+          <CostCard
+            title="AI Annotation"
+            usd={cb.aiAnnotationCostUsd}
+            inr={cb.aiAnnotationCostUsd * USD_TO_INR}
+            subtitle="Zone-level AI decisions"
+          />
+          <CostCard
+            title="AI Report Generation"
+            usd={cb.aiReportCostUsd}
+            inr={cb.aiReportCostUsd * USD_TO_INR}
+            subtitle="Claude Haiku analysis"
+          />
+          <CostCard
+            title="Annotator Labor"
+            inr={cb.annotatorCostInr}
+            subtitle={`${cb.annotatorActiveHours.toFixed(2)} hrs @ ₹400/hr (active time only)`}
+          />
+          <div className="bg-purple-50 border border-purple-200 rounded-lg p-4">
+            <div className="text-sm font-medium text-purple-800">Total Cost</div>
+            <div className="text-2xl font-bold text-purple-900 mt-1">₹{cb.totalCostInr.toFixed(2)}</div>
+            <div className="text-xs text-purple-600 mt-1">All costs combined (AI costs converted at $1 = ₹{USD_TO_INR})</div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function CostCard({ title, usd, inr, subtitle }: { title: string; usd?: number; inr: number; subtitle: string }) {
+  return (
+    <div className="bg-white border border-gray-200 rounded-lg p-4">
+      <div className="text-sm font-medium text-gray-700">{title}</div>
+      <div className="text-xl font-bold text-gray-900 mt-1">₹{inr.toFixed(2)}</div>
+      {usd != null && <div className="text-xs text-gray-500">${usd.toFixed(4)} USD</div>}
+      <div className="text-xs text-gray-400 mt-1">{subtitle}</div>
+    </div>
+  );
+}

--- a/src/pages/calibration/AnnotationAnalysisPage.tsx
+++ b/src/pages/calibration/AnnotationAnalysisPage.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
+import DOMPurify from 'dompurify';
 import { annotationReportService } from '@/services/annotation-report.service';
 
 /* Minimal markdown-to-HTML: handles ##, |tables|, **bold**, - bullets, \n */
@@ -154,7 +155,7 @@ export default function AnnotationAnalysisPage() {
         <div className="bg-white rounded-lg border border-gray-200 p-6">
           <div
             className="prose prose-sm max-w-none [&_table]:w-full [&_table]:border-collapse [&_tr]:border-b [&_tr]:border-gray-100"
-            dangerouslySetInnerHTML={{ __html: renderMarkdown(report.markdown) }}
+            dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(renderMarkdown(report.markdown)) }}
           />
           <div className="mt-6 pt-4 border-t border-gray-200 text-xs text-gray-400 flex gap-4">
             <span>Generated: {new Date(report.generatedAt).toLocaleString()}</span>

--- a/src/pages/calibration/CorpusSummaryPage.tsx
+++ b/src/pages/calibration/CorpusSummaryPage.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
+import DOMPurify from 'dompurify';
 import { annotationReportService } from '@/services/annotation-report.service';
 
 /* Minimal markdown-to-HTML */
@@ -137,7 +138,7 @@ export default function CorpusSummaryPage() {
         <div className="bg-white rounded-lg border border-gray-200 p-6">
           <div
             className="prose prose-sm max-w-none [&_table]:w-full [&_table]:border-collapse [&_tr]:border-b [&_tr]:border-gray-100"
-            dangerouslySetInnerHTML={{ __html: renderMarkdown(summaryReport.markdown) }}
+            dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(renderMarkdown(summaryReport.markdown)) }}
           />
           <div className="mt-6 pt-4 border-t border-gray-200 text-xs text-gray-400 flex gap-4">
             <span>Generated: {new Date(summaryReport.generatedAt).toLocaleString()}</span>

--- a/src/pages/calibration/CorpusSummaryPage.tsx
+++ b/src/pages/calibration/CorpusSummaryPage.tsx
@@ -1,0 +1,193 @@
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { annotationReportService } from '@/services/annotation-report.service';
+
+/* Minimal markdown-to-HTML */
+function renderMarkdown(md: string): string {
+  return md
+    .split('\n')
+    .map((line) => {
+      if (line.startsWith('#### ')) return `<h4 class="text-sm font-semibold mt-3 mb-1">${line.slice(5)}</h4>`;
+      if (line.startsWith('### ')) return `<h3 class="text-base font-semibold mt-4 mb-2">${line.slice(4)}</h3>`;
+      if (line.startsWith('## ')) return `<h2 class="text-lg font-bold mt-6 mb-2">${line.slice(3)}</h2>`;
+      if (line.startsWith('# ')) return `<h1 class="text-xl font-bold mt-6 mb-3">${line.slice(2)}</h1>`;
+      if (line.startsWith('|')) {
+        const cells = line.split('|').filter(Boolean).map((c) => c.trim());
+        if (cells.every((c) => /^[-:]+$/.test(c))) return '';
+        return `<tr>${cells.map((c) => `<td class="border border-gray-200 px-2 py-1 text-sm">${c}</td>`).join('')}</tr>`;
+      }
+      if (line.trim().startsWith('- ')) {
+        const content = line.trim().slice(2);
+        return `<li class="text-sm text-gray-700 ml-4 list-disc">${content.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')}</li>`;
+      }
+      if (line.trim() === '') return '<br/>';
+      return `<p class="text-sm text-gray-700 mb-1">${line.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')}</p>`;
+    })
+    .join('\n');
+}
+
+interface CostTitle {
+  documentName: string;
+  runId: string;
+  pages: number;
+  zones: number;
+  aiAnnotationCostInr: number;
+  aiReportCostInr: number;
+  annotatorCostInr: number;
+  totalCostInr: number;
+}
+
+interface CostTotals {
+  documents: number;
+  pages: number;
+  zones: number;
+  aiAnnotationCostInr: number;
+  aiReportCostInr: number;
+  annotatorCostInr: number;
+  totalCostInr: number;
+}
+
+interface CorpusSummaryResult {
+  summaryReport: {
+    markdown: string;
+    generatedAt: string;
+    model: string;
+    tokenUsage: { promptTokens: number; completionTokens: number };
+  };
+  costSummary: {
+    titles: CostTitle[];
+    totals: CostTotals;
+  };
+}
+
+export default function CorpusSummaryPage() {
+  const queryClient = useQueryClient();
+  const [activeTab, setActiveTab] = useState<'summary' | 'cost'>('summary');
+  const [refreshing, setRefreshing] = useState(false);
+
+  const { data, isLoading, error } = useQuery<CorpusSummaryResult>({
+    queryKey: ['corpus-summary'],
+    queryFn: () => annotationReportService.getCorpusSummary(),
+  });
+
+  const handleRefresh = async () => {
+    setRefreshing(true);
+    try {
+      await queryClient.invalidateQueries({ queryKey: ['corpus-summary'] });
+    } finally {
+      setRefreshing(false);
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center h-64">
+        <div className="text-gray-500">Generating corpus summary...</div>
+      </div>
+    );
+  }
+
+  if (error || !data) {
+    return (
+      <div className="max-w-4xl mx-auto p-6">
+        <Link to="/bootstrap" className="text-sm text-gray-500 hover:text-gray-700 mb-4 inline-block">&larr; Back to Console</Link>
+        <div className="bg-red-50 border border-red-200 rounded p-4 text-red-700 text-sm">
+          {error instanceof Error ? error.message : 'No completed runs found. Mark annotation runs as complete first.'}
+        </div>
+      </div>
+    );
+  }
+
+  const { summaryReport, costSummary } = data;
+
+  return (
+    <div className="max-w-5xl mx-auto p-6">
+      <Link to="/bootstrap" className="text-sm text-gray-500 hover:text-gray-700 mb-4 inline-block">&larr; Back to Console</Link>
+
+      <div className="flex items-center justify-between mb-4">
+        <h1 className="text-xl font-bold text-gray-900">Corpus Summary</h1>
+        <button
+          onClick={handleRefresh}
+          disabled={refreshing}
+          className="px-3 py-1.5 text-xs font-medium rounded border border-gray-300 text-gray-600 hover:bg-gray-50 disabled:opacity-50"
+        >
+          {refreshing ? 'Refreshing...' : 'Refresh'}
+        </button>
+      </div>
+
+      {/* Tabs */}
+      <div className="flex border-b border-gray-200 mb-4">
+        {(['summary', 'cost'] as const).map((tab) => (
+          <button
+            key={tab}
+            onClick={() => setActiveTab(tab)}
+            className={`px-4 py-2 text-sm font-medium border-b-2 -mb-px ${
+              activeTab === tab
+                ? 'border-purple-600 text-purple-600'
+                : 'border-transparent text-gray-500 hover:text-gray-700'
+            }`}
+          >
+            {tab === 'summary' ? 'Summary Report' : 'Cost Summary'}
+          </button>
+        ))}
+      </div>
+
+      {activeTab === 'summary' && (
+        <div className="bg-white rounded-lg border border-gray-200 p-6">
+          <div
+            className="prose prose-sm max-w-none [&_table]:w-full [&_table]:border-collapse [&_tr]:border-b [&_tr]:border-gray-100"
+            dangerouslySetInnerHTML={{ __html: renderMarkdown(summaryReport.markdown) }}
+          />
+          <div className="mt-6 pt-4 border-t border-gray-200 text-xs text-gray-400 flex gap-4">
+            <span>Generated: {new Date(summaryReport.generatedAt).toLocaleString()}</span>
+            <span>Model: {summaryReport.model}</span>
+            <span>Tokens: {summaryReport.tokenUsage.promptTokens} in / {summaryReport.tokenUsage.completionTokens} out</span>
+          </div>
+        </div>
+      )}
+
+      {activeTab === 'cost' && (
+        <div className="bg-white rounded-lg border border-gray-200 overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead className="bg-gray-50">
+              <tr>
+                <th className="text-left px-4 py-2 font-medium text-gray-700">Document</th>
+                <th className="text-right px-4 py-2 font-medium text-gray-700">Pages</th>
+                <th className="text-right px-4 py-2 font-medium text-gray-700">Zones</th>
+                <th className="text-right px-4 py-2 font-medium text-gray-700">AI Annotation (₹)</th>
+                <th className="text-right px-4 py-2 font-medium text-gray-700">AI Report (₹)</th>
+                <th className="text-right px-4 py-2 font-medium text-gray-700">Annotator (₹)</th>
+                <th className="text-right px-4 py-2 font-medium text-gray-700">Total (₹)</th>
+              </tr>
+            </thead>
+            <tbody>
+              {costSummary.titles.map((t) => (
+                <tr key={t.runId} className="border-t border-gray-100">
+                  <td className="px-4 py-2 text-gray-800">{t.documentName}</td>
+                  <td className="px-4 py-2 text-right text-gray-600">{t.pages}</td>
+                  <td className="px-4 py-2 text-right text-gray-600">{t.zones}</td>
+                  <td className="px-4 py-2 text-right text-gray-600">{t.aiAnnotationCostInr.toFixed(2)}</td>
+                  <td className="px-4 py-2 text-right text-gray-600">{t.aiReportCostInr.toFixed(2)}</td>
+                  <td className="px-4 py-2 text-right text-gray-600">{t.annotatorCostInr.toFixed(2)}</td>
+                  <td className="px-4 py-2 text-right font-medium text-gray-800">{t.totalCostInr.toFixed(2)}</td>
+                </tr>
+              ))}
+            </tbody>
+            <tfoot>
+              <tr className="border-t-2 border-gray-300 bg-gray-50 font-semibold">
+                <td className="px-4 py-2 text-gray-900">Total ({costSummary.totals.documents} documents)</td>
+                <td className="px-4 py-2 text-right text-gray-900">{costSummary.totals.pages}</td>
+                <td className="px-4 py-2 text-right text-gray-900">{costSummary.totals.zones}</td>
+                <td className="px-4 py-2 text-right text-gray-900">{costSummary.totals.aiAnnotationCostInr.toFixed(2)}</td>
+                <td className="px-4 py-2 text-right text-gray-900">{costSummary.totals.aiReportCostInr.toFixed(2)}</td>
+                <td className="px-4 py-2 text-right text-gray-900">{costSummary.totals.annotatorCostInr.toFixed(2)}</td>
+                <td className="px-4 py-2 text-right text-gray-900">{costSummary.totals.totalCostInr.toFixed(2)}</td>
+              </tr>
+            </tfoot>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/services/annotation-report.service.ts
+++ b/src/services/annotation-report.service.ts
@@ -45,4 +45,13 @@ export const annotationReportService = {
     sessionLog?: unknown;
   }) =>
     api.post(`/calibration/runs/${runId}/sessions/${sessionId}/end`, data).then(r => r.data.data),
+
+  markAnnotationComplete: (runId: string) =>
+    api.post(`/calibration/runs/${runId}/complete`).then(r => r.data.data),
+
+  getAnalysis: (runId: string) =>
+    api.get(`/calibration/runs/${runId}/analysis`).then(r => r.data.data),
+
+  getCorpusSummary: () =>
+    api.get('/calibration/corpus/analysis-summary').then(r => r.data.data),
 };


### PR DESCRIPTION
## Summary
- Add "Mark Complete" button in ZoneReviewWorkspace — triggers backend analysis report generation with loading spinner and success/error banner
- Add `AnnotationAnalysisPage` (2 tabs: Analysis Report with markdown render + Cost Breakdown with card grid)
- Add `CorpusSummaryPage` (2 tabs: Summary Report + Cost Summary table with per-title rows and totals)
- Add "Analysis" per-document button and "Corpus Summary" header button in DocumentQueueView
- Wire routes in App.tsx and API methods in annotation-report.service.ts

## Test plan
- [ ] Click "Mark Complete" on Zone Review page — shows spinner, then green banner with "View Analysis" link
- [ ] Analysis page renders 10-section markdown report + cost breakdown tabs
- [ ] Corpus Summary page renders cross-title report + cost table
- [ ] "Regenerate" button on analysis page regenerates the report
- [ ] "Export Markdown" downloads .md file
- [ ] `npx tsc --noEmit` passes
- [ ] `npx eslint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Annotation analysis page: view generated analysis reports, export markdown, and see cost breakdowns.
  * Corpus summary page: view aggregate corpus metrics and per-run cost analysis in a table.
  * Mark complete workflow: confirm and mark annotations complete with success/error feedback.
  * Navigation shortcuts: quick access to analysis and corpus summary from workspace and queue.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->