### PR TITLE
feat: operator Mark Complete, Word export, frozen filename column

### DIFF
--- a/src/components/bootstrap/DocumentQueueView.tsx
+++ b/src/components/bootstrap/DocumentQueueView.tsx
@@ -337,7 +337,7 @@ export default function DocumentQueueView() {
           <table className="min-w-full divide-y divide-gray-200">
             <thead className="bg-gray-50">
               <tr>
-                <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Filename</th>
+                <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider sticky left-0 z-20 bg-gray-50 after:absolute after:right-0 after:top-0 after:bottom-0 after:w-px after:bg-gray-200">Filename</th>
                 <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Publisher</th>
                 <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Content Type</th>
                 <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Pages</th>
@@ -354,8 +354,8 @@ export default function DocumentQueueView() {
                 filtered.map((doc) => {
                   const opStatus = getCorpusDocumentStatus(doc);
                   return (
-                    <tr key={doc.id} className="hover:bg-gray-50">
-                      <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900 truncate max-w-xs">
+                    <tr key={doc.id} className="group hover:bg-gray-50">
+                      <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900 truncate max-w-xs sticky left-0 z-10 bg-white group-hover:bg-gray-50 after:absolute after:right-0 after:top-0 after:bottom-0 after:w-px after:bg-gray-200">
                         {doc.filename}
                       </td>
                       <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">

--- a/src/components/bootstrap/ZoneReviewWorkspace.tsx
+++ b/src/components/bootstrap/ZoneReviewWorkspace.tsx
@@ -110,6 +110,11 @@ export default function ZoneReviewWorkspace({
   const { data: zonesData } = useCalibrationZones(runId, filterParam);
   const zones: CalibrationZone[] = useMemo(() => zonesData?.zones ?? [], [zonesData]);
 
+  // Unfiltered zones — used for Mark Complete eligibility so that switching
+  // bucket tabs does not undercount how many pages have been reviewed.
+  const { data: allZonesData } = useCalibrationZones(runId);
+  const allZones: CalibrationZone[] = useMemo(() => allZonesData?.zones ?? [], [allZonesData]);
+
   // Zone mutations
   const confirmZone = useConfirmZone(runId);
   const correctZone = useCorrectZone(runId);
@@ -176,18 +181,21 @@ export default function ZoneReviewWorkspace({
     return map;
   }, [zones]);
 
-  // Count unique pages with at least one operator-verified zone
+  // Count unique pages with at least one operator-verified zone.
+  // Use `allZones` (unfiltered) so that switching bucket tabs does not undercount.
   const pagesReviewed = useMemo(() => {
     const reviewed = new Set<number>();
-    for (const zone of zones) {
+    for (const zone of allZones) {
       if (zone.operatorVerified) reviewed.add(zone.pageNumber);
     }
     return reviewed.size;
-  }, [zones]);
+  }, [allZones]);
 
-  // Mark Complete enabled: always for ≤150-page titles; ≥150 pages reviewed for larger titles
+  // Mark Complete enabled: always for ≤150-page titles; ≥150 pages reviewed for larger titles.
+  // `numPages` is 0 until the PDF loads — treat unknown page count as "not yet ready".
   const MIN_PAGES_THRESHOLD = 150;
-  const canMarkComplete = numPages <= MIN_PAGES_THRESHOLD || pagesReviewed >= MIN_PAGES_THRESHOLD;
+  const canMarkComplete =
+    numPages > 0 && (numPages <= MIN_PAGES_THRESHOLD || pagesReviewed >= MIN_PAGES_THRESHOLD);
 
   // Handlers
   const handleConfirm = useCallback(

--- a/src/components/bootstrap/ZoneReviewWorkspace.tsx
+++ b/src/components/bootstrap/ZoneReviewWorkspace.tsx
@@ -78,6 +78,7 @@ export default function ZoneReviewWorkspace({
   const [comparisonResult, setComparisonResult] = useState<ComparisonResult | null>(null);
   const [completing, setCompleting] = useState(false);
   const [completeBanner, setCompleteBanner] = useState<{ type: 'success' | 'error'; message: string } | null>(null);
+  const [analysisGenerated, setAnalysisGenerated] = useState(false);
 
   // Keep page input in sync with currentPage (arrow buttons, thumbnail clicks, etc.)
   useEffect(() => {
@@ -174,6 +175,19 @@ export default function ZoneReviewWorkspace({
     }
     return map;
   }, [zones]);
+
+  // Count unique pages with at least one operator-verified zone
+  const pagesReviewed = useMemo(() => {
+    const reviewed = new Set<number>();
+    for (const zone of zones) {
+      if (zone.operatorVerified) reviewed.add(zone.pageNumber);
+    }
+    return reviewed.size;
+  }, [zones]);
+
+  // Mark Complete enabled: always for ≤150-page titles; ≥150 pages reviewed for larger titles
+  const MIN_PAGES_THRESHOLD = 150;
+  const canMarkComplete = numPages <= MIN_PAGES_THRESHOLD || pagesReviewed >= MIN_PAGES_THRESHOLD;
 
   // Handlers
   const handleConfirm = useCallback(
@@ -371,7 +385,8 @@ export default function ZoneReviewWorkspace({
     try {
       await annotationReportService.markAnnotationComplete(runId);
       queryClient.invalidateQueries({ queryKey: ['calibration', 'runs'] });
-      setCompleteBanner({ type: 'success', message: 'Analysis report generated. View it from the Analysis button.' });
+      setAnalysisGenerated(true);
+      setCompleteBanner({ type: 'success', message: 'Analysis report generated.' });
     } catch (err) {
       setCompleteBanner({ type: 'error', message: err instanceof Error ? err.message : 'Failed to generate analysis report' });
     } finally {
@@ -490,11 +505,16 @@ export default function ZoneReviewWorkspace({
             </button>
           )}
 
-          {/* Mark Complete (hidden for OPERATOR) */}
-          {!isOperator && runId && (
+          {/* Mark Complete */}
+          {runId && (
             <button
               onClick={handleMarkComplete}
-              disabled={completing}
+              disabled={completing || !canMarkComplete}
+              title={
+                !canMarkComplete
+                  ? `${pagesReviewed} of ${MIN_PAGES_THRESHOLD} pages reviewed — review at least ${MIN_PAGES_THRESHOLD} pages to mark complete`
+                  : undefined
+              }
               className="px-3 py-1.5 text-xs font-medium rounded bg-green-600 text-white hover:bg-green-700 disabled:opacity-50 disabled:cursor-not-allowed inline-flex items-center gap-1.5"
             >
               {completing && (
@@ -504,6 +524,16 @@ export default function ZoneReviewWorkspace({
                 </svg>
               )}
               {completing ? 'Generating Analysis...' : 'Mark Complete'}
+            </button>
+          )}
+
+          {/* Analysis link — appears after Mark Complete succeeds */}
+          {runId && analysisGenerated && (
+            <button
+              onClick={() => navigate(`/calibration/runs/${runId}/analysis`)}
+              className="px-3 py-1.5 text-xs font-medium rounded border border-purple-300 text-purple-700 bg-purple-50 hover:bg-purple-100"
+            >
+              View Analysis
             </button>
           )}
 

--- a/src/pages/calibration/AnnotationAnalysisPage.tsx
+++ b/src/pages/calibration/AnnotationAnalysisPage.tsx
@@ -1,31 +1,72 @@
-import { useState } from 'react';
+import { useState, useRef } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import DOMPurify from 'dompurify';
 import { annotationReportService } from '@/services/annotation-report.service';
 
-/* Minimal markdown-to-HTML: handles ##, |tables|, **bold**, - bullets, \n */
+const bold = (s: string) => s.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>');
+
+/* Markdown-to-HTML with proper table/list wrapping */
 function renderMarkdown(md: string): string {
-  return md
-    .split('\n')
-    .map((line) => {
-      if (line.startsWith('#### ')) return `<h4 class="text-sm font-semibold mt-3 mb-1">${line.slice(5)}</h4>`;
-      if (line.startsWith('### ')) return `<h3 class="text-base font-semibold mt-4 mb-2">${line.slice(4)}</h3>`;
-      if (line.startsWith('## ')) return `<h2 class="text-lg font-bold mt-6 mb-2">${line.slice(3)}</h2>`;
-      if (line.startsWith('# ')) return `<h1 class="text-xl font-bold mt-6 mb-3">${line.slice(2)}</h1>`;
-      if (line.startsWith('|')) {
-        const cells = line.split('|').filter(Boolean).map((c) => c.trim());
-        if (cells.every((c) => /^[-:]+$/.test(c))) return '';
-        return `<tr>${cells.map((c) => `<td class="border border-gray-200 px-2 py-1 text-sm">${c}</td>`).join('')}</tr>`;
+  const lines = md.split('\n');
+  const result: string[] = [];
+  let inTable = false;
+  let isFirstTableRow = true;
+  let inList = false;
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+
+    // ── Table rows ──
+    if (trimmed.startsWith('|')) {
+      if (inList) { result.push('</ul>'); inList = false; }
+      const cells = trimmed.split('|').filter(Boolean).map((c) => c.trim());
+      if (cells.every((c) => /^[-:]+$/.test(c))) continue;
+
+      if (!inTable) {
+        result.push('<table class="w-full border-collapse my-4 text-sm">');
+        inTable = true;
+        isFirstTableRow = true;
       }
-      if (line.trim().startsWith('- ')) {
-        const content = line.trim().slice(2);
-        return `<li class="text-sm text-gray-700 ml-4 list-disc">${content.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')}</li>`;
+      if (isFirstTableRow) {
+        result.push(
+          `<thead><tr class="bg-gray-50">${cells.map((c) =>
+            `<th class="border border-gray-200 px-3 py-2 text-left font-semibold text-gray-700">${bold(c)}</th>`,
+          ).join('')}</tr></thead><tbody>`,
+        );
+        isFirstTableRow = false;
+      } else {
+        result.push(
+          `<tr class="even:bg-gray-50">${cells.map((c) =>
+            `<td class="border border-gray-200 px-3 py-2 text-gray-600">${bold(c)}</td>`,
+          ).join('')}</tr>`,
+        );
       }
-      if (line.trim() === '') return '<br/>';
-      return `<p class="text-sm text-gray-700 mb-1">${line.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')}</p>`;
-    })
-    .join('\n');
+      continue;
+    }
+    if (inTable) { result.push('</tbody></table>'); inTable = false; }
+
+    // ── List items ──
+    if (trimmed.startsWith('- ')) {
+      if (!inList) { result.push('<ul class="my-2">'); inList = true; }
+      result.push(`<li class="text-sm text-gray-700 ml-4 list-disc">${bold(trimmed.slice(2))}</li>`);
+      continue;
+    }
+    if (inList) { result.push('</ul>'); inList = false; }
+
+    // ── Headings, rules, paragraphs ──
+    if (line.startsWith('#### '))      result.push(`<h4 class="text-sm font-semibold mt-3 mb-1">${line.slice(5)}</h4>`);
+    else if (line.startsWith('### '))   result.push(`<h3 class="text-base font-semibold mt-4 mb-2">${line.slice(4)}</h3>`);
+    else if (line.startsWith('## '))    result.push(`<h2 class="text-lg font-bold mt-6 mb-2">${line.slice(3)}</h2>`);
+    else if (line.startsWith('# '))     result.push(`<h1 class="text-xl font-bold mt-6 mb-3">${line.slice(2)}</h1>`);
+    else if (trimmed === '---')         result.push('<hr class="my-4 border-gray-200"/>');
+    else if (trimmed === '')            result.push('<br/>');
+    else                                result.push(`<p class="text-sm text-gray-700 mb-1">${bold(line)}</p>`);
+  }
+
+  if (inTable) result.push('</tbody></table>');
+  if (inList) result.push('</ul>');
+  return result.join('\n');
 }
 
 interface AnalysisReport {
@@ -55,12 +96,22 @@ export default function AnnotationAnalysisPage() {
   const queryClient = useQueryClient();
   const [activeTab, setActiveTab] = useState<'report' | 'cost'>('report');
   const [regenerating, setRegenerating] = useState(false);
+  const reportRef = useRef<HTMLDivElement>(null);
 
   const { data, isLoading, error } = useQuery<AnalysisResult>({
     queryKey: ['analysis-report', runId],
     queryFn: () => annotationReportService.getAnalysis(runId!),
     enabled: !!runId,
+    retry: (failureCount, err) => {
+      // Don't retry on 404 — the report simply doesn't exist yet
+      const status = (err as { response?: { status?: number } })?.response?.status;
+      if (status === 404) return false;
+      return failureCount < 2;
+    },
   });
+
+  const isNotFound =
+    (error as { response?: { status?: number } })?.response?.status === 404;
 
   const handleRegenerate = async () => {
     if (!runId || !window.confirm('Regenerate the analysis report? This will overwrite the existing report.')) return;
@@ -73,13 +124,37 @@ export default function AnnotationAnalysisPage() {
     }
   };
 
-  const handleExportMarkdown = () => {
+  const handleExportWord = () => {
     if (!data?.report.markdown) return;
-    const blob = new Blob([data.report.markdown], { type: 'text/markdown' });
+    const html = renderMarkdown(data.report.markdown);
+    const wordDoc = `<html xmlns:o="urn:schemas-microsoft-com:office:office"
+      xmlns:w="urn:schemas-microsoft-com:office:word"
+      xmlns="http://www.w3.org/TR/REC-html40">
+<head><meta charset="utf-8"><title>Annotation Analysis Report</title>
+<style>
+  body { font-family: Calibri, Arial, sans-serif; font-size: 11pt; color: #333; line-height: 1.6; margin: 1in; }
+  h1 { font-size: 18pt; font-weight: bold; color: #1a1a1a; margin-top: 24pt; margin-bottom: 12pt; }
+  h2 { font-size: 14pt; font-weight: bold; color: #1a1a1a; margin-top: 20pt; margin-bottom: 8pt; border-bottom: 1px solid #e5e7eb; padding-bottom: 4pt; }
+  h3 { font-size: 12pt; font-weight: 600; color: #1a1a1a; margin-top: 16pt; margin-bottom: 6pt; }
+  h4 { font-size: 11pt; font-weight: 600; color: #1a1a1a; margin-top: 12pt; margin-bottom: 4pt; }
+  p { font-size: 11pt; color: #374151; margin-bottom: 4pt; }
+  table { width: 100%; border-collapse: collapse; margin: 12pt 0; }
+  th { border: 1px solid #d1d5db; padding: 6pt 10pt; text-align: left; font-weight: 600; background-color: #f9fafb; color: #374151; font-size: 10pt; }
+  td { border: 1px solid #d1d5db; padding: 6pt 10pt; color: #4b5563; font-size: 10pt; }
+  li { font-size: 11pt; color: #374151; margin-left: 16pt; margin-bottom: 2pt; }
+  hr { border: none; border-top: 1px solid #e5e7eb; margin: 16pt 0; }
+</style></head>
+<body>
+  <h1>Annotation Analysis Report</h1>
+  <p style="color:#9ca3af;font-size:9pt;">Generated: ${new Date(data.report.generatedAt).toLocaleString()} &nbsp;|&nbsp; Model: ${data.report.model}</p>
+  ${html}
+</body></html>`;
+
+    const blob = new Blob(['\ufeff' + wordDoc], { type: 'application/msword' });
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a');
     a.href = url;
-    a.download = `analysis-report-${runId?.slice(0, 8)}.md`;
+    a.download = `analysis-report-${runId?.slice(0, 8)}.doc`;
     a.click();
     URL.revokeObjectURL(url);
   };
@@ -96,9 +171,18 @@ export default function AnnotationAnalysisPage() {
     return (
       <div className="max-w-4xl mx-auto p-6">
         <Link to="/bootstrap" className="text-sm text-gray-500 hover:text-gray-700 mb-4 inline-block">&larr; Back to Console</Link>
-        <div className="bg-red-50 border border-red-200 rounded p-4 text-red-700 text-sm">
-          {error instanceof Error ? error.message : 'No analysis report found. Click "Mark Complete" on the Zone Review page to generate one.'}
-        </div>
+        {isNotFound ? (
+          <div className="bg-amber-50 border border-amber-200 rounded-lg p-6 text-center">
+            <h2 className="text-base font-semibold text-amber-900 mb-2">No analysis report yet</h2>
+            <p className="text-sm text-amber-800 mb-4">
+              This calibration run has not been marked complete. Open the Zone Review page and click <strong>Mark Complete</strong> to generate an analysis report.
+            </p>
+          </div>
+        ) : (
+          <div className="bg-red-50 border border-red-200 rounded p-4 text-red-700 text-sm">
+            {error instanceof Error ? error.message : 'Failed to load analysis report.'}
+          </div>
+        )}
       </div>
     );
   }
@@ -126,10 +210,10 @@ export default function AnnotationAnalysisPage() {
             {regenerating ? 'Regenerating...' : 'Regenerate'}
           </button>
           <button
-            onClick={handleExportMarkdown}
+            onClick={handleExportWord}
             className="px-3 py-1.5 text-xs font-medium rounded border border-gray-300 text-gray-600 hover:bg-gray-50"
           >
-            Export Markdown
+            Export Word
           </button>
         </div>
       </div>
@@ -152,7 +236,7 @@ export default function AnnotationAnalysisPage() {
       </div>
 
       {activeTab === 'report' && (
-        <div className="bg-white rounded-lg border border-gray-200 p-6">
+        <div className="bg-white rounded-lg border border-gray-200 p-6" ref={reportRef}>
           <div
             className="prose prose-sm max-w-none [&_table]:w-full [&_table]:border-collapse [&_tr]:border-b [&_tr]:border-gray-100"
             dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(renderMarkdown(report.markdown)) }}

--- a/src/pages/calibration/AnnotationAnalysisPage.tsx
+++ b/src/pages/calibration/AnnotationAnalysisPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef } from 'react';
+import { useState, useRef, useMemo } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import DOMPurify from 'dompurify';
@@ -113,6 +113,13 @@ export default function AnnotationAnalysisPage() {
   const isNotFound =
     (error as { response?: { status?: number } })?.response?.status === 404;
 
+  // Sanitize once and reuse for both on-screen rendering and Word export so
+  // we never emit unsanitized HTML from the markdown renderer.
+  const sanitizedReportHtml = useMemo(
+    () => (data?.report.markdown ? DOMPurify.sanitize(renderMarkdown(data.report.markdown)) : ''),
+    [data?.report.markdown],
+  );
+
   const handleRegenerate = async () => {
     if (!runId || !window.confirm('Regenerate the analysis report? This will overwrite the existing report.')) return;
     setRegenerating(true);
@@ -126,7 +133,7 @@ export default function AnnotationAnalysisPage() {
 
   const handleExportWord = () => {
     if (!data?.report.markdown) return;
-    const html = renderMarkdown(data.report.markdown);
+    const html = sanitizedReportHtml;
     const wordDoc = `<html xmlns:o="urn:schemas-microsoft-com:office:office"
       xmlns:w="urn:schemas-microsoft-com:office:word"
       xmlns="http://www.w3.org/TR/REC-html40">
@@ -239,7 +246,7 @@ export default function AnnotationAnalysisPage() {
         <div className="bg-white rounded-lg border border-gray-200 p-6" ref={reportRef}>
           <div
             className="prose prose-sm max-w-none [&_table]:w-full [&_table]:border-collapse [&_tr]:border-b [&_tr]:border-gray-100"
-            dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(renderMarkdown(report.markdown)) }}
+            dangerouslySetInnerHTML={{ __html: sanitizedReportHtml }}
           />
           <div className="mt-6 pt-4 border-t border-gray-200 text-xs text-gray-400 flex gap-4">
             <span>Generated: {new Date(report.generatedAt).toLocaleString()}</span>


### PR DESCRIPTION
## Summary
- **Mark Complete for operators** — Remove ADMIN-only restriction on Mark Complete and View Analysis so operators can finalise their own annotation runs and view the generated report. AI features (AI Annotate, Compare, Auto Annotation, Confirm All Green) remain admin-only.
- **150-page rule** — Mark Complete is always enabled for titles with ≤150 pages. For larger titles, it requires ≥150 unique pages to have operator-verified zones, with a tooltip showing progress (e.g. "87 of 150 pages reviewed").
- **Frozen filename column** — The filename column in the Bootstrap Console Document Queue is now sticky, so filenames stay visible when scrolling horizontally to reach the Action buttons (Review Zones, Lineage, Timesheet, Analysis).
- **Analysis Report table rendering fix** — Rewrote the markdown renderer to properly wrap consecutive `|` table rows in `<table><thead>/<tbody>`, fixing the bug where tables rendered as concatenated inline text (e.g. `DecisionCount% of AI-Annotated CONFIRMED85570.9%...`). Also handles `<ul>` wrapping and `<hr/>` separators.
- **Export Word** — Replaced "Export Markdown" with "Export Word" on the Analysis Report page. Generates a styled `.doc` file with proper tables, headings, and inline CSS that Word can open directly.
- **404 empty state** — Clicking Analysis on a run that hasn't been marked complete no longer gets stuck on "Loading analysis report..." (React Query was retrying the 404 three times). Now shows a friendly amber panel prompting the user to click Mark Complete.

## Test plan
- [ ] As OPERATOR: open a calibration run with ≤150 pages → Mark Complete is enabled and works
- [ ] As OPERATOR: open a calibration run with >150 pages and <150 reviewed → Mark Complete is disabled, tooltip shows progress
- [ ] As OPERATOR: review 150+ unique pages of a large title → Mark Complete becomes enabled
- [ ] As OPERATOR: click Mark Complete → success banner shows, View Analysis button appears
- [ ] As OPERATOR: click View Analysis → navigates to analysis page
- [ ] As ADMIN: verify all existing admin features still work (AI Annotate, Compare, Confirm All Green, etc.)
- [ ] Bootstrap Console: scroll the Document Queue horizontally → filename column stays frozen on the left
- [ ] Analysis Report: verify tables render as proper tables with headers (not concatenated text)
- [ ] Analysis Report: click Export Word → downloads `.doc` file that opens correctly in Word with formatted tables
- [ ] Click Analysis from Document Queue on a run not yet marked complete → shows "No analysis report yet" amber panel (not infinite loading)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "View Analysis" button to access analysis reports.
  * Added Word document (.doc) export for analysis reports.

* **Improvements**
  * Made "Filename" column sticky in tables for easier navigation.
  * Enhanced Markdown rendering for tables and lists in analysis reports.
  * Improved error messaging and retry behavior when loading analysis reports.
  * Updated "Mark Complete" flow: now visible to all roles, requires a minimum pages-reviewed threshold and shows a contextual tooltip when disabled; success banner text simplified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->