### PR TITLE
feat: split Status column and two-color annotation progress bar

### DIFF
--- a/src/components/bootstrap/DocumentQueueView.tsx
+++ b/src/components/bootstrap/DocumentQueueView.tsx
@@ -121,7 +121,7 @@ function AnnotationStatusBadge({
         <div
           className="w-16 h-1.5 bg-gray-200 rounded-full overflow-hidden flex"
           role="progressbar"
-          aria-valuenow={annotatedZones}
+          aria-valuenow={Math.max(0, Math.min(annotatedZones, totalZones))}
           aria-valuemin={0}
           aria-valuemax={totalZones}
           aria-label={`Annotation progress: ${humanVerified} human-verified and ${autoOnly} auto-annotated of ${totalZones} zones`}

--- a/src/components/bootstrap/DocumentQueueView.tsx
+++ b/src/components/bootstrap/DocumentQueueView.tsx
@@ -19,7 +19,7 @@ function SkeletonRows() {
     <>
       {Array.from({ length: 5 }, (_, i) => (
         <tr key={i}>
-          {Array.from({ length: 8 }, (_, j) => (
+          {Array.from({ length: 9 }, (_, j) => (
             <td key={j} className="px-6 py-4">
               <div className="h-4 bg-gray-200 rounded animate-pulse" />
             </td>
@@ -82,10 +82,26 @@ function AiAnnotationBadge({ ai }: { ai?: CorpusDocument['aiAnnotation'] }) {
   return <span className="text-xs text-gray-400">{ai.status}</span>;
 }
 
-function AnnotationStatusBadge({ progress }: { progress?: CorpusDocument['annotationProgress'] }) {
+function AnnotationStatusBadge({
+  progress,
+  ai,
+}: {
+  progress?: CorpusDocument['annotationProgress'];
+  ai?: CorpusDocument['aiAnnotation'];
+}) {
   if (!progress) return <span className="text-xs text-gray-400">—</span>;
 
   const { totalZones, annotatedZones, status } = progress;
+
+  // Human-verified = Confirm + Correct + Reject. All three are deliberate
+  // human decisions and all flip operatorVerified=true on the backend.
+  const humanVerified = ai
+    ? Math.min(
+        annotatedZones,
+        (ai.confirmedCount ?? 0) + (ai.correctedCount ?? 0) + (ai.rejectedCount ?? 0),
+      )
+    : 0;
+  const autoOnly = Math.max(0, annotatedZones - humanVerified);
 
   if (status === 'COMPLETED') {
     return (
@@ -96,20 +112,30 @@ function AnnotationStatusBadge({ progress }: { progress?: CorpusDocument['annota
   }
 
   if (status === 'IN_PROGRESS') {
-    const pct = totalZones > 0 ? Math.min(100, Math.round((annotatedZones / totalZones) * 100)) : 0;
+    const autoPct = totalZones > 0 ? Math.min(100, (autoOnly / totalZones) * 100) : 0;
+    const humanPct =
+      totalZones > 0 ? Math.min(100 - autoPct, (humanVerified / totalZones) * 100) : 0;
+    const tooltip = `${humanVerified} human-verified, ${autoOnly} auto-only, of ${totalZones} total zones`;
     return (
-      <div className="flex items-center gap-1.5">
+      <div className="flex items-center gap-1.5" title={tooltip}>
         <div
-          className="w-16 h-1.5 bg-gray-200 rounded-full overflow-hidden"
+          className="w-16 h-1.5 bg-gray-200 rounded-full overflow-hidden flex"
           role="progressbar"
-          aria-valuenow={pct}
+          aria-valuenow={annotatedZones}
           aria-valuemin={0}
-          aria-valuemax={100}
-          aria-label={`Annotation progress: ${annotatedZones} of ${totalZones} zones`}
+          aria-valuemax={totalZones}
+          aria-label={`Annotation progress: ${humanVerified} human-verified and ${autoOnly} auto-annotated of ${totalZones} zones`}
         >
-          <div className="h-full bg-blue-500 rounded-full" style={{ width: `${pct}%` }} />
+          <div className="h-full bg-blue-500" style={{ width: `${autoPct}%` }} />
+          <div className="h-full bg-green-500" style={{ width: `${humanPct}%` }} />
         </div>
-        <span className="text-xs text-blue-700 font-medium">{annotatedZones}/{totalZones}</span>
+        <span className="text-xs font-medium">
+          <span className="text-green-700">{humanVerified}</span>
+          <span className="text-gray-400">/</span>
+          <span className="text-blue-700">{annotatedZones}</span>
+          <span className="text-gray-400">/</span>
+          <span className="text-gray-600">{totalZones}</span>
+        </span>
       </div>
     );
   }
@@ -341,8 +367,9 @@ export default function DocumentQueueView() {
                 <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Publisher</th>
                 <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Content Type</th>
                 <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Pages</th>
-                <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
-                <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Annotation</th>
+                <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Extraction</th>
+                <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Annotation Status</th>
+                <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Annotation Progress</th>
                 <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">AI</th>
                 <th scope="col" className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Actions</th>
               </tr>
@@ -368,13 +395,13 @@ export default function DocumentQueueView() {
                         {doc.pageCount ?? '—'}
                       </td>
                       <td className="px-6 py-4 whitespace-nowrap">
-                        <div className="flex items-center gap-2">
-                          <DocumentStatusBadge status={doc.status ?? 'PENDING'} />
-                          <OperatorStatusBadge status={opStatus} />
-                        </div>
+                        <OperatorStatusBadge status={opStatus} />
                       </td>
                       <td className="px-6 py-4 whitespace-nowrap">
-                        <AnnotationStatusBadge progress={doc.annotationProgress} />
+                        <DocumentStatusBadge status={doc.status ?? 'PENDING'} />
+                      </td>
+                      <td className="px-6 py-4 whitespace-nowrap">
+                        <AnnotationStatusBadge progress={doc.annotationProgress} ai={doc.aiAnnotation} />
                       </td>
                       <td className="px-6 py-4 whitespace-nowrap">
                         <AiAnnotationBadge ai={doc.aiAnnotation} />


### PR DESCRIPTION
## Summary

Two related UX improvements to the Bootstrap Console document queue:

### 1. Split the ambiguous "Status" column into two labeled columns
Previously the Status column rendered **two different** status pills side-by-side — extraction pipeline status (from \`getCorpusDocumentStatus\`) and calibration workflow status (\`doc.status\`) — and both pill systems used the words **Pending** and **Complete**. Every in-progress row showed "Pending · Complete," which read as a contradiction unless you knew the semantics.

The column is now split into:

- **Extraction** — pipeline readiness (Pending / Tagged / Queued / Complete / Failed)
- **Annotation Status** — calibration run workflow (Pending / In Progress / Needs Review / Complete)

Same data, just separated and labeled honestly.

### 2. Two-color annotation progress bar
The existing single-blue progress bar showed "X/Y zones annotated" without distinguishing **auto-annotation** from **human review**. That made it impossible to glance at the console and tell whether an operator had actually started reviewing a title.

The new bar has two segments:

- **Blue** — zones AI-annotated but not yet human-verified
- **Green** — zones a human has Confirmed, Corrected, **or Rejected** (all three are deliberate human decisions and all flip \`operatorVerified=true\` on the backend)

Computed client-side from \`aiAnnotation.confirmedCount + correctedCount + rejectedCount\` — **no backend change required**. Gracefully falls back to all-blue when \`aiAnnotation\` is missing.

The counter after the bar now reads \`green / blue+green / total\` — e.g. \`1250 / 3992 / 6166\` means 1250 human-verified out of 3992 annotated out of 6166 total zones.

## Files changed

- \`src/components/bootstrap/DocumentQueueView.tsx\`

## Test plan

- [ ] On staging, open Bootstrap Console → Document Queue
- [ ] Confirm three distinct columns appear: **Extraction**, **Annotation Status**, **Annotation Progress**
- [ ] Confirm "Extraction" shows Complete for extracted titles, "Annotation Status" shows Pending for in-progress runs
- [ ] On a title where AI has annotated but no human review yet: progress bar is entirely blue
- [ ] On a title where operator has confirmed/corrected/rejected some zones: bar shows a green segment proportional to those actions
- [ ] Confirm tooltip on the bar reads "X human-verified, Y auto-only, of Z total zones"
- [ ] Screen-reader: \`aria-label\` conveys the human + auto split

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved annotation progress tracking with split progress indicators distinguishing human-verified from auto-generated annotations.
  * Reorganized document table layout with separate columns for extraction status, annotation status, and annotation progress for clearer visibility.
* **Style**
  * Updated table placeholder rendering for consistent row cell count.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->