### PR TITLE
feat: Mark Complete modal with structured issue log

### DIFF
--- a/src/components/bootstrap/MarkCompleteModal.tsx
+++ b/src/components/bootstrap/MarkCompleteModal.tsx
@@ -7,7 +7,7 @@
  * zone content divergence, etc.) and feed the corpus-level lineage rollup.
  */
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Button } from '@/components/ui/Button';
 import { Plus, X, Trash2 } from 'lucide-react';
 
@@ -26,6 +26,18 @@ export interface RunIssueInput {
   pagesAffected?: number;
   description: string;
   blocking: boolean;
+}
+
+// Local-only stable id so that removing an issue from the middle of the list
+// does not shift React's key mapping onto the wrong DOM nodes.
+interface RunIssueDraft extends RunIssueInput {
+  _key: string;
+}
+
+let __issueKeyCounter = 0;
+function nextIssueKey(): string {
+  __issueKeyCounter += 1;
+  return `issue-${__issueKeyCounter}`;
 }
 
 export interface MarkCompleteRequest {
@@ -89,8 +101,13 @@ const CATEGORY_OPTIONS: Array<{ value: RunIssueCategory; label: string; hint: st
   },
 ];
 
-function emptyIssue(): RunIssueInput {
-  return { category: 'PAGE_ALIGNMENT_MISMATCH', description: '', blocking: false };
+function emptyIssue(): RunIssueDraft {
+  return {
+    _key: nextIssueKey(),
+    category: 'PAGE_ALIGNMENT_MISMATCH',
+    description: '',
+    blocking: false,
+  };
 }
 
 export function MarkCompleteModal({
@@ -105,20 +122,27 @@ export function MarkCompleteModal({
   isSubmitting,
 }: MarkCompleteModalProps) {
   const [pagesReviewed, setPagesReviewed] = useState<number>(defaultPagesReviewed);
-  const [issues, setIssues] = useState<RunIssueInput[]>([]);
+  const [issues, setIssues] = useState<RunIssueDraft[]>([]);
+  const pagesReviewedRef = useRef<HTMLInputElement | null>(null);
   const [notes, setNotes] = useState('');
   const [error, setError] = useState<string | null>(null);
 
   // Reset form whenever the modal transitions from closed → open so stale
   // state from a previous open (issues, notes, error, or a defaultPagesReviewed
   // prop that changed while the modal was closed) does not leak through.
+  // Also focuses the pages-reviewed input so keyboard users land inside the
+  // modal instead of on the backdrop.
   useEffect(() => {
     if (isOpen) {
       setPagesReviewed(defaultPagesReviewed);
       setIssues([]);
       setNotes('');
       setError(null);
+      // Defer focus until after the element mounts.
+      const id = window.setTimeout(() => pagesReviewedRef.current?.focus(), 0);
+      return () => window.clearTimeout(id);
     }
+    return undefined;
   }, [isOpen, defaultPagesReviewed]);
 
   // Escape-to-close — attached to window because divs do not receive keydown
@@ -152,8 +176,8 @@ export function MarkCompleteModal({
   };
 
   const validate = (): string | null => {
-    if (!Number.isFinite(pagesReviewed) || pagesReviewed < 1) {
-      return 'Pages reviewed must be at least 1.';
+    if (!Number.isInteger(pagesReviewed) || pagesReviewed < 1) {
+      return 'Pages reviewed must be a whole number ≥ 1.';
     }
     if (totalPages > 0 && pagesReviewed > totalPages) {
       return `Pages reviewed cannot exceed total pages (${totalPages}).`;
@@ -163,11 +187,10 @@ export function MarkCompleteModal({
       if (issue.category === 'OTHER' && !issue.description.trim()) {
         return `Issue ${i + 1}: description is required for "Other".`;
       }
-      if (
-        issue.pagesAffected !== undefined &&
-        (!Number.isFinite(issue.pagesAffected) || issue.pagesAffected < 0)
-      ) {
-        return `Issue ${i + 1}: pages affected must be 0 or more.`;
+      if (issue.pagesAffected !== undefined) {
+        if (!Number.isInteger(issue.pagesAffected) || issue.pagesAffected < 0) {
+          return `Issue ${i + 1}: pages affected must be a whole number ≥ 0.`;
+        }
       }
     }
     return null;
@@ -238,9 +261,11 @@ export function MarkCompleteModal({
             <div>
               <div className="text-xs text-gray-500 uppercase">Pages reviewed</div>
               <input
+                ref={pagesReviewedRef}
                 type="number"
                 min={1}
                 max={totalPages || undefined}
+                step={1}
                 value={Number.isFinite(pagesReviewed) ? pagesReviewed : ''}
                 onChange={(e) => {
                   clearError();
@@ -300,7 +325,7 @@ export function MarkCompleteModal({
                 const descriptionRequired = issue.category === 'OTHER';
                 return (
                   <div
-                    key={idx}
+                    key={issue._key}
                     className="border border-gray-200 rounded-md p-3 bg-white relative"
                   >
                     <button
@@ -344,15 +369,22 @@ export function MarkCompleteModal({
                         <input
                           type="number"
                           min={0}
+                          step={1}
                           value={issue.pagesAffected ?? ''}
-                          onChange={(e) =>
+                          onChange={(e) => {
+                            const raw = e.target.value;
+                            if (raw === '') {
+                              handleUpdateIssue(idx, { pagesAffected: undefined });
+                              return;
+                            }
+                            const parsed = Number(raw);
                             handleUpdateIssue(idx, {
-                              pagesAffected:
-                                e.target.value === '' ? undefined : Number(e.target.value),
-                            })
-                          }
+                              pagesAffected: Number.isFinite(parsed) ? parsed : undefined,
+                            });
+                          }}
                           placeholder="—"
                           className="w-full px-2 py-1.5 text-sm border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-purple-500"
+                          aria-label={`Pages affected by issue ${idx + 1}`}
                         />
                       </div>
 

--- a/src/components/bootstrap/MarkCompleteModal.tsx
+++ b/src/components/bootstrap/MarkCompleteModal.tsx
@@ -125,17 +125,25 @@ export function MarkCompleteModal({
   const [issues, setIssues] = useState<RunIssueDraft[]>([]);
   const pagesReviewedRef = useRef<HTMLInputElement | null>(null);
   const errorRef = useRef<HTMLDivElement | null>(null);
+  const wasOpenRef = useRef(false);
+  // Capture defaultPagesReviewed in a ref so the reset-on-open effect can
+  // read the latest value without re-running when it changes mid-session.
+  const defaultPagesReviewedRef = useRef(defaultPagesReviewed);
+  useEffect(() => {
+    defaultPagesReviewedRef.current = defaultPagesReviewed;
+  }, [defaultPagesReviewed]);
   const [notes, setNotes] = useState('');
   const [error, setError] = useState<string | null>(null);
 
-  // Reset form whenever the modal transitions from closed → open so stale
-  // state from a previous open (issues, notes, error, or a defaultPagesReviewed
-  // prop that changed while the modal was closed) does not leak through.
-  // Also focuses the pages-reviewed input so keyboard users land inside the
-  // modal instead of on the backdrop.
+  // Reset form ONLY on the closed → open transition so stale state from a
+  // previous open (issues, notes, error) does not leak through. Crucially we
+  // do NOT reset when defaultPagesReviewed changes mid-session — a background
+  // React Query refetch updating that prop must not wipe out a user who is
+  // mid-way through adding issues.
   useEffect(() => {
-    if (isOpen) {
-      setPagesReviewed(defaultPagesReviewed);
+    if (isOpen && !wasOpenRef.current) {
+      wasOpenRef.current = true;
+      setPagesReviewed(defaultPagesReviewedRef.current);
       setIssues([]);
       setNotes('');
       setError(null);
@@ -143,8 +151,11 @@ export function MarkCompleteModal({
       const id = window.setTimeout(() => pagesReviewedRef.current?.focus(), 0);
       return () => window.clearTimeout(id);
     }
+    if (!isOpen && wasOpenRef.current) {
+      wasOpenRef.current = false;
+    }
     return undefined;
-  }, [isOpen, defaultPagesReviewed]);
+  }, [isOpen]);
 
   // Escape-to-close — attached to window because divs do not receive keydown
   // events unless they are focusable.

--- a/src/components/bootstrap/MarkCompleteModal.tsx
+++ b/src/components/bootstrap/MarkCompleteModal.tsx
@@ -124,6 +124,7 @@ export function MarkCompleteModal({
   const [pagesReviewed, setPagesReviewed] = useState<number>(defaultPagesReviewed);
   const [issues, setIssues] = useState<RunIssueDraft[]>([]);
   const pagesReviewedRef = useRef<HTMLInputElement | null>(null);
+  const errorRef = useRef<HTMLDivElement | null>(null);
   const [notes, setNotes] = useState('');
   const [error, setError] = useState<string | null>(null);
 
@@ -196,10 +197,16 @@ export function MarkCompleteModal({
     return null;
   };
 
-  const handleSubmit = async () => {
+  const handleSubmit = async (e?: React.FormEvent) => {
+    if (e) e.preventDefault();
     const validationError = validate();
     if (validationError) {
       setError(validationError);
+      // Bring the error into view — the body is scrollable and a long
+      // issues list can push the error below the fold.
+      requestAnimationFrame(() => {
+        errorRef.current?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+      });
       return;
     }
     setError(null);
@@ -219,6 +226,9 @@ export function MarkCompleteModal({
       // Surface submit failures inside the modal — the parent's banner is
       // hidden behind the backdrop so the user would otherwise see nothing.
       setError(err instanceof Error ? err.message : 'Failed to generate analysis report.');
+      requestAnimationFrame(() => {
+        errorRef.current?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+      });
     }
   };
 
@@ -232,7 +242,11 @@ export function MarkCompleteModal({
       aria-modal="true"
       aria-labelledby="mark-complete-title"
     >
-      <div className="bg-white rounded-lg shadow-xl max-w-2xl w-full mx-4 max-h-[90vh] flex flex-col">
+      <form
+        className="bg-white rounded-lg shadow-xl max-w-2xl w-full mx-4 max-h-[90vh] flex flex-col"
+        onSubmit={handleSubmit}
+        noValidate
+      >
         {/* Header */}
         <div className="flex items-start justify-between px-6 py-4 border-b border-gray-200">
           <div>
@@ -277,6 +291,9 @@ export function MarkCompleteModal({
                   const parsed = Number(raw);
                   setPagesReviewed(Number.isFinite(parsed) ? parsed : NaN);
                 }}
+                // Prevent the scroll-wheel from silently mutating the value
+                // while the user is scrolling the modal body.
+                onWheel={(e) => (e.target as HTMLInputElement).blur()}
                 className="mt-1 w-20 px-2 py-1 text-sm border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-purple-500"
                 aria-label="Pages reviewed"
               />
@@ -382,6 +399,7 @@ export function MarkCompleteModal({
                               pagesAffected: Number.isFinite(parsed) ? parsed : undefined,
                             });
                           }}
+                          onWheel={(e) => (e.target as HTMLInputElement).blur()}
                           placeholder="—"
                           className="w-full px-2 py-1.5 text-sm border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-purple-500"
                           aria-label={`Pages affected by issue ${idx + 1}`}
@@ -445,7 +463,12 @@ export function MarkCompleteModal({
           </div>
 
           {error && (
-            <div className="bg-red-50 border border-red-200 rounded p-2 text-xs text-red-700">
+            <div
+              ref={errorRef}
+              role="alert"
+              aria-live="assertive"
+              className="bg-red-50 border border-red-200 rounded p-2 text-xs text-red-700"
+            >
               {error}
             </div>
           )}
@@ -453,18 +476,14 @@ export function MarkCompleteModal({
 
         {/* Footer */}
         <div className="flex justify-end gap-3 px-6 py-4 border-t border-gray-200 bg-gray-50">
-          <Button variant="outline" onClick={onClose} disabled={isSubmitting}>
+          <Button type="button" variant="outline" onClick={onClose} disabled={isSubmitting}>
             Cancel
           </Button>
-          <Button
-            variant="primary"
-            onClick={handleSubmit}
-            isLoading={isSubmitting}
-          >
+          <Button type="submit" variant="primary" isLoading={isSubmitting}>
             Mark Complete &amp; Generate Report
           </Button>
         </div>
-      </div>
+      </form>
     </div>
   );
 }

--- a/src/components/bootstrap/MarkCompleteModal.tsx
+++ b/src/components/bootstrap/MarkCompleteModal.tsx
@@ -1,0 +1,389 @@
+/**
+ * MarkCompleteModal
+ *
+ * Captures a structured issue log when an operator clicks "Mark Complete"
+ * in Zone Review. The categories are derived from recurring patterns in
+ * operator emails (page alignment mismatches, extractor coverage gaps,
+ * zone content divergence, etc.) and feed the corpus-level lineage rollup.
+ */
+
+import { useState } from 'react';
+import { Button } from '@/components/ui/Button';
+import { Plus, X, Trash2 } from 'lucide-react';
+
+export type RunIssueCategory =
+  | 'PAGE_ALIGNMENT_MISMATCH'
+  | 'INSUFFICIENT_JOINT_COVERAGE'
+  | 'LIMITED_ZONE_COVERAGE'
+  | 'UNEQUAL_EXTRACTOR_COVERAGE'
+  | 'SINGLE_EXTRACTOR_ONLY'
+  | 'ZONE_CONTENT_DIVERGENCE'
+  | 'COMPLETED_WITH_REDUCED_SCOPE'
+  | 'OTHER';
+
+export interface RunIssueInput {
+  category: RunIssueCategory;
+  pagesAffected?: number;
+  description: string;
+  blocking: boolean;
+}
+
+export interface MarkCompleteRequest {
+  pagesReviewed: number;
+  issues: RunIssueInput[];
+  notes?: string;
+}
+
+interface MarkCompleteModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSubmit: (data: MarkCompleteRequest) => Promise<void>;
+  documentName: string;
+  totalPages: number;
+  defaultPagesReviewed: number;
+  zonesReviewed: number;
+  totalZones: number;
+  isSubmitting: boolean;
+}
+
+const CATEGORY_OPTIONS: Array<{ value: RunIssueCategory; label: string; hint: string }> = [
+  {
+    value: 'PAGE_ALIGNMENT_MISMATCH',
+    label: 'Page alignment mismatch',
+    hint: 'e.g. PDFxt offset by one page vs Docling',
+  },
+  {
+    value: 'INSUFFICIENT_JOINT_COVERAGE',
+    label: 'Insufficient joint coverage',
+    hint: 'Both extractors do not cover the 150-page minimum',
+  },
+  {
+    value: 'LIMITED_ZONE_COVERAGE',
+    label: 'Limited zone coverage',
+    hint: 'Extractors produced zones for only a fraction of pages',
+  },
+  {
+    value: 'UNEQUAL_EXTRACTOR_COVERAGE',
+    label: 'Unequal extractor coverage',
+    hint: 'Docling and PDFxt zone counts diverge significantly',
+  },
+  {
+    value: 'SINGLE_EXTRACTOR_ONLY',
+    label: 'Single extractor only',
+    hint: 'One extractor produced no zones at all',
+  },
+  {
+    value: 'ZONE_CONTENT_DIVERGENCE',
+    label: 'Zone content divergence',
+    hint: 'Same position but different content (e.g. list vs paragraph)',
+  },
+  {
+    value: 'COMPLETED_WITH_REDUCED_SCOPE',
+    label: 'Completed with reduced scope',
+    hint: 'Verification done based on available zoning only',
+  },
+  {
+    value: 'OTHER',
+    label: 'Other',
+    hint: 'Describe in the text field below',
+  },
+];
+
+function emptyIssue(): RunIssueInput {
+  return { category: 'PAGE_ALIGNMENT_MISMATCH', description: '', blocking: false };
+}
+
+export function MarkCompleteModal({
+  isOpen,
+  onClose,
+  onSubmit,
+  documentName,
+  totalPages,
+  defaultPagesReviewed,
+  zonesReviewed,
+  totalZones,
+  isSubmitting,
+}: MarkCompleteModalProps) {
+  const [pagesReviewed, setPagesReviewed] = useState<number>(defaultPagesReviewed);
+  const [issues, setIssues] = useState<RunIssueInput[]>([]);
+  const [notes, setNotes] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  if (!isOpen) return null;
+
+  const handleAddIssue = () => setIssues((prev) => [...prev, emptyIssue()]);
+  const handleRemoveIssue = (idx: number) =>
+    setIssues((prev) => prev.filter((_, i) => i !== idx));
+  const handleUpdateIssue = (idx: number, patch: Partial<RunIssueInput>) =>
+    setIssues((prev) => prev.map((issue, i) => (i === idx ? { ...issue, ...patch } : issue)));
+
+  const validate = (): string | null => {
+    if (!Number.isFinite(pagesReviewed) || pagesReviewed < 1) {
+      return 'Pages reviewed must be at least 1.';
+    }
+    if (totalPages > 0 && pagesReviewed > totalPages) {
+      return `Pages reviewed cannot exceed total pages (${totalPages}).`;
+    }
+    for (let i = 0; i < issues.length; i++) {
+      const issue = issues[i];
+      if (issue.category === 'OTHER' && !issue.description.trim()) {
+        return `Issue ${i + 1}: description is required for "Other".`;
+      }
+      if (
+        issue.pagesAffected !== undefined &&
+        (!Number.isFinite(issue.pagesAffected) || issue.pagesAffected < 0)
+      ) {
+        return `Issue ${i + 1}: pages affected must be 0 or more.`;
+      }
+    }
+    return null;
+  };
+
+  const handleSubmit = async () => {
+    const validationError = validate();
+    if (validationError) {
+      setError(validationError);
+      return;
+    }
+    setError(null);
+    const payload: MarkCompleteRequest = {
+      pagesReviewed,
+      issues: issues.map((i) => ({
+        category: i.category,
+        pagesAffected: i.pagesAffected,
+        description: i.description.trim(),
+        blocking: i.blocking,
+      })),
+      notes: notes.trim() || undefined,
+    };
+    await onSubmit(payload);
+  };
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/50 flex items-center justify-center z-50"
+      onClick={(e) => {
+        if (e.target === e.currentTarget && !isSubmitting) onClose();
+      }}
+      onKeyDown={(e) => {
+        if (e.key === 'Escape' && !isSubmitting) onClose();
+      }}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="mark-complete-title"
+    >
+      <div className="bg-white rounded-lg shadow-xl max-w-2xl w-full mx-4 max-h-[90vh] flex flex-col">
+        {/* Header */}
+        <div className="flex items-start justify-between px-6 py-4 border-b border-gray-200">
+          <div>
+            <h3 id="mark-complete-title" className="text-lg font-semibold text-gray-900">
+              Mark Annotation Complete
+            </h3>
+            <p className="text-xs text-gray-500 mt-1 truncate max-w-md" title={documentName}>
+              {documentName}
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={isSubmitting}
+            className="text-gray-400 hover:text-gray-600 disabled:opacity-50"
+            aria-label="Close"
+          >
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+
+        {/* Body (scrollable) */}
+        <div className="flex-1 overflow-y-auto px-6 py-4 space-y-5">
+          {/* Summary */}
+          <div className="grid grid-cols-3 gap-3 bg-gray-50 border border-gray-200 rounded-md p-3 text-sm">
+            <div>
+              <div className="text-xs text-gray-500 uppercase">Pages reviewed</div>
+              <input
+                type="number"
+                min={1}
+                max={totalPages || undefined}
+                value={pagesReviewed}
+                onChange={(e) => setPagesReviewed(Number(e.target.value))}
+                className="mt-1 w-20 px-2 py-1 text-sm border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-purple-500"
+                aria-label="Pages reviewed"
+              />
+            </div>
+            <div>
+              <div className="text-xs text-gray-500 uppercase">Total pages</div>
+              <div className="mt-1 text-gray-800 font-medium">{totalPages || '—'}</div>
+            </div>
+            <div>
+              <div className="text-xs text-gray-500 uppercase">Zones reviewed</div>
+              <div className="mt-1 text-gray-800 font-medium">
+                {zonesReviewed} / {totalZones}
+              </div>
+            </div>
+          </div>
+
+          {/* Issues */}
+          <div>
+            <div className="flex items-center justify-between mb-2">
+              <div>
+                <h4 className="text-sm font-semibold text-gray-900">Issues encountered</h4>
+                <p className="text-xs text-gray-500">
+                  Log any problems found during annotation so they can be rolled up into the corpus
+                  lineage report. Leave empty if there were none.
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={handleAddIssue}
+                className="inline-flex items-center gap-1 text-xs font-medium text-purple-700 hover:text-purple-900"
+              >
+                <Plus className="w-3.5 h-3.5" />
+                Add issue
+              </button>
+            </div>
+
+            {issues.length === 0 && (
+              <div className="text-xs text-gray-400 italic border border-dashed border-gray-200 rounded p-3 text-center">
+                No issues logged.
+              </div>
+            )}
+
+            <div className="space-y-3">
+              {issues.map((issue, idx) => {
+                const catOption = CATEGORY_OPTIONS.find((o) => o.value === issue.category);
+                const descriptionRequired = issue.category === 'OTHER';
+                return (
+                  <div
+                    key={idx}
+                    className="border border-gray-200 rounded-md p-3 bg-white relative"
+                  >
+                    <button
+                      type="button"
+                      onClick={() => handleRemoveIssue(idx)}
+                      className="absolute top-2 right-2 text-gray-400 hover:text-red-600"
+                      aria-label={`Remove issue ${idx + 1}`}
+                    >
+                      <Trash2 className="w-4 h-4" />
+                    </button>
+
+                    <div className="grid grid-cols-2 gap-3">
+                      <div className="col-span-2">
+                        <label className="block text-xs font-medium text-gray-700 mb-1">
+                          Category
+                        </label>
+                        <select
+                          value={issue.category}
+                          onChange={(e) =>
+                            handleUpdateIssue(idx, {
+                              category: e.target.value as RunIssueCategory,
+                            })
+                          }
+                          className="w-full px-2 py-1.5 text-sm border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-purple-500"
+                        >
+                          {CATEGORY_OPTIONS.map((opt) => (
+                            <option key={opt.value} value={opt.value}>
+                              {opt.label}
+                            </option>
+                          ))}
+                        </select>
+                        {catOption && (
+                          <p className="text-xs text-gray-400 mt-1">{catOption.hint}</p>
+                        )}
+                      </div>
+
+                      <div>
+                        <label className="block text-xs font-medium text-gray-700 mb-1">
+                          Pages affected
+                        </label>
+                        <input
+                          type="number"
+                          min={0}
+                          value={issue.pagesAffected ?? ''}
+                          onChange={(e) =>
+                            handleUpdateIssue(idx, {
+                              pagesAffected:
+                                e.target.value === '' ? undefined : Number(e.target.value),
+                            })
+                          }
+                          placeholder="—"
+                          className="w-full px-2 py-1.5 text-sm border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-purple-500"
+                        />
+                      </div>
+
+                      <div className="flex items-center mt-5">
+                        <label className="inline-flex items-center gap-1.5 text-sm text-gray-700">
+                          <input
+                            type="checkbox"
+                            checked={issue.blocking}
+                            onChange={(e) =>
+                              handleUpdateIssue(idx, { blocking: e.target.checked })
+                            }
+                            className="rounded border-gray-300 text-purple-600 focus:ring-purple-500"
+                          />
+                          Blocking?
+                        </label>
+                      </div>
+
+                      <div className="col-span-2">
+                        <label className="block text-xs font-medium text-gray-700 mb-1">
+                          Description{' '}
+                          {descriptionRequired && <span className="text-red-500">*</span>}
+                        </label>
+                        <textarea
+                          rows={2}
+                          value={issue.description}
+                          onChange={(e) =>
+                            handleUpdateIssue(idx, { description: e.target.value })
+                          }
+                          placeholder="Describe the issue, pages, and any workaround..."
+                          className="w-full px-2 py-1.5 text-sm border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-purple-500"
+                          required={descriptionRequired}
+                        />
+                      </div>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+
+          {/* Notes */}
+          <div>
+            <label className="block text-sm font-semibold text-gray-900 mb-1">
+              Additional notes{' '}
+              <span className="text-xs font-normal text-gray-500">(optional)</span>
+            </label>
+            <textarea
+              rows={3}
+              value={notes}
+              onChange={(e) => setNotes(e.target.value)}
+              placeholder="Anything else worth capturing alongside the analysis report..."
+              className="w-full px-3 py-2 text-sm border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-purple-500"
+              maxLength={2000}
+            />
+          </div>
+
+          {error && (
+            <div className="bg-red-50 border border-red-200 rounded p-2 text-xs text-red-700">
+              {error}
+            </div>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="flex justify-end gap-3 px-6 py-4 border-t border-gray-200 bg-gray-50">
+          <Button variant="outline" onClick={onClose} disabled={isSubmitting}>
+            Cancel
+          </Button>
+          <Button
+            variant="primary"
+            onClick={handleSubmit}
+            isLoading={isSubmitting}
+          >
+            Mark Complete &amp; Generate Report
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/bootstrap/MarkCompleteModal.tsx
+++ b/src/components/bootstrap/MarkCompleteModal.tsx
@@ -7,7 +7,7 @@
  * zone content divergence, etc.) and feed the corpus-level lineage rollup.
  */
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Button } from '@/components/ui/Button';
 import { Plus, X, Trash2 } from 'lucide-react';
 
@@ -109,13 +109,47 @@ export function MarkCompleteModal({
   const [notes, setNotes] = useState('');
   const [error, setError] = useState<string | null>(null);
 
+  // Reset form whenever the modal transitions from closed → open so stale
+  // state from a previous open (issues, notes, error, or a defaultPagesReviewed
+  // prop that changed while the modal was closed) does not leak through.
+  useEffect(() => {
+    if (isOpen) {
+      setPagesReviewed(defaultPagesReviewed);
+      setIssues([]);
+      setNotes('');
+      setError(null);
+    }
+  }, [isOpen, defaultPagesReviewed]);
+
+  // Escape-to-close — attached to window because divs do not receive keydown
+  // events unless they are focusable.
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && !isSubmitting) onClose();
+    };
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [isOpen, isSubmitting, onClose]);
+
   if (!isOpen) return null;
 
-  const handleAddIssue = () => setIssues((prev) => [...prev, emptyIssue()]);
-  const handleRemoveIssue = (idx: number) =>
+  const clearError = () => {
+    if (error) setError(null);
+  };
+
+  const handleAddIssue = () => {
+    clearError();
+    setIssues((prev) => [...prev, emptyIssue()]);
+  };
+  const handleRemoveIssue = (idx: number) => {
+    clearError();
     setIssues((prev) => prev.filter((_, i) => i !== idx));
-  const handleUpdateIssue = (idx: number, patch: Partial<RunIssueInput>) =>
+  };
+  const handleUpdateIssue = (idx: number, patch: Partial<RunIssueInput>) => {
+    clearError();
     setIssues((prev) => prev.map((issue, i) => (i === idx ? { ...issue, ...patch } : issue)));
+  };
 
   const validate = (): string | null => {
     if (!Number.isFinite(pagesReviewed) || pagesReviewed < 1) {
@@ -156,7 +190,13 @@ export function MarkCompleteModal({
       })),
       notes: notes.trim() || undefined,
     };
-    await onSubmit(payload);
+    try {
+      await onSubmit(payload);
+    } catch (err) {
+      // Surface submit failures inside the modal — the parent's banner is
+      // hidden behind the backdrop so the user would otherwise see nothing.
+      setError(err instanceof Error ? err.message : 'Failed to generate analysis report.');
+    }
   };
 
   return (
@@ -164,9 +204,6 @@ export function MarkCompleteModal({
       className="fixed inset-0 bg-black/50 flex items-center justify-center z-50"
       onClick={(e) => {
         if (e.target === e.currentTarget && !isSubmitting) onClose();
-      }}
-      onKeyDown={(e) => {
-        if (e.key === 'Escape' && !isSubmitting) onClose();
       }}
       role="dialog"
       aria-modal="true"
@@ -204,8 +241,17 @@ export function MarkCompleteModal({
                 type="number"
                 min={1}
                 max={totalPages || undefined}
-                value={pagesReviewed}
-                onChange={(e) => setPagesReviewed(Number(e.target.value))}
+                value={Number.isFinite(pagesReviewed) ? pagesReviewed : ''}
+                onChange={(e) => {
+                  clearError();
+                  const raw = e.target.value;
+                  if (raw === '') {
+                    setPagesReviewed(NaN);
+                    return;
+                  }
+                  const parsed = Number(raw);
+                  setPagesReviewed(Number.isFinite(parsed) ? parsed : NaN);
+                }}
                 className="mt-1 w-20 px-2 py-1 text-sm border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-purple-500"
                 aria-label="Pages reviewed"
               />
@@ -356,7 +402,10 @@ export function MarkCompleteModal({
             <textarea
               rows={3}
               value={notes}
-              onChange={(e) => setNotes(e.target.value)}
+              onChange={(e) => {
+                clearError();
+                setNotes(e.target.value);
+              }}
               placeholder="Anything else worth capturing alongside the analysis report..."
               className="w-full px-3 py-2 text-sm border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-purple-500"
               maxLength={2000}

--- a/src/components/bootstrap/MarkCompleteModal.tsx
+++ b/src/components/bootstrap/MarkCompleteModal.tsx
@@ -208,8 +208,8 @@ export function MarkCompleteModal({
     return null;
   };
 
-  const handleSubmit = async (e?: React.FormEvent) => {
-    if (e) e.preventDefault();
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
     const validationError = validate();
     if (validationError) {
       setError(validationError);

--- a/src/components/bootstrap/ZoneReviewWorkspace.tsx
+++ b/src/components/bootstrap/ZoneReviewWorkspace.tsx
@@ -404,10 +404,14 @@ export default function ZoneReviewWorkspace({
         setCompleteBanner({ type: 'success', message: 'Analysis report generated.' });
         setMarkCompleteModalOpen(false);
       } catch (err) {
+        // Surface the failure in the parent banner as well (visible after the
+        // modal closes via cancel/next open), but rethrow so the modal can
+        // display the error inline while it is still on screen.
         setCompleteBanner({
           type: 'error',
           message: err instanceof Error ? err.message : 'Failed to generate analysis report',
         });
+        throw err;
       } finally {
         setCompleting(false);
       }

--- a/src/components/bootstrap/ZoneReviewWorkspace.tsx
+++ b/src/components/bootstrap/ZoneReviewWorkspace.tsx
@@ -27,6 +27,7 @@ import ZonePdfPanel from './ZonePdfPanel';
 import ZoneComparisonDetailBar from './ZoneComparisonDetailBar';
 import ZoneOverlay from './ZoneOverlay';
 import ZoneListSidebar from './ZoneListSidebar';
+import { MarkCompleteModal, type MarkCompleteRequest } from './MarkCompleteModal';
 import { useZoneNumberMap } from '@/hooks/useZoneNumberMap';
 import { TableStructureEditor } from '../quickfix/TableStructureEditor';
 import type { TableSection } from '@/types/zone.types';
@@ -79,6 +80,7 @@ export default function ZoneReviewWorkspace({
   const [completing, setCompleting] = useState(false);
   const [completeBanner, setCompleteBanner] = useState<{ type: 'success' | 'error'; message: string } | null>(null);
   const [analysisGenerated, setAnalysisGenerated] = useState(false);
+  const [markCompleteModalOpen, setMarkCompleteModalOpen] = useState(false);
 
   // Keep page input in sync with currentPage (arrow buttons, thumbnail clicks, etc.)
   useEffect(() => {
@@ -385,22 +387,33 @@ export default function ZoneReviewWorkspace({
     });
   }, [comparisonMutation]);
 
-  const handleMarkComplete = useCallback(async () => {
+  const handleMarkComplete = useCallback(() => {
     if (!runId) return;
-    if (!window.confirm('Mark annotation as complete and generate analysis report? This will set completedAt on the run.')) return;
-    setCompleting(true);
-    setCompleteBanner(null);
-    try {
-      await annotationReportService.markAnnotationComplete(runId);
-      queryClient.invalidateQueries({ queryKey: ['calibration', 'runs'] });
-      setAnalysisGenerated(true);
-      setCompleteBanner({ type: 'success', message: 'Analysis report generated.' });
-    } catch (err) {
-      setCompleteBanner({ type: 'error', message: err instanceof Error ? err.message : 'Failed to generate analysis report' });
-    } finally {
-      setCompleting(false);
-    }
-  }, [runId, queryClient]);
+    setMarkCompleteModalOpen(true);
+  }, [runId]);
+
+  const handleSubmitMarkComplete = useCallback(
+    async (payload: MarkCompleteRequest) => {
+      if (!runId) return;
+      setCompleting(true);
+      setCompleteBanner(null);
+      try {
+        await annotationReportService.markAnnotationComplete(runId, payload);
+        queryClient.invalidateQueries({ queryKey: ['calibration', 'runs'] });
+        setAnalysisGenerated(true);
+        setCompleteBanner({ type: 'success', message: 'Analysis report generated.' });
+        setMarkCompleteModalOpen(false);
+      } catch (err) {
+        setCompleteBanner({
+          type: 'error',
+          message: err instanceof Error ? err.message : 'Failed to generate analysis report',
+        });
+      } finally {
+        setCompleting(false);
+      }
+    },
+    [runId, queryClient],
+  );
 
   return (
     <div className="flex flex-col h-[calc(100vh-64px)] bg-gray-50">
@@ -890,6 +903,19 @@ export default function ZoneReviewWorkspace({
           onClose={() => setTableEditorZone(null)}
         />
       )}
+
+      {/* Mark Complete modal */}
+      <MarkCompleteModal
+        isOpen={markCompleteModalOpen}
+        onClose={() => setMarkCompleteModalOpen(false)}
+        onSubmit={handleSubmitMarkComplete}
+        documentName={docId}
+        totalPages={numPages}
+        defaultPagesReviewed={pagesReviewed}
+        zonesReviewed={allZones.filter((z) => z.operatorVerified).length}
+        totalZones={allZones.length}
+        isSubmitting={completing}
+      />
     </div>
   );
 }

--- a/src/services/annotation-report.service.ts
+++ b/src/services/annotation-report.service.ts
@@ -46,8 +46,28 @@ export const annotationReportService = {
   }) =>
     api.post(`/calibration/runs/${runId}/sessions/${sessionId}/end`, data).then(r => r.data.data),
 
-  markAnnotationComplete: (runId: string) =>
-    api.post(`/calibration/runs/${runId}/complete`).then(r => r.data.data),
+  markAnnotationComplete: (
+    runId: string,
+    payload?: {
+      pagesReviewed: number;
+      issues: Array<{
+        category:
+          | 'PAGE_ALIGNMENT_MISMATCH'
+          | 'INSUFFICIENT_JOINT_COVERAGE'
+          | 'LIMITED_ZONE_COVERAGE'
+          | 'UNEQUAL_EXTRACTOR_COVERAGE'
+          | 'SINGLE_EXTRACTOR_ONLY'
+          | 'ZONE_CONTENT_DIVERGENCE'
+          | 'COMPLETED_WITH_REDUCED_SCOPE'
+          | 'OTHER';
+        pagesAffected?: number;
+        description: string;
+        blocking: boolean;
+      }>;
+      notes?: string;
+    },
+  ) =>
+    api.post(`/calibration/runs/${runId}/complete`, payload).then(r => r.data.data),
 
   getAnalysis: (runId: string) =>
     api.get(`/calibration/runs/${runId}/analysis`).then(r => r.data.data),


### PR DESCRIPTION
## Summary

- Adds `MarkCompleteModal` — operators now record `pagesReviewed`, a list of structured issues, and freeform notes before the LLM analysis report is generated.
- 8 issue categories (with explanatory hints) are derived from recurring operator-email patterns: page alignment mismatch, insufficient joint coverage, limited zone coverage, unequal extractor coverage, single extractor only, zone content divergence, completed with reduced scope, other.
- `annotationReportService.markAnnotationComplete` extended to accept the new payload; backwards-compatible (backend still accepts an empty body until Backend PR #1 lands).
- Replaces the previous `window.confirm` flow in `ZoneReviewWorkspace`.

## Backend dependency

Frontend is backwards-compatible. Backend PR #1 (persist `pagesReviewed`, `completionNotes`, and `calibration_run_issues` rows) should land for the issue log to actually be stored — spec lives at `Ninja-Documentation/Annotations/BACKEND_SPEC_MARK_COMPLETE_AND_CORPUS_SUMMARY.md`.

## Test plan

- [ ] Open a run in Zone Review, click **Mark Complete** — modal opens instead of a confirm dialog
- [ ] `pagesReviewed` defaults to the count of pages with at least one operator-verified zone
- [ ] Add an issue, pick each category, verify the hint updates
- [ ] "Other" category requires a description; other categories do not
- [ ] `pagesAffected` accepts only integers ≥ 0
- [ ] Submit — analysis report generates, success banner shows, modal closes
- [ ] Submit while the API 500s — error banner shows, modal stays open, button re-enables
- [ ] Escape / backdrop click closes modal (but not while submitting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dismissible "Mark Complete" modal to finish reviews: summary metrics, editable issues list (category, pages affected, blocking, description), notes (max 2000 chars), and a "Mark Complete & Generate Report" action.
  * Replaced the simple confirm flow with the modal; submission sends a detailed completion payload (pages reviewed, issues, optional notes) to generate reports.

* **Bug Fixes**
  * Client-side validation with an inline error banner; Escape/backdrop close is disabled while submitting and errors are scrolled into view.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->