### PR TITLE
feat: Corpus Summary v2 scaffold + async mark-complete polling

### DIFF
--- a/src/components/bootstrap/ZoneReviewWorkspace.tsx
+++ b/src/components/bootstrap/ZoneReviewWorkspace.tsx
@@ -398,7 +398,10 @@ export default function ZoneReviewWorkspace({
       setCompleting(true);
       setCompleteBanner(null);
       try {
+        // POST returns 202 immediately; report generates in background.
         await annotationReportService.markAnnotationComplete(runId, payload);
+        // Poll until the backend finishes report generation.
+        await annotationReportService.pollAnalysisUntilDone(runId);
         queryClient.invalidateQueries({ queryKey: ['calibration', 'runs'] });
         setAnalysisGenerated(true);
         setCompleteBanner({ type: 'success', message: 'Analysis report generated.' });

--- a/src/components/calibration/BackfillCaveatBanner.tsx
+++ b/src/components/calibration/BackfillCaveatBanner.tsx
@@ -1,0 +1,36 @@
+import { useState } from 'react';
+import { AlertTriangle, X } from 'lucide-react';
+
+// Renders an inline info banner at the top of the Lineage and Timesheet tab
+// bodies to warn that data prior to 2026-04-13 is backfilled and may be
+// incomplete. Dismissible in-session only — state is NOT persisted, because
+// the warning should re-appear for operators each time they navigate to the
+// page until the backfill gap is far enough in the past to no longer matter.
+
+export function BackfillCaveatBanner() {
+  const [dismissed, setDismissed] = useState(false);
+  if (dismissed) return null;
+
+  return (
+    <div
+      role="status"
+      className="flex items-start gap-3 rounded-md border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900"
+      data-testid="backfill-caveat-banner"
+    >
+      <AlertTriangle className="mt-0.5 h-4 w-4 flex-shrink-0 text-amber-600" aria-hidden="true" />
+      <div className="flex-1">
+        Data prior to <strong>2026-04-13</strong> is backfilled and may be incomplete.
+        Per-run issue logs and per-operator timing are only authoritative for runs completed on or
+        after that date.
+      </div>
+      <button
+        type="button"
+        onClick={() => setDismissed(true)}
+        aria-label="Dismiss backfill notice"
+        className="text-amber-700 hover:text-amber-900"
+      >
+        <X className="h-4 w-4" />
+      </button>
+    </div>
+  );
+}

--- a/src/components/calibration/CorpusLineageTab.tsx
+++ b/src/components/calibration/CorpusLineageTab.tsx
@@ -1,0 +1,127 @@
+import { Download, Loader2 } from 'lucide-react';
+import { useLineageSummary } from '@/hooks/useCorpusSummary';
+import { corpusSummaryService } from '@/services/corpus-summary.service';
+import type { DateRange } from '@/types/corpus-summary.types';
+import { BackfillCaveatBanner } from './BackfillCaveatBanner';
+
+interface Props {
+  range: DateRange;
+}
+
+// Lineage tab for the Corpus Summary page.
+//
+// This is a SKELETON. It wires up the React Query hook, the loading/error/
+// empty states, the backfill caveat banner, and the per-tab Export CSV
+// button. The six section bodies are placeholders until the LineageSummary
+// response shape is confirmed against the staging PR #344 response via the
+// curl checks documented in the FE PR #2 plan doc §7.3.
+//
+// When those curls run successfully, each placeholder `<section>` gets a
+// proper implementation: headline cards → confusion matrix → per-zone-type
+// table → bucket flow → issues log drilldown → extractor disagreement.
+
+export function CorpusLineageTab({ range }: Props) {
+  const { data, isLoading, error } = useLineageSummary(range);
+
+  const handleExportCsv = () => {
+    void corpusSummaryService.downloadLineageCsv(range);
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <div className="text-sm text-gray-600">
+          {data ? (
+            <>
+              <span className="font-medium text-gray-900">{data.runsIncluded}</span> runs included
+              for {range.from} &rarr; {range.to}
+            </>
+          ) : (
+            <>&nbsp;</>
+          )}
+        </div>
+        <button
+          type="button"
+          onClick={handleExportCsv}
+          disabled={isLoading || !data || data.runsIncluded === 0}
+          className="inline-flex items-center gap-2 rounded-md border border-gray-300 bg-white px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          <Download className="h-4 w-4" />
+          Export CSV
+        </button>
+      </div>
+
+      <BackfillCaveatBanner />
+
+      {isLoading && (
+        <div className="flex items-center justify-center py-12 text-sm text-gray-500">
+          <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" />
+          Loading lineage summary&hellip;
+        </div>
+      )}
+
+      {error && (
+        <div
+          role="alert"
+          className="rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-800"
+        >
+          Failed to load lineage summary.{' '}
+          {error instanceof Error ? error.message : 'Unknown error.'}
+        </div>
+      )}
+
+      {data && data.runsIncluded === 0 && (
+        <div className="rounded-md border border-gray-200 bg-gray-50 px-4 py-8 text-center text-sm text-gray-600">
+          No completed runs in this date range. Try a wider range or mark runs complete first.
+        </div>
+      )}
+
+      {data && data.runsIncluded > 0 && (
+        <>
+          <LineageSection title="Headline metrics">
+            <SectionPlaceholder label="Headline cards: totalZones, aiAgreementRate, humanCorrectionRate, humanRejectionRate" />
+          </LineageSection>
+
+          <LineageSection title="Confusion matrix">
+            <SectionPlaceholder label="AI label vs final label matrix" />
+          </LineageSection>
+
+          <LineageSection title="Per zone type">
+            <SectionPlaceholder label="Zone type · total · confirm % · correction % · rejection % · top corrected to" />
+          </LineageSection>
+
+          <LineageSection title="Bucket flow">
+            <SectionPlaceholder label="Green / amber / red buckets → total / confirmed / corrected / rejected" />
+          </LineageSection>
+
+          <LineageSection title="Issues log">
+            <SectionPlaceholder label="Collapsed drilldown per RunIssueCategory" />
+          </LineageSection>
+
+          <LineageSection title="Extractor disagreement">
+            <SectionPlaceholder label="Final label · total zones · disagreement %" />
+          </LineageSection>
+        </>
+      )}
+    </div>
+  );
+}
+
+function LineageSection({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section className="rounded-md border border-gray-200 bg-white">
+      <header className="border-b border-gray-200 px-4 py-2">
+        <h3 className="text-sm font-semibold text-gray-900">{title}</h3>
+      </header>
+      <div className="p-4">{children}</div>
+    </section>
+  );
+}
+
+function SectionPlaceholder({ label }: { label: string }) {
+  return (
+    <div className="rounded border border-dashed border-gray-300 bg-gray-50 px-4 py-6 text-center text-xs text-gray-500">
+      {label}
+    </div>
+  );
+}

--- a/src/components/calibration/CorpusTimeRangeFilter.tsx
+++ b/src/components/calibration/CorpusTimeRangeFilter.tsx
@@ -1,0 +1,96 @@
+import { useMemo } from 'react';
+import type { DateRange } from '@/types/corpus-summary.types';
+import {
+  clampDateRange,
+  rangeLastNDays,
+  rangeThisQuarter,
+  defaultRange,
+  toIsoDate,
+} from './corpusDateRange';
+
+interface Props {
+  value: DateRange;
+  onChange: (range: DateRange) => void;
+}
+
+export function CorpusTimeRangeFilter({ value, onChange }: Props) {
+  const today = useMemo(() => toIsoDate(new Date()), []);
+
+  const applyChange = (next: DateRange) => {
+    onChange(clampDateRange(next, today));
+  };
+
+  const onFromChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    applyChange({ from: e.target.value, to: value.to });
+  };
+  const onToChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    applyChange({ from: value.from, to: e.target.value });
+  };
+
+  return (
+    <div
+      className="flex flex-wrap items-end gap-3 border-b border-gray-200 bg-white px-4 py-3"
+      data-testid="corpus-time-range-filter"
+    >
+      <div className="flex flex-col">
+        <label htmlFor="corpus-range-from" className="text-xs font-medium text-gray-600">
+          From
+        </label>
+        <input
+          id="corpus-range-from"
+          type="date"
+          className="rounded-md border border-gray-300 px-2 py-1 text-sm"
+          value={value.from}
+          max={today}
+          onChange={onFromChange}
+        />
+      </div>
+
+      <div className="flex flex-col">
+        <label htmlFor="corpus-range-to" className="text-xs font-medium text-gray-600">
+          To
+        </label>
+        <input
+          id="corpus-range-to"
+          type="date"
+          className="rounded-md border border-gray-300 px-2 py-1 text-sm"
+          value={value.to}
+          max={today}
+          onChange={onToChange}
+        />
+      </div>
+
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          className="rounded-md border border-gray-300 bg-white px-2 py-1 text-xs font-medium text-gray-700 hover:bg-gray-50"
+          onClick={() => onChange(rangeLastNDays(30))}
+        >
+          Last 30 days
+        </button>
+        <button
+          type="button"
+          className="rounded-md border border-gray-300 bg-white px-2 py-1 text-xs font-medium text-gray-700 hover:bg-gray-50"
+          onClick={() => onChange(rangeLastNDays(90))}
+        >
+          Last 90 days
+        </button>
+        <button
+          type="button"
+          className="rounded-md border border-gray-300 bg-white px-2 py-1 text-xs font-medium text-gray-700 hover:bg-gray-50"
+          onClick={() => onChange(rangeThisQuarter())}
+        >
+          This quarter
+        </button>
+      </div>
+
+      <button
+        type="button"
+        className="ml-auto text-xs font-medium text-indigo-600 hover:text-indigo-800"
+        onClick={() => onChange(defaultRange())}
+      >
+        Reset to default
+      </button>
+    </div>
+  );
+}

--- a/src/components/calibration/CorpusTimesheetTab.tsx
+++ b/src/components/calibration/CorpusTimesheetTab.tsx
@@ -1,0 +1,134 @@
+import { Download, FileText, Loader2 } from 'lucide-react';
+import { useTimesheetSummary } from '@/hooks/useCorpusSummary';
+import { corpusSummaryService } from '@/services/corpus-summary.service';
+import type { DateRange } from '@/types/corpus-summary.types';
+import { BackfillCaveatBanner } from './BackfillCaveatBanner';
+
+interface Props {
+  range: DateRange;
+}
+
+// Timesheet tab for the Corpus Summary page.
+//
+// SKELETON — see the note on CorpusLineageTab. Same pattern: hook wiring,
+// loading/error/empty, banner, per-tab exports (CSV + PDF). Five placeholder
+// sections until the TimesheetSummary shape is confirmed:
+// totals → per operator → per title (display-only) → per zone type → throughput trend.
+
+export function CorpusTimesheetTab({ range }: Props) {
+  const { data, isLoading, error } = useTimesheetSummary(range);
+
+  const handleExportCsv = () => {
+    void corpusSummaryService.downloadTimesheetCsv(range);
+  };
+  const handleExportPdf = () => {
+    void corpusSummaryService.downloadTimesheetPdf(range);
+  };
+
+  const exportsDisabled = isLoading || !data || data.runsIncluded === 0;
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <div className="text-sm text-gray-600">
+          {data ? (
+            <>
+              <span className="font-medium text-gray-900">{data.runsIncluded}</span> runs included
+              for {range.from} &rarr; {range.to}
+            </>
+          ) : (
+            <>&nbsp;</>
+          )}
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={handleExportCsv}
+            disabled={exportsDisabled}
+            className="inline-flex items-center gap-2 rounded-md border border-gray-300 bg-white px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            <Download className="h-4 w-4" />
+            Export CSV
+          </button>
+          <button
+            type="button"
+            onClick={handleExportPdf}
+            disabled={exportsDisabled}
+            className="inline-flex items-center gap-2 rounded-md border border-gray-300 bg-white px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            <FileText className="h-4 w-4" />
+            Export PDF
+          </button>
+        </div>
+      </div>
+
+      <BackfillCaveatBanner />
+
+      {isLoading && (
+        <div className="flex items-center justify-center py-12 text-sm text-gray-500">
+          <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" />
+          Loading timesheet summary&hellip;
+        </div>
+      )}
+
+      {error && (
+        <div
+          role="alert"
+          className="rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-800"
+        >
+          Failed to load timesheet summary.{' '}
+          {error instanceof Error ? error.message : 'Unknown error.'}
+        </div>
+      )}
+
+      {data && data.runsIncluded === 0 && (
+        <div className="rounded-md border border-gray-200 bg-gray-50 px-4 py-8 text-center text-sm text-gray-600">
+          No completed runs in this date range.
+        </div>
+      )}
+
+      {data && data.runsIncluded > 0 && (
+        <>
+          <TimesheetSection title="Totals">
+            <SectionPlaceholder label="Wall clock · active · idle · zones reviewed · zones/hr · cost ₹" />
+          </TimesheetSection>
+
+          <TimesheetSection title="Per operator">
+            <SectionPlaceholder label="Operator · active hrs · zones reviewed · zones/hr · confirm % · correct % · reject % · runs · cost ₹" />
+          </TimesheetSection>
+
+          <TimesheetSection title="Per title">
+            <SectionPlaceholder label="Run · document · pages · active hrs · zones · zones/hr · cost ₹ · issues · completed at (display only)" />
+          </TimesheetSection>
+
+          <TimesheetSection title="Per zone type">
+            <SectionPlaceholder label="Zone type · total zones · avg sec/zone" />
+          </TimesheetSection>
+
+          <TimesheetSection title="Throughput trend">
+            <SectionPlaceholder label="Table: date · zones reviewed · active hrs · zones/hr · operators active (chart deferred to PR #3)" />
+          </TimesheetSection>
+        </>
+      )}
+    </div>
+  );
+}
+
+function TimesheetSection({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section className="rounded-md border border-gray-200 bg-white">
+      <header className="border-b border-gray-200 px-4 py-2">
+        <h3 className="text-sm font-semibold text-gray-900">{title}</h3>
+      </header>
+      <div className="p-4">{children}</div>
+    </section>
+  );
+}
+
+function SectionPlaceholder({ label }: { label: string }) {
+  return (
+    <div className="rounded border border-dashed border-gray-300 bg-gray-50 px-4 py-6 text-center text-xs text-gray-500">
+      {label}
+    </div>
+  );
+}

--- a/src/components/calibration/__tests__/corpusDateRange.test.ts
+++ b/src/components/calibration/__tests__/corpusDateRange.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  toIsoDate,
+  rangeLastNDays,
+  defaultRange,
+  rangeThisQuarter,
+  clampDateRange,
+} from '../corpusDateRange';
+
+describe('corpusDateRange', () => {
+  describe('toIsoDate', () => {
+    it('formats as YYYY-MM-DD with zero padding', () => {
+      expect(toIsoDate(new Date(2026, 0, 1))).toBe('2026-01-01');
+      expect(toIsoDate(new Date(2026, 3, 15))).toBe('2026-04-15');
+      expect(toIsoDate(new Date(2026, 11, 31))).toBe('2026-12-31');
+    });
+  });
+
+  describe('rangeLastNDays', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date(2026, 3, 15)); // 2026-04-15
+    });
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('returns today - N days through today for N=30', () => {
+      const r = rangeLastNDays(30);
+      expect(r.to).toBe('2026-04-15');
+      expect(r.from).toBe('2026-03-16');
+    });
+
+    it('returns today - N days through today for N=90', () => {
+      const r = rangeLastNDays(90);
+      expect(r.to).toBe('2026-04-15');
+      expect(r.from).toBe('2026-01-15');
+    });
+
+    it('handles month boundaries', () => {
+      vi.setSystemTime(new Date(2026, 2, 5)); // 2026-03-05
+      const r = rangeLastNDays(10);
+      expect(r.to).toBe('2026-03-05');
+      expect(r.from).toBe('2026-02-23');
+    });
+
+    it('handles year boundaries', () => {
+      vi.setSystemTime(new Date(2026, 0, 5)); // 2026-01-05
+      const r = rangeLastNDays(10);
+      expect(r.to).toBe('2026-01-05');
+      expect(r.from).toBe('2025-12-26');
+    });
+
+    it('N=0 yields a same-day range', () => {
+      const r = rangeLastNDays(0);
+      expect(r.from).toBe('2026-04-15');
+      expect(r.to).toBe('2026-04-15');
+    });
+  });
+
+  describe('defaultRange', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date(2026, 3, 15));
+    });
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('is exactly last 30 days through today', () => {
+      const r = defaultRange();
+      expect(r).toEqual({ from: '2026-03-16', to: '2026-04-15' });
+    });
+  });
+
+  describe('rangeThisQuarter', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('Q1: Jan 1 through today when today is in Jan-Mar', () => {
+      vi.setSystemTime(new Date(2026, 1, 20)); // Feb 20
+      const r = rangeThisQuarter();
+      expect(r.from).toBe('2026-01-01');
+      expect(r.to).toBe('2026-02-20');
+    });
+
+    it('Q2: Apr 1 through today when today is in Apr-Jun', () => {
+      vi.setSystemTime(new Date(2026, 3, 15)); // Apr 15
+      const r = rangeThisQuarter();
+      expect(r.from).toBe('2026-04-01');
+      expect(r.to).toBe('2026-04-15');
+    });
+
+    it('Q3: Jul 1 through today when today is in Jul-Sep', () => {
+      vi.setSystemTime(new Date(2026, 8, 10)); // Sep 10
+      const r = rangeThisQuarter();
+      expect(r.from).toBe('2026-07-01');
+      expect(r.to).toBe('2026-09-10');
+    });
+
+    it('Q4: Oct 1 through today when today is in Oct-Dec', () => {
+      vi.setSystemTime(new Date(2026, 10, 5)); // Nov 5
+      const r = rangeThisQuarter();
+      expect(r.from).toBe('2026-10-01');
+      expect(r.to).toBe('2026-11-05');
+    });
+
+    it('exact quarter start dates land on themselves', () => {
+      vi.setSystemTime(new Date(2026, 3, 1)); // Apr 1
+      const r = rangeThisQuarter();
+      expect(r.from).toBe('2026-04-01');
+      expect(r.to).toBe('2026-04-01');
+    });
+  });
+
+  describe('clampDateRange', () => {
+    const today = '2026-04-15';
+
+    it('leaves an already-valid range alone', () => {
+      expect(clampDateRange({ from: '2026-03-01', to: '2026-04-10' }, today)).toEqual({
+        from: '2026-03-01',
+        to: '2026-04-10',
+      });
+    });
+
+    it('clamps a future `to` down to today', () => {
+      expect(clampDateRange({ from: '2026-03-01', to: '2026-05-01' }, today)).toEqual({
+        from: '2026-03-01',
+        to: '2026-04-15',
+      });
+    });
+
+    it('clamps a future `from` down to today', () => {
+      expect(clampDateRange({ from: '2026-06-01', to: '2026-06-15' }, today)).toEqual({
+        from: '2026-04-15',
+        to: '2026-04-15',
+      });
+    });
+
+    it('snaps `to` up to `from` when from > to', () => {
+      // User types a `from` later than `to` — we snap `to` to `from`.
+      expect(clampDateRange({ from: '2026-04-10', to: '2026-04-01' }, today)).toEqual({
+        from: '2026-04-10',
+        to: '2026-04-10',
+      });
+    });
+
+    it('combines future-clamp and from>to snap', () => {
+      // Both from and to are in the future; from > to. Everything collapses to today.
+      expect(clampDateRange({ from: '2026-06-10', to: '2026-06-01' }, today)).toEqual({
+        from: '2026-04-15',
+        to: '2026-04-15',
+      });
+    });
+
+    it('accepts a range ending exactly on today', () => {
+      expect(clampDateRange({ from: '2026-04-01', to: '2026-04-15' }, today)).toEqual({
+        from: '2026-04-01',
+        to: '2026-04-15',
+      });
+    });
+  });
+});

--- a/src/components/calibration/corpusDateRange.ts
+++ b/src/components/calibration/corpusDateRange.ts
@@ -1,0 +1,50 @@
+import type { DateRange } from '@/types/corpus-summary.types';
+
+// Helpers for building and clamping DateRange values used across the corpus
+// summary components. Kept separate from the component file so React Fast
+// Refresh can handle the component file cleanly.
+
+/** Format a Date as YYYY-MM-DD in local time. */
+export function toIsoDate(d: Date): string {
+  const year = d.getFullYear();
+  const month = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+function subtractDays(d: Date, days: number): Date {
+  const copy = new Date(d);
+  copy.setDate(copy.getDate() - days);
+  return copy;
+}
+
+/** Return { from: today - days, to: today } inclusive, in YYYY-MM-DD. */
+export function rangeLastNDays(days: number): DateRange {
+  const today = new Date();
+  return { from: toIsoDate(subtractDays(today, days)), to: toIsoDate(today) };
+}
+
+/** Default range used when ?from / ?to are absent from the URL. */
+export function defaultRange(): DateRange {
+  return rangeLastNDays(30);
+}
+
+/** Range from the start of the current calendar quarter through today. */
+export function rangeThisQuarter(): DateRange {
+  const now = new Date();
+  const quarterStartMonth = Math.floor(now.getMonth() / 3) * 3;
+  const start = new Date(now.getFullYear(), quarterStartMonth, 1);
+  return { from: toIsoDate(start), to: toIsoDate(now) };
+}
+
+/**
+ * Clamp a DateRange so that:
+ *   - neither endpoint is in the future
+ *   - `from <= to` (if not, snap `to` to `from`)
+ * Pass `nowIso` (the ISO date representing "today") to keep the function pure.
+ */
+export function clampDateRange(next: DateRange, nowIso: string): DateRange {
+  const to = next.to > nowIso ? nowIso : next.to;
+  const from = next.from > nowIso ? nowIso : next.from;
+  return from > to ? { from, to: from } : { from, to };
+}

--- a/src/hooks/useCorpusSummary.ts
+++ b/src/hooks/useCorpusSummary.ts
@@ -1,0 +1,29 @@
+import { useQuery } from '@tanstack/react-query';
+import { corpusSummaryService } from '@/services/corpus-summary.service';
+import type { DateRange } from '@/types/corpus-summary.types';
+
+// React Query hooks for the Corpus Summary v2 endpoints.
+//
+// The query key shape is ['corpus', <endpoint>, from, to] so a range change
+// produces a fresh cache entry, and we can invalidate the whole 'corpus'
+// subtree at once if we ever need to.
+//
+// Aggregate data — not real-time — so a 60-second staleTime is plenty.
+
+const STALE_MS = 60_000;
+
+export function useLineageSummary(range: DateRange) {
+  return useQuery({
+    queryKey: ['corpus', 'lineage-summary', range.from, range.to],
+    queryFn: () => corpusSummaryService.getLineageSummary(range),
+    staleTime: STALE_MS,
+  });
+}
+
+export function useTimesheetSummary(range: DateRange) {
+  return useQuery({
+    queryKey: ['corpus', 'timesheet-summary', range.from, range.to],
+    queryFn: () => corpusSummaryService.getTimesheetSummary(range),
+    staleTime: STALE_MS,
+  });
+}

--- a/src/pages/calibration/CorpusSummaryPage.tsx
+++ b/src/pages/calibration/CorpusSummaryPage.tsx
@@ -1,8 +1,31 @@
-import { useState } from 'react';
-import { Link } from 'react-router-dom';
+import { useCallback, useMemo, useState } from 'react';
+import { Link, useSearchParams } from 'react-router-dom';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import DOMPurify from 'dompurify';
 import { annotationReportService } from '@/services/annotation-report.service';
+import { CorpusTimeRangeFilter } from '@/components/calibration/CorpusTimeRangeFilter';
+import {
+  clampDateRange,
+  defaultRange,
+  toIsoDate,
+} from '@/components/calibration/corpusDateRange';
+import { CorpusLineageTab } from '@/components/calibration/CorpusLineageTab';
+import { CorpusTimesheetTab } from '@/components/calibration/CorpusTimesheetTab';
+import type { DateRange } from '@/types/corpus-summary.types';
+
+type CorpusTab = 'summary' | 'lineage' | 'timesheet' | 'cost';
+
+const TABS: ReadonlyArray<{ id: CorpusTab; label: string }> = [
+  { id: 'summary', label: 'Summary Report' },
+  { id: 'lineage', label: 'Lineage' },
+  { id: 'timesheet', label: 'Timesheet' },
+  { id: 'cost', label: 'Cost Summary' },
+];
+
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+function isIsoDate(s: string | null): s is string {
+  return !!s && ISO_DATE_RE.test(s);
+}
 
 /* Minimal markdown-to-HTML */
 function renderMarkdown(md: string): string {
@@ -64,10 +87,56 @@ interface CorpusSummaryResult {
 
 export default function CorpusSummaryPage() {
   const queryClient = useQueryClient();
-  const [activeTab, setActiveTab] = useState<'summary' | 'cost'>('summary');
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  // URL state: ?tab, ?from, ?to. Defaults: summary tab, last 30 days.
+  const initialTab: CorpusTab = useMemo(() => {
+    const t = searchParams.get('tab');
+    return t === 'lineage' || t === 'timesheet' || t === 'cost' || t === 'summary'
+      ? t
+      : 'summary';
+  }, [searchParams]);
+  const [activeTab, setActiveTab] = useState<CorpusTab>(initialTab);
+
+  // Read `from` / `to` from URL each render so back/forward and shared links
+  // stay deterministic. If either is missing or invalid, fall back to the
+  // default 30-day range.
+  const range: DateRange = useMemo(() => {
+    const from = searchParams.get('from');
+    const to = searchParams.get('to');
+    if (isIsoDate(from) && isIsoDate(to)) {
+      return clampDateRange({ from, to }, toIsoDate(new Date()));
+    }
+    return defaultRange();
+  }, [searchParams]);
+
+  const handleRangeChange = useCallback(
+    (next: DateRange) => {
+      const params = new URLSearchParams(searchParams);
+      params.set('from', next.from);
+      params.set('to', next.to);
+      setSearchParams(params, { replace: true });
+    },
+    [searchParams, setSearchParams],
+  );
+
+  const handleTabChange = useCallback(
+    (tab: CorpusTab) => {
+      setActiveTab(tab);
+      const params = new URLSearchParams(searchParams);
+      params.set('tab', tab);
+      setSearchParams(params, { replace: true });
+    },
+    [searchParams, setSearchParams],
+  );
+
   const [refreshing, setRefreshing] = useState(false);
 
-  const { data, isLoading, error } = useQuery<CorpusSummaryResult>({
+  const {
+    data,
+    isLoading: summaryLoading,
+    error: summaryError,
+  } = useQuery<CorpusSummaryResult>({
     queryKey: ['corpus-summary'],
     queryFn: () => annotationReportService.getCorpusSummary(),
   });
@@ -75,36 +144,18 @@ export default function CorpusSummaryPage() {
   const handleRefresh = async () => {
     setRefreshing(true);
     try {
+      await queryClient.invalidateQueries({ queryKey: ['corpus'] });
       await queryClient.invalidateQueries({ queryKey: ['corpus-summary'] });
     } finally {
       setRefreshing(false);
     }
   };
 
-  if (isLoading) {
-    return (
-      <div className="flex items-center justify-center h-64">
-        <div className="text-gray-500">Generating corpus summary...</div>
-      </div>
-    );
-  }
-
-  if (error || !data) {
-    return (
-      <div className="max-w-4xl mx-auto p-6">
-        <Link to="/bootstrap" className="text-sm text-gray-500 hover:text-gray-700 mb-4 inline-block">&larr; Back to Console</Link>
-        <div className="bg-red-50 border border-red-200 rounded p-4 text-red-700 text-sm">
-          {error instanceof Error ? error.message : 'No completed runs found. Mark annotation runs as complete first.'}
-        </div>
-      </div>
-    );
-  }
-
-  const { summaryReport, costSummary } = data;
-
   return (
     <div className="max-w-5xl mx-auto p-6">
-      <Link to="/bootstrap" className="text-sm text-gray-500 hover:text-gray-700 mb-4 inline-block">&larr; Back to Console</Link>
+      <Link to="/bootstrap" className="text-sm text-gray-500 hover:text-gray-700 mb-4 inline-block">
+        &larr; Back to Console
+      </Link>
 
       <div className="flex items-center justify-between mb-4">
         <h1 className="text-xl font-bold text-gray-900">Corpus Summary</h1>
@@ -117,78 +168,163 @@ export default function CorpusSummaryPage() {
         </button>
       </div>
 
+      <div className="mb-4">
+        <CorpusTimeRangeFilter value={range} onChange={handleRangeChange} />
+      </div>
+
       {/* Tabs */}
       <div className="flex border-b border-gray-200 mb-4">
-        {(['summary', 'cost'] as const).map((tab) => (
+        {TABS.map((tab) => (
           <button
-            key={tab}
-            onClick={() => setActiveTab(tab)}
+            key={tab.id}
+            onClick={() => handleTabChange(tab.id)}
             className={`px-4 py-2 text-sm font-medium border-b-2 -mb-px ${
-              activeTab === tab
+              activeTab === tab.id
                 ? 'border-purple-600 text-purple-600'
                 : 'border-transparent text-gray-500 hover:text-gray-700'
             }`}
           >
-            {tab === 'summary' ? 'Summary Report' : 'Cost Summary'}
+            {tab.label}
           </button>
         ))}
       </div>
 
       {activeTab === 'summary' && (
-        <div className="bg-white rounded-lg border border-gray-200 p-6">
-          <div
-            className="prose prose-sm max-w-none [&_table]:w-full [&_table]:border-collapse [&_tr]:border-b [&_tr]:border-gray-100"
-            dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(renderMarkdown(summaryReport.markdown)) }}
-          />
-          <div className="mt-6 pt-4 border-t border-gray-200 text-xs text-gray-400 flex gap-4">
-            <span>Generated: {new Date(summaryReport.generatedAt).toLocaleString()}</span>
-            <span>Model: {summaryReport.model}</span>
-            <span>Tokens: {summaryReport.tokenUsage.promptTokens} in / {summaryReport.tokenUsage.completionTokens} out</span>
-          </div>
-        </div>
+        <SummaryTabBody
+          data={data}
+          isLoading={summaryLoading}
+          error={summaryError}
+        />
       )}
 
+      {activeTab === 'lineage' && <CorpusLineageTab range={range} />}
+
+      {activeTab === 'timesheet' && <CorpusTimesheetTab range={range} />}
+
       {activeTab === 'cost' && (
-        <div className="bg-white rounded-lg border border-gray-200 overflow-x-auto">
-          <table className="w-full text-sm">
-            <thead className="bg-gray-50">
-              <tr>
-                <th className="text-left px-4 py-2 font-medium text-gray-700">Document</th>
-                <th className="text-right px-4 py-2 font-medium text-gray-700">Pages</th>
-                <th className="text-right px-4 py-2 font-medium text-gray-700">Zones</th>
-                <th className="text-right px-4 py-2 font-medium text-gray-700">AI Annotation (₹)</th>
-                <th className="text-right px-4 py-2 font-medium text-gray-700">AI Report (₹)</th>
-                <th className="text-right px-4 py-2 font-medium text-gray-700">Annotator (₹)</th>
-                <th className="text-right px-4 py-2 font-medium text-gray-700">Total (₹)</th>
-              </tr>
-            </thead>
-            <tbody>
-              {costSummary.titles.map((t) => (
-                <tr key={t.runId} className="border-t border-gray-100">
-                  <td className="px-4 py-2 text-gray-800">{t.documentName}</td>
-                  <td className="px-4 py-2 text-right text-gray-600">{t.pages}</td>
-                  <td className="px-4 py-2 text-right text-gray-600">{t.zones}</td>
-                  <td className="px-4 py-2 text-right text-gray-600">{t.aiAnnotationCostInr.toFixed(2)}</td>
-                  <td className="px-4 py-2 text-right text-gray-600">{t.aiReportCostInr.toFixed(2)}</td>
-                  <td className="px-4 py-2 text-right text-gray-600">{t.annotatorCostInr.toFixed(2)}</td>
-                  <td className="px-4 py-2 text-right font-medium text-gray-800">{t.totalCostInr.toFixed(2)}</td>
-                </tr>
-              ))}
-            </tbody>
-            <tfoot>
-              <tr className="border-t-2 border-gray-300 bg-gray-50 font-semibold">
-                <td className="px-4 py-2 text-gray-900">Total ({costSummary.totals.documents} documents)</td>
-                <td className="px-4 py-2 text-right text-gray-900">{costSummary.totals.pages}</td>
-                <td className="px-4 py-2 text-right text-gray-900">{costSummary.totals.zones}</td>
-                <td className="px-4 py-2 text-right text-gray-900">{costSummary.totals.aiAnnotationCostInr.toFixed(2)}</td>
-                <td className="px-4 py-2 text-right text-gray-900">{costSummary.totals.aiReportCostInr.toFixed(2)}</td>
-                <td className="px-4 py-2 text-right text-gray-900">{costSummary.totals.annotatorCostInr.toFixed(2)}</td>
-                <td className="px-4 py-2 text-right text-gray-900">{costSummary.totals.totalCostInr.toFixed(2)}</td>
-              </tr>
-            </tfoot>
-          </table>
-        </div>
+        <CostTabBody
+          data={data}
+          isLoading={summaryLoading}
+          error={summaryError}
+        />
       )}
+    </div>
+  );
+}
+
+interface CostSummaryBodyProps {
+  data: CorpusSummaryResult | undefined;
+  isLoading: boolean;
+  error: Error | unknown;
+}
+
+function SummaryTabBody({ data, isLoading, error }: CostSummaryBodyProps) {
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center h-64">
+        <div className="text-gray-500">Generating corpus summary...</div>
+      </div>
+    );
+  }
+  if (error || !data) {
+    return (
+      <div className="bg-red-50 border border-red-200 rounded p-4 text-red-700 text-sm">
+        {error instanceof Error
+          ? error.message
+          : 'No completed runs found. Mark annotation runs as complete first.'}
+      </div>
+    );
+  }
+  const { summaryReport } = data;
+  return (
+    <div className="bg-white rounded-lg border border-gray-200 p-6">
+      <div
+        className="prose prose-sm max-w-none [&_table]:w-full [&_table]:border-collapse [&_tr]:border-b [&_tr]:border-gray-100"
+        dangerouslySetInnerHTML={{
+          __html: DOMPurify.sanitize(renderMarkdown(summaryReport.markdown)),
+        }}
+      />
+      <div className="mt-6 pt-4 border-t border-gray-200 text-xs text-gray-400 flex gap-4">
+        <span>Generated: {new Date(summaryReport.generatedAt).toLocaleString()}</span>
+        <span>Model: {summaryReport.model}</span>
+        <span>
+          Tokens: {summaryReport.tokenUsage.promptTokens} in /{' '}
+          {summaryReport.tokenUsage.completionTokens} out
+        </span>
+      </div>
+    </div>
+  );
+}
+
+function CostTabBody({ data, isLoading, error }: CostSummaryBodyProps) {
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center h-64">
+        <div className="text-gray-500">Loading cost summary...</div>
+      </div>
+    );
+  }
+  if (error || !data) {
+    return (
+      <div className="bg-red-50 border border-red-200 rounded p-4 text-red-700 text-sm">
+        {error instanceof Error
+          ? error.message
+          : 'No completed runs found. Mark annotation runs as complete first.'}
+      </div>
+    );
+  }
+  const { costSummary } = data;
+  return (
+    <div className="bg-white rounded-lg border border-gray-200 overflow-x-auto">
+      <table className="w-full text-sm">
+        <thead className="bg-gray-50">
+          <tr>
+            <th className="text-left px-4 py-2 font-medium text-gray-700">Document</th>
+            <th className="text-right px-4 py-2 font-medium text-gray-700">Pages</th>
+            <th className="text-right px-4 py-2 font-medium text-gray-700">Zones</th>
+            <th className="text-right px-4 py-2 font-medium text-gray-700">AI Annotation (₹)</th>
+            <th className="text-right px-4 py-2 font-medium text-gray-700">AI Report (₹)</th>
+            <th className="text-right px-4 py-2 font-medium text-gray-700">Annotator (₹)</th>
+            <th className="text-right px-4 py-2 font-medium text-gray-700">Total (₹)</th>
+          </tr>
+        </thead>
+        <tbody>
+          {costSummary.titles.map((t) => (
+            <tr key={t.runId} className="border-t border-gray-100">
+              <td className="px-4 py-2 text-gray-800">{t.documentName}</td>
+              <td className="px-4 py-2 text-right text-gray-600">{t.pages}</td>
+              <td className="px-4 py-2 text-right text-gray-600">{t.zones}</td>
+              <td className="px-4 py-2 text-right text-gray-600">{t.aiAnnotationCostInr.toFixed(2)}</td>
+              <td className="px-4 py-2 text-right text-gray-600">{t.aiReportCostInr.toFixed(2)}</td>
+              <td className="px-4 py-2 text-right text-gray-600">{t.annotatorCostInr.toFixed(2)}</td>
+              <td className="px-4 py-2 text-right font-medium text-gray-800">
+                {t.totalCostInr.toFixed(2)}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+        <tfoot>
+          <tr className="border-t-2 border-gray-300 bg-gray-50 font-semibold">
+            <td className="px-4 py-2 text-gray-900">
+              Total ({costSummary.totals.documents} documents)
+            </td>
+            <td className="px-4 py-2 text-right text-gray-900">{costSummary.totals.pages}</td>
+            <td className="px-4 py-2 text-right text-gray-900">{costSummary.totals.zones}</td>
+            <td className="px-4 py-2 text-right text-gray-900">
+              {costSummary.totals.aiAnnotationCostInr.toFixed(2)}
+            </td>
+            <td className="px-4 py-2 text-right text-gray-900">
+              {costSummary.totals.aiReportCostInr.toFixed(2)}
+            </td>
+            <td className="px-4 py-2 text-right text-gray-900">
+              {costSummary.totals.annotatorCostInr.toFixed(2)}
+            </td>
+            <td className="px-4 py-2 text-right text-gray-900">
+              {costSummary.totals.totalCostInr.toFixed(2)}
+            </td>
+          </tr>
+        </tfoot>
+      </table>
     </div>
   );
 }

--- a/src/services/annotation-report.service.ts
+++ b/src/services/annotation-report.service.ts
@@ -72,6 +72,31 @@ export const annotationReportService = {
   getAnalysis: (runId: string) =>
     api.get(`/calibration/runs/${runId}/analysis`).then(r => r.data.data),
 
+  getAnalysisStatus: (runId: string) =>
+    api.get(`/calibration/runs/${runId}/analysis-status`).then(r => r.data.data),
+
+  /**
+   * Poll GET /analysis-status every `intervalMs` until `status` is
+   * 'COMPLETED' or 'FAILED'. Throws on 'FAILED' or if `maxAttempts`
+   * is exceeded.
+   */
+  pollAnalysisUntilDone: async (
+    runId: string,
+    { intervalMs = 3_000, maxAttempts = 100 } = {},
+  ) => {
+    for (let i = 0; i < maxAttempts; i++) {
+      await new Promise((r) => setTimeout(r, intervalMs));
+      const status = await api
+        .get(`/calibration/runs/${runId}/analysis-status`)
+        .then((r) => r.data.data);
+      if (status.status === 'COMPLETED') return status;
+      if (status.status === 'FAILED') {
+        throw new Error(status.error || 'Analysis report generation failed');
+      }
+    }
+    throw new Error('Analysis report generation timed out');
+  },
+
   getCorpusSummary: () =>
     api.get('/calibration/corpus/analysis-summary').then(r => r.data.data),
 };

--- a/src/services/corpus-summary.service.ts
+++ b/src/services/corpus-summary.service.ts
@@ -1,0 +1,67 @@
+import { api } from './api';
+import type {
+  DateRange,
+  LineageSummaryResponse,
+  TimesheetSummaryResponse,
+} from '@/types/corpus-summary.types';
+
+// Service wrapper for the Corpus Summary v2 endpoints introduced in Backend
+// PR #344. All functions take an explicit DateRange — no implicit defaults —
+// so callers are always aware of the window they're querying.
+
+function rangeParams(range: DateRange) {
+  return { from: range.from, to: range.to };
+}
+
+async function downloadFile(
+  url: string,
+  params: Record<string, string>,
+  filename: string,
+) {
+  const response = await api.get(url, { params, responseType: 'blob' });
+  const blob = new Blob([response.data]);
+  const link = document.createElement('a');
+  link.href = URL.createObjectURL(blob);
+  link.download = filename;
+  link.click();
+  URL.revokeObjectURL(link.href);
+}
+
+function rangeFilename(range: DateRange, prefix: string, ext: string) {
+  const from = range.from.replace(/-/g, '');
+  const to = range.to.replace(/-/g, '');
+  return `${prefix}-${from}-${to}.${ext}`;
+}
+
+export const corpusSummaryService = {
+  getLineageSummary: (range: DateRange): Promise<LineageSummaryResponse> =>
+    api
+      .get('/calibration/corpus/lineage-summary', { params: rangeParams(range) })
+      .then((r) => r.data.data),
+
+  getTimesheetSummary: (range: DateRange): Promise<TimesheetSummaryResponse> =>
+    api
+      .get('/calibration/corpus/timesheet-summary', { params: rangeParams(range) })
+      .then((r) => r.data.data),
+
+  downloadLineageCsv: (range: DateRange) =>
+    downloadFile(
+      '/calibration/corpus/lineage-summary/export/csv',
+      rangeParams(range),
+      rangeFilename(range, 'corpus-lineage-summary', 'csv'),
+    ),
+
+  downloadTimesheetCsv: (range: DateRange) =>
+    downloadFile(
+      '/calibration/corpus/timesheet-summary/export/csv',
+      rangeParams(range),
+      rangeFilename(range, 'corpus-timesheet-summary', 'csv'),
+    ),
+
+  downloadTimesheetPdf: (range: DateRange) =>
+    downloadFile(
+      '/calibration/corpus/timesheet-summary/export/pdf',
+      rangeParams(range),
+      rangeFilename(range, 'corpus-timesheet-summary', 'pdf'),
+    ),
+};

--- a/src/types/corpus-summary.types.ts
+++ b/src/types/corpus-summary.types.ts
@@ -1,0 +1,172 @@
+// Types for Corpus Summary v2 (FE PR #2).
+//
+// These mirror the response shapes of the backend endpoints introduced in
+// Backend PR #344 (`/calibration/corpus/lineage-summary` and
+// `/calibration/corpus/timesheet-summary`).
+//
+// NOTE: the shapes here are the *planned* shapes from the FE PR #2 design doc
+// (Ninja-Documentation/Annotations/FRONTEND_PR2_PLAN_CORPUS_SUMMARY_V2.md §3).
+// They must be verified against the actual staging response payloads before
+// being relied on in production code — see the staging curl checks in that
+// same doc. Any field marked `// TODO: verify` is a guess pending backend
+// confirmation.
+
+export interface DateRange {
+  /** ISO date, YYYY-MM-DD, inclusive. */
+  from: string;
+  /** ISO date, YYYY-MM-DD, inclusive. */
+  to: string;
+}
+
+// ─── Lineage summary ──────────────────────────────────────────────────
+
+export interface LineageHeadline {
+  totalZones: number;
+  /** 0..1 */
+  aiAgreementRate: number;
+  /** 0..1 */
+  humanCorrectionRate: number;
+  /** 0..1 */
+  humanRejectionRate: number;
+}
+
+export interface ConfusionMatrix {
+  labels: string[];
+  /** cells[aiLabelIdx][finalLabelIdx] */
+  cells: number[][];
+}
+
+export interface PerZoneTypeLineage {
+  zoneType: string;
+  totalZones: number;
+  /** 0..100 */
+  aiConfirmPct: number;
+  /** 0..100 */
+  aiCorrectionPct: number;
+  /** 0..100 */
+  aiRejectionPct: number;
+  topCorrectedTo: string | null;
+}
+
+export interface BucketFlowEntry {
+  total: number;
+  humanConfirmed: number;
+  humanCorrected: number;
+  humanRejected: number;
+}
+
+export interface BucketFlow {
+  green: BucketFlowEntry;
+  amber: BucketFlowEntry;
+  red: BucketFlowEntry;
+}
+
+export type RunIssueCategory =
+  | 'PAGE_ALIGNMENT_MISMATCH'
+  | 'INSUFFICIENT_JOINT_COVERAGE'
+  | 'LIMITED_ZONE_COVERAGE'
+  | 'UNEQUAL_EXTRACTOR_COVERAGE'
+  | 'SINGLE_EXTRACTOR_ONLY'
+  | 'ZONE_CONTENT_DIVERGENCE'
+  | 'COMPLETED_WITH_REDUCED_SCOPE'
+  | 'OTHER';
+
+export interface IssuesLogTitle {
+  runId: string;
+  documentName: string;
+  /** ISO timestamp */
+  completedAt: string;
+  pagesAffected: number | null;
+  description: string;
+  blocking: boolean;
+}
+
+export interface IssuesLogEntry {
+  category: RunIssueCategory;
+  titleCount: number;
+  totalPagesAffected: number;
+  blockingCount: number;
+  titles: IssuesLogTitle[];
+}
+
+export interface ExtractorDisagreementEntry {
+  finalLabel: string;
+  totalZones: number;
+  /** 0..100 */
+  disagreementPct: number;
+}
+
+export interface LineageSummaryResponse {
+  range: DateRange;
+  runsIncluded: number;
+  headline: LineageHeadline;
+  confusionMatrix: ConfusionMatrix;
+  perZoneType: PerZoneTypeLineage[];
+  bucketFlow: BucketFlow;
+  issuesLog: IssuesLogEntry[];
+  extractorDisagreement: ExtractorDisagreementEntry[];
+}
+
+// ─── Timesheet summary ────────────────────────────────────────────────
+
+export interface TimesheetTotals {
+  wallClockHours: number;
+  activeHours: number;
+  idleHours: number;
+  zonesReviewed: number;
+  zonesPerHour: number;
+  annotatorCostInr: number;
+}
+
+export interface PerOperatorEntry {
+  operator: string;
+  activeHours: number;
+  zonesReviewed: number;
+  zonesPerHour: number;
+  /** 0..100 */
+  confirmPct: number;
+  /** 0..100 */
+  correctPct: number;
+  /** 0..100 */
+  rejectPct: number;
+  runsContributedTo: number;
+  costInr: number;
+}
+
+export interface PerTitleEntry {
+  runId: string;
+  documentName: string;
+  pages: number;
+  activeHours: number;
+  zonesReviewed: number;
+  zonesPerHour: number;
+  costInr: number;
+  issuesCount: number;
+  /** ISO timestamp */
+  completedAt: string;
+}
+
+export interface PerZoneTypeTiming {
+  zoneType: string;
+  totalZones: number;
+  avgSecondsPerZone: number;
+}
+
+export interface ThroughputTrendEntry {
+  /** YYYY-MM-DD, day-bucketed */
+  date: string;
+  zonesReviewed: number;
+  activeHours: number;
+  zonesPerHour: number;
+  operatorsActive: number;
+}
+
+export interface TimesheetSummaryResponse {
+  range: DateRange;
+  runsIncluded: number;
+  totals: TimesheetTotals;
+  perOperator: PerOperatorEntry[];
+  perTitle: PerTitleEntry[];
+  perZoneType: PerZoneTypeTiming[];
+  throughputTrend: ThroughputTrendEntry[];
+}


### PR DESCRIPTION
## Summary

- **Commit 1 — `feat(corpus-summary): scaffold v2 UI`**: Adds the full type/service/hook/component scaffold for the Corpus Summary v2 page (Lineage + Timesheet tabs). Tab section internals are placeholder shells — real rendering follows once the backend response shapes are confirmed via staging curl checks. Per-tab export buttons, backfill caveat banner, date-range filter with URL persistence, and 18 unit tests for the date helpers.
- **Commit 2 — `fix: poll analysis-status after async mark-complete`**: Adapts the Mark Complete flow to backend PR #346's async contract. `POST /complete` now returns 202 immediately; the FE polls `GET /analysis-status` every 3s until `COMPLETED` or `FAILED`. Fixes the 504 Gateway Timeout that was surfacing as a misleading CORS error.

## Files changed

### New (PR #2 scaffold)
- `src/types/corpus-summary.types.ts` — response types
- `src/services/corpus-summary.service.ts` — axios calls with `DateRange`
- `src/hooks/useCorpusSummary.ts` — React Query hooks
- `src/components/calibration/corpusDateRange.ts` — pure date helpers
- `src/components/calibration/CorpusTimeRangeFilter.tsx` — from/to + quick ranges
- `src/components/calibration/BackfillCaveatBanner.tsx` — dismissible info banner
- `src/components/calibration/CorpusLineageTab.tsx` — skeleton, 6 sections
- `src/components/calibration/CorpusTimesheetTab.tsx` — skeleton, 5 sections
- `src/components/calibration/__tests__/corpusDateRange.test.ts` — 18 tests

### Modified
- `src/pages/calibration/CorpusSummaryPage.tsx` — 4-tab union, URL state, filter
- `src/services/annotation-report.service.ts` — `getAnalysisStatus` + `pollAnalysisUntilDone`
- `src/components/bootstrap/ZoneReviewWorkspace.tsx` — chain polling after 202

## Test plan

- [ ] `npx vitest run src/components/calibration/__tests__/corpusDateRange.test.ts` — 18/18 passing
- [ ] Staging: open Zone Review → Mark Complete → submit → modal spins during poll → success banner on COMPLETED
- [ ] Staging: Corpus Summary page → 4 tabs visible (Summary, Lineage, Timesheet, Cost) → Lineage/Timesheet show placeholder sections
- [ ] Staging: date-range filter changes URL params `?from=&to=` → tabs reload data on range change
- [ ] Staging: existing Summary + Cost tabs unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Lineage and Timesheet tabs to corpus summary page with CSV and PDF export options
  * Added date range filter with preset time-range options
  * Added dismissible backfill caveat warning banner

* **Improvements**
  * Enhanced Mark Complete submission flow to await server-side analysis completion before updating UI state

* **Tests**
  * Added comprehensive test coverage for date range utilities and calculations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->