### PR TITLE
feat(corpus-summary): tab body implementations + export path fix

### DIFF
--- a/src/components/calibration/CorpusLineageTab.tsx
+++ b/src/components/calibration/CorpusLineageTab.tsx
@@ -1,24 +1,300 @@
-import { Download, Loader2 } from 'lucide-react';
+import { useState } from 'react';
+import { ChevronDown, ChevronRight, Download, Loader2 } from 'lucide-react';
 import { useLineageSummary } from '@/hooks/useCorpusSummary';
 import { corpusSummaryService } from '@/services/corpus-summary.service';
-import type { DateRange } from '@/types/corpus-summary.types';
+import type {
+  BucketFlow,
+  BucketFlowEntry,
+  ConfusionMatrix,
+  DateRange,
+  ExtractorDisagreementEntry,
+  IssuesLogEntry,
+  LineageHeadline,
+  PerZoneTypeLineage,
+} from '@/types/corpus-summary.types';
 import { BackfillCaveatBanner } from './BackfillCaveatBanner';
 
 interface Props {
   range: DateRange;
 }
 
-// Lineage tab for the Corpus Summary page.
-//
-// This is a SKELETON. It wires up the React Query hook, the loading/error/
-// empty states, the backfill caveat banner, and the per-tab Export CSV
-// button. The six section bodies are placeholders until the LineageSummary
-// response shape is confirmed against the staging PR #344 response via the
-// curl checks documented in the FE PR #2 plan doc §7.3.
-//
-// When those curls run successfully, each placeholder `<section>` gets a
-// proper implementation: headline cards → confusion matrix → per-zone-type
-// table → bucket flow → issues log drilldown → extractor disagreement.
+function pct(v: number, scale: 1 | 100 = 1): string {
+  const p = scale === 1 ? v * 100 : v;
+  return `${p.toFixed(1)}%`;
+}
+
+function num(v: number): string {
+  return v.toLocaleString();
+}
+
+// ── Section: Headline cards ──────────────────────────────────────────
+
+function HeadlineCards({ h }: { h: LineageHeadline }) {
+  const cards = [
+    { label: 'Total zones', value: num(h.totalZones) },
+    { label: 'AI agreement rate', value: pct(h.aiAgreementRate) },
+    { label: 'Human correction rate', value: pct(h.humanCorrectionRate) },
+    { label: 'Human rejection rate', value: pct(h.humanRejectionRate) },
+  ];
+  return (
+    <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+      {cards.map((c) => (
+        <div key={c.label} className="rounded-md border border-gray-200 bg-gray-50 px-4 py-3 text-center">
+          <div className="text-lg font-semibold text-gray-900">{c.value}</div>
+          <div className="text-xs text-gray-500">{c.label}</div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// ── Section: Confusion matrix ────────────────────────────────────────
+
+function ConfusionMatrixTable({ matrix }: { matrix: ConfusionMatrix }) {
+  const { labels, cells } = matrix;
+  const maxVal = Math.max(1, ...cells.flat());
+
+  function cellBg(val: number, isDiag: boolean): string {
+    if (val === 0) return '';
+    const intensity = Math.min(val / maxVal, 1);
+    if (isDiag) {
+      // Diagonal = AI agreed with final → emerald scale
+      if (intensity > 0.5) return 'bg-emerald-300';
+      if (intensity > 0.2) return 'bg-emerald-200';
+      return 'bg-emerald-100';
+    }
+    // Off-diagonal = disagreement → purple scale
+    if (intensity > 0.5) return 'bg-purple-300';
+    if (intensity > 0.2) return 'bg-purple-200';
+    return 'bg-purple-100';
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="text-xs">
+        <thead>
+          <tr>
+            <th className="sticky left-0 z-10 bg-white px-2 py-1 text-left text-gray-500">
+              AI ↓ / Final →
+            </th>
+            {labels.map((l) => (
+              <th key={l} className="px-2 py-1 text-center font-medium text-gray-700 whitespace-nowrap">
+                {l}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {labels.map((rowLabel, ri) => (
+            <tr key={rowLabel}>
+              <td className="sticky left-0 z-10 bg-white px-2 py-1 font-medium text-gray-700 whitespace-nowrap">
+                {rowLabel}
+              </td>
+              {cells[ri].map((val, ci) => (
+                <td
+                  key={ci}
+                  className={`px-2 py-1 text-center tabular-nums ${cellBg(val, ri === ci)} ${ri === ci ? 'font-semibold' : ''}`}
+                >
+                  {val > 0 ? num(val) : ''}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+// ── Section: Per zone type ───────────────────────────────────────────
+
+function PerZoneTypeTable({ rows }: { rows: PerZoneTypeLineage[] }) {
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-sm">
+        <thead className="bg-gray-50">
+          <tr>
+            <th className="px-3 py-2 text-left font-medium text-gray-700">Zone type</th>
+            <th className="px-3 py-2 text-right font-medium text-gray-700">Total</th>
+            <th className="px-3 py-2 text-right font-medium text-gray-700">Confirm %</th>
+            <th className="px-3 py-2 text-right font-medium text-gray-700">Correction %</th>
+            <th className="px-3 py-2 text-right font-medium text-gray-700">Rejection %</th>
+            <th className="px-3 py-2 text-left font-medium text-gray-700">Top corrected to</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((r) => (
+            <tr key={r.zoneType} className="border-t border-gray-100">
+              <td className="px-3 py-2 font-medium text-gray-800">{r.zoneType}</td>
+              <td className="px-3 py-2 text-right tabular-nums text-gray-600">{num(r.totalZones)}</td>
+              <td className="px-3 py-2 text-right tabular-nums text-gray-600">{pct(r.aiConfirmPct, 100)}</td>
+              <td className="px-3 py-2 text-right tabular-nums text-gray-600">{pct(r.aiCorrectionPct, 100)}</td>
+              <td className="px-3 py-2 text-right tabular-nums text-gray-600">{pct(r.aiRejectionPct, 100)}</td>
+              <td className="px-3 py-2 text-gray-600">{r.topCorrectedTo ?? '—'}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+// ── Section: Bucket flow ─────────────────────────────────────────────
+
+function BucketFlowSection({ flow }: { flow: BucketFlow }) {
+  const buckets: Array<{ label: string; color: string; barColor: string; entry: BucketFlowEntry }> = [
+    { label: 'Green (high confidence)', color: 'text-emerald-700', barColor: 'bg-emerald-500', entry: flow.green },
+    { label: 'Amber (medium confidence)', color: 'text-amber-700', barColor: 'bg-amber-500', entry: flow.amber },
+    { label: 'Red (low confidence)', color: 'text-red-700', barColor: 'bg-red-500', entry: flow.red },
+  ];
+  const maxTotal = Math.max(1, ...buckets.map((b) => b.entry.total));
+
+  return (
+    <div className="space-y-4">
+      {buckets.map((b) => {
+        const { total, humanConfirmed, humanCorrected, humanRejected } = b.entry;
+        const barWidth = total > 0 ? `${(total / maxTotal) * 100}%` : '0%';
+        return (
+          <div key={b.label}>
+            <div className={`mb-1 text-sm font-medium ${b.color}`}>
+              {b.label} — {num(total)} zones
+            </div>
+            <div className="mb-1 h-3 w-full rounded-full bg-gray-100">
+              <div className={`h-3 rounded-full ${b.barColor}`} style={{ width: barWidth }} />
+            </div>
+            <div className="flex gap-4 text-xs text-gray-600">
+              <span>Confirmed: {num(humanConfirmed)}</span>
+              <span>Corrected: {num(humanCorrected)}</span>
+              <span>Rejected: {num(humanRejected)}</span>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+// ── Section: Issues log drilldown ────────────────────────────────────
+
+const CATEGORY_LABELS: Record<string, string> = {
+  PAGE_ALIGNMENT_MISMATCH: 'Page alignment mismatch',
+  INSUFFICIENT_JOINT_COVERAGE: 'Insufficient joint coverage',
+  LIMITED_ZONE_COVERAGE: 'Limited zone coverage',
+  UNEQUAL_EXTRACTOR_COVERAGE: 'Unequal extractor coverage',
+  SINGLE_EXTRACTOR_ONLY: 'Single extractor only',
+  ZONE_CONTENT_DIVERGENCE: 'Zone content divergence',
+  COMPLETED_WITH_REDUCED_SCOPE: 'Completed with reduced scope',
+  OTHER: 'Other',
+};
+
+function IssuesLogDrilldown({ entries }: { entries: IssuesLogEntry[] }) {
+  const [expanded, setExpanded] = useState<Record<string, boolean>>({});
+
+  if (entries.length === 0) {
+    return <div className="text-sm text-gray-500">No issues logged in this date range.</div>;
+  }
+
+  const toggle = (cat: string) =>
+    setExpanded((prev) => ({ ...prev, [cat]: !prev[cat] }));
+
+  return (
+    <div className="divide-y divide-gray-100">
+      {entries.map((e) => {
+        const isOpen = expanded[e.category] ?? false;
+        return (
+          <div key={e.category}>
+            <button
+              type="button"
+              onClick={() => toggle(e.category)}
+              className="flex w-full items-center gap-2 px-1 py-2 text-left text-sm hover:bg-gray-50"
+            >
+              {isOpen ? (
+                <ChevronDown className="h-4 w-4 flex-shrink-0 text-gray-400" />
+              ) : (
+                <ChevronRight className="h-4 w-4 flex-shrink-0 text-gray-400" />
+              )}
+              <span className="font-medium text-gray-800">
+                {CATEGORY_LABELS[e.category] ?? e.category}
+              </span>
+              <span className="text-xs text-gray-500">
+                {e.titleCount} {e.titleCount === 1 ? 'title' : 'titles'}
+                {e.blockingCount > 0 && ` · ${e.blockingCount} blocking`}
+                {e.totalPagesAffected > 0 && ` · ${e.totalPagesAffected} pages`}
+              </span>
+            </button>
+            {isOpen && (
+              <div className="ml-6 mb-2">
+                <table className="w-full text-xs">
+                  <thead>
+                    <tr className="text-gray-500">
+                      <th className="px-2 py-1 text-left font-medium">Document</th>
+                      <th className="px-2 py-1 text-left font-medium">Description</th>
+                      <th className="px-2 py-1 text-right font-medium">Pages</th>
+                      <th className="px-2 py-1 text-center font-medium">Blocking</th>
+                      <th className="px-2 py-1 text-left font-medium">Completed</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {e.titles.map((t) => (
+                      <tr key={`${t.runId}-${t.description}`} className="border-t border-gray-50">
+                        <td className="px-2 py-1 text-gray-700 max-w-[200px] truncate" title={t.documentName}>
+                          {t.documentName}
+                        </td>
+                        <td className="px-2 py-1 text-gray-600">{t.description}</td>
+                        <td className="px-2 py-1 text-right tabular-nums text-gray-600">
+                          {t.pagesAffected ?? '—'}
+                        </td>
+                        <td className="px-2 py-1 text-center">
+                          {t.blocking ? (
+                            <span className="inline-block rounded bg-red-100 px-1.5 py-0.5 text-red-700">Yes</span>
+                          ) : (
+                            <span className="text-gray-400">No</span>
+                          )}
+                        </td>
+                        <td className="px-2 py-1 text-gray-500 whitespace-nowrap">
+                          {new Date(t.completedAt).toLocaleDateString()}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+// ── Section: Extractor disagreement ──────────────────────────────────
+
+function ExtractorDisagreementTable({ rows }: { rows: ExtractorDisagreementEntry[] }) {
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-sm">
+        <thead className="bg-gray-50">
+          <tr>
+            <th className="px-3 py-2 text-left font-medium text-gray-700">Final label</th>
+            <th className="px-3 py-2 text-right font-medium text-gray-700">Total zones</th>
+            <th className="px-3 py-2 text-right font-medium text-gray-700">Disagreement %</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((r) => (
+            <tr key={r.finalLabel} className="border-t border-gray-100">
+              <td className="px-3 py-2 font-medium text-gray-800">{r.finalLabel}</td>
+              <td className="px-3 py-2 text-right tabular-nums text-gray-600">{num(r.totalZones)}</td>
+              <td className="px-3 py-2 text-right tabular-nums text-gray-600">{pct(r.disagreementPct, 100)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+// ── Main component ───────────────────────────────────────────────────
 
 export function CorpusLineageTab({ range }: Props) {
   const { data, isLoading, error } = useLineageSummary(range);
@@ -79,27 +355,27 @@ export function CorpusLineageTab({ range }: Props) {
       {data && data.runsIncluded > 0 && (
         <>
           <LineageSection title="Headline metrics">
-            <SectionPlaceholder label="Headline cards: totalZones, aiAgreementRate, humanCorrectionRate, humanRejectionRate" />
+            <HeadlineCards h={data.headline} />
           </LineageSection>
 
-          <LineageSection title="Confusion matrix">
-            <SectionPlaceholder label="AI label vs final label matrix" />
+          <LineageSection title="Confusion matrix (AI label vs final label)">
+            <ConfusionMatrixTable matrix={data.confusionMatrix} />
           </LineageSection>
 
           <LineageSection title="Per zone type">
-            <SectionPlaceholder label="Zone type · total · confirm % · correction % · rejection % · top corrected to" />
+            <PerZoneTypeTable rows={data.perZoneType} />
           </LineageSection>
 
           <LineageSection title="Bucket flow">
-            <SectionPlaceholder label="Green / amber / red buckets → total / confirmed / corrected / rejected" />
+            <BucketFlowSection flow={data.bucketFlow} />
           </LineageSection>
 
           <LineageSection title="Issues log">
-            <SectionPlaceholder label="Collapsed drilldown per RunIssueCategory" />
+            <IssuesLogDrilldown entries={data.issuesLog} />
           </LineageSection>
 
           <LineageSection title="Extractor disagreement">
-            <SectionPlaceholder label="Final label · total zones · disagreement %" />
+            <ExtractorDisagreementTable rows={data.extractorDisagreement} />
           </LineageSection>
         </>
       )}
@@ -115,13 +391,5 @@ function LineageSection({ title, children }: { title: string; children: React.Re
       </header>
       <div className="p-4">{children}</div>
     </section>
-  );
-}
-
-function SectionPlaceholder({ label }: { label: string }) {
-  return (
-    <div className="rounded border border-dashed border-gray-300 bg-gray-50 px-4 py-6 text-center text-xs text-gray-500">
-      {label}
-    </div>
   );
 }

--- a/src/components/calibration/CorpusTimesheetTab.tsx
+++ b/src/components/calibration/CorpusTimesheetTab.tsx
@@ -18,8 +18,11 @@ interface Props {
 export function CorpusTimesheetTab({ range }: Props) {
   const { data, isLoading, error } = useTimesheetSummary(range);
 
-  const handleExportCsv = () => {
-    void corpusSummaryService.downloadTimesheetCsv(range);
+  const handleExportOperatorCsv = () => {
+    void corpusSummaryService.downloadTimesheetPerOperatorCsv(range);
+  };
+  const handleExportTitleCsv = () => {
+    void corpusSummaryService.downloadTimesheetPerTitleCsv(range);
   };
   const handleExportPdf = () => {
     void corpusSummaryService.downloadTimesheetPdf(range);
@@ -43,12 +46,21 @@ export function CorpusTimesheetTab({ range }: Props) {
         <div className="flex items-center gap-2">
           <button
             type="button"
-            onClick={handleExportCsv}
+            onClick={handleExportOperatorCsv}
             disabled={exportsDisabled}
             className="inline-flex items-center gap-2 rounded-md border border-gray-300 bg-white px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50"
           >
             <Download className="h-4 w-4" />
-            Export CSV
+            CSV (per operator)
+          </button>
+          <button
+            type="button"
+            onClick={handleExportTitleCsv}
+            disabled={exportsDisabled}
+            className="inline-flex items-center gap-2 rounded-md border border-gray-300 bg-white px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            <Download className="h-4 w-4" />
+            CSV (per title)
           </button>
           <button
             type="button"

--- a/src/components/calibration/CorpusTimesheetTab.tsx
+++ b/src/components/calibration/CorpusTimesheetTab.tsx
@@ -1,19 +1,212 @@
 import { Download, FileText, Loader2 } from 'lucide-react';
 import { useTimesheetSummary } from '@/hooks/useCorpusSummary';
 import { corpusSummaryService } from '@/services/corpus-summary.service';
-import type { DateRange } from '@/types/corpus-summary.types';
+import type {
+  DateRange,
+  PerOperatorEntry,
+  PerTitleEntry,
+  PerZoneTypeTiming,
+  ThroughputTrendEntry,
+  TimesheetTotals,
+} from '@/types/corpus-summary.types';
 import { BackfillCaveatBanner } from './BackfillCaveatBanner';
 
 interface Props {
   range: DateRange;
 }
 
-// Timesheet tab for the Corpus Summary page.
-//
-// SKELETON — see the note on CorpusLineageTab. Same pattern: hook wiring,
-// loading/error/empty, banner, per-tab exports (CSV + PDF). Five placeholder
-// sections until the TimesheetSummary shape is confirmed:
-// totals → per operator → per title (display-only) → per zone type → throughput trend.
+function num(v: number): string {
+  return v.toLocaleString();
+}
+
+function hrs(v: number): string {
+  return v.toFixed(1);
+}
+
+function inr(v: number): string {
+  return `₹${v.toFixed(2)}`;
+}
+
+function pct100(v: number): string {
+  return `${v.toFixed(1)}%`;
+}
+
+// ── Section: Totals cards ────────────────────────────────────────────
+
+function TotalsCards({ t }: { t: TimesheetTotals }) {
+  const cards = [
+    { label: 'Wall clock', value: `${hrs(t.wallClockHours)} hrs` },
+    { label: 'Active', value: `${hrs(t.activeHours)} hrs` },
+    { label: 'Idle', value: `${hrs(t.idleHours)} hrs` },
+    { label: 'Zones reviewed', value: num(t.zonesReviewed) },
+    { label: 'Zones / hour', value: t.zonesPerHour.toFixed(1) },
+    { label: 'Cost', value: inr(t.annotatorCostInr) },
+  ];
+  return (
+    <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-6">
+      {cards.map((c) => (
+        <div key={c.label} className="rounded-md border border-gray-200 bg-gray-50 px-4 py-3 text-center">
+          <div className="text-lg font-semibold text-gray-900">{c.value}</div>
+          <div className="text-xs text-gray-500">{c.label}</div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// ── Section: Per operator ────────────────────────────────────────────
+
+function PerOperatorTable({ rows }: { rows: PerOperatorEntry[] }) {
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-sm">
+        <thead className="bg-gray-50">
+          <tr>
+            <th className="px-3 py-2 text-left font-medium text-gray-700">Operator</th>
+            <th className="px-3 py-2 text-right font-medium text-gray-700">Active hrs</th>
+            <th className="px-3 py-2 text-right font-medium text-gray-700">Zones</th>
+            <th className="px-3 py-2 text-right font-medium text-gray-700">Zones/hr</th>
+            <th className="px-3 py-2 text-right font-medium text-gray-700">Confirm %</th>
+            <th className="px-3 py-2 text-right font-medium text-gray-700">Correct %</th>
+            <th className="px-3 py-2 text-right font-medium text-gray-700">Reject %</th>
+            <th className="px-3 py-2 text-right font-medium text-gray-700">Runs</th>
+            <th className="px-3 py-2 text-right font-medium text-gray-700">Cost</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((r) => (
+            <tr key={r.operator} className="border-t border-gray-100">
+              <td className="px-3 py-2 font-medium text-gray-800">{r.operator}</td>
+              <td className="px-3 py-2 text-right tabular-nums text-gray-600">{hrs(r.activeHours)}</td>
+              <td className="px-3 py-2 text-right tabular-nums text-gray-600">{num(r.zonesReviewed)}</td>
+              <td className="px-3 py-2 text-right tabular-nums text-gray-600">{r.zonesPerHour.toFixed(1)}</td>
+              <td className="px-3 py-2 text-right tabular-nums text-gray-600">{pct100(r.confirmPct)}</td>
+              <td className="px-3 py-2 text-right tabular-nums text-gray-600">{pct100(r.correctPct)}</td>
+              <td className="px-3 py-2 text-right tabular-nums text-gray-600">{pct100(r.rejectPct)}</td>
+              <td className="px-3 py-2 text-right tabular-nums text-gray-600">{r.runsContributedTo}</td>
+              <td className="px-3 py-2 text-right tabular-nums text-gray-600">{inr(r.costInr)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+// ── Section: Per title ───────────────────────────────────────────────
+
+function PerTitleTable({ rows }: { rows: PerTitleEntry[] }) {
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-sm">
+        <thead className="bg-gray-50">
+          <tr>
+            <th className="px-3 py-2 text-left font-medium text-gray-700">Document</th>
+            <th className="px-3 py-2 text-right font-medium text-gray-700">Pages</th>
+            <th className="px-3 py-2 text-right font-medium text-gray-700">Active hrs</th>
+            <th className="px-3 py-2 text-right font-medium text-gray-700">Zones</th>
+            <th className="px-3 py-2 text-right font-medium text-gray-700">Zones/hr</th>
+            <th className="px-3 py-2 text-right font-medium text-gray-700">Cost</th>
+            <th className="px-3 py-2 text-right font-medium text-gray-700">Issues</th>
+            <th className="px-3 py-2 text-left font-medium text-gray-700">Completed</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((r) => (
+            <tr key={r.runId} className="border-t border-gray-100">
+              <td className="px-3 py-2 text-gray-800 max-w-[250px] truncate" title={r.documentName}>
+                {r.documentName}
+              </td>
+              <td className="px-3 py-2 text-right tabular-nums text-gray-600">{r.pages}</td>
+              <td className="px-3 py-2 text-right tabular-nums text-gray-600">{hrs(r.activeHours)}</td>
+              <td className="px-3 py-2 text-right tabular-nums text-gray-600">{num(r.zonesReviewed)}</td>
+              <td className="px-3 py-2 text-right tabular-nums text-gray-600">{r.zonesPerHour.toFixed(1)}</td>
+              <td className="px-3 py-2 text-right tabular-nums text-gray-600">{inr(r.costInr)}</td>
+              <td className="px-3 py-2 text-right tabular-nums text-gray-600">{r.issuesCount}</td>
+              <td className="px-3 py-2 text-gray-500 whitespace-nowrap">
+                {new Date(r.completedAt).toLocaleDateString()}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+// ── Section: Per zone type timing ────────────────────────────────────
+
+function PerZoneTypeTimingTable({ rows }: { rows: PerZoneTypeTiming[] }) {
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-sm">
+        <thead className="bg-gray-50">
+          <tr>
+            <th className="px-3 py-2 text-left font-medium text-gray-700">Zone type</th>
+            <th className="px-3 py-2 text-right font-medium text-gray-700">Total zones</th>
+            <th className="px-3 py-2 text-right font-medium text-gray-700">Avg sec/zone</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((r) => (
+            <tr key={r.zoneType} className="border-t border-gray-100">
+              <td className="px-3 py-2 font-medium text-gray-800">{r.zoneType}</td>
+              <td className="px-3 py-2 text-right tabular-nums text-gray-600">{num(r.totalZones)}</td>
+              <td className="px-3 py-2 text-right tabular-nums text-gray-600">{r.avgSecondsPerZone.toFixed(2)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+// ── Section: Throughput trend (table) ────────────────────────────────
+
+function ThroughputTrendTable({ rows }: { rows: ThroughputTrendEntry[] }) {
+  // Filter out days with zero activity to keep the table compact
+  const active = rows.filter(
+    (r) => r.zonesReviewed > 0 || r.activeHours > 0 || r.operatorsActive > 0,
+  );
+
+  if (active.length === 0) {
+    return <div className="text-sm text-gray-500">No active days in this period.</div>;
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-sm">
+        <thead className="bg-gray-50">
+          <tr>
+            <th className="px-3 py-2 text-left font-medium text-gray-700">Date</th>
+            <th className="px-3 py-2 text-right font-medium text-gray-700">Zones</th>
+            <th className="px-3 py-2 text-right font-medium text-gray-700">Active hrs</th>
+            <th className="px-3 py-2 text-right font-medium text-gray-700">Zones/hr</th>
+            <th className="px-3 py-2 text-right font-medium text-gray-700">Operators</th>
+          </tr>
+        </thead>
+        <tbody>
+          {active.map((r) => (
+            <tr key={r.date} className="border-t border-gray-100">
+              <td className="px-3 py-2 tabular-nums text-gray-800">{r.date}</td>
+              <td className="px-3 py-2 text-right tabular-nums text-gray-600">{num(r.zonesReviewed)}</td>
+              <td className="px-3 py-2 text-right tabular-nums text-gray-600">{hrs(r.activeHours)}</td>
+              <td className="px-3 py-2 text-right tabular-nums text-gray-600">{r.zonesPerHour.toFixed(1)}</td>
+              <td className="px-3 py-2 text-right tabular-nums text-gray-600">{r.operatorsActive}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      {rows.length !== active.length && (
+        <div className="px-3 py-1 text-xs text-gray-400">
+          {rows.length - active.length} inactive days hidden
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── Main component ───────────────────────────────────────────────────
 
 export function CorpusTimesheetTab({ range }: Props) {
   const { data, isLoading, error } = useTimesheetSummary(range);
@@ -102,23 +295,23 @@ export function CorpusTimesheetTab({ range }: Props) {
       {data && data.runsIncluded > 0 && (
         <>
           <TimesheetSection title="Totals">
-            <SectionPlaceholder label="Wall clock · active · idle · zones reviewed · zones/hr · cost ₹" />
+            <TotalsCards t={data.totals} />
           </TimesheetSection>
 
           <TimesheetSection title="Per operator">
-            <SectionPlaceholder label="Operator · active hrs · zones reviewed · zones/hr · confirm % · correct % · reject % · runs · cost ₹" />
+            <PerOperatorTable rows={data.perOperator} />
           </TimesheetSection>
 
           <TimesheetSection title="Per title">
-            <SectionPlaceholder label="Run · document · pages · active hrs · zones · zones/hr · cost ₹ · issues · completed at (display only)" />
+            <PerTitleTable rows={data.perTitle} />
           </TimesheetSection>
 
           <TimesheetSection title="Per zone type">
-            <SectionPlaceholder label="Zone type · total zones · avg sec/zone" />
+            <PerZoneTypeTimingTable rows={data.perZoneType} />
           </TimesheetSection>
 
           <TimesheetSection title="Throughput trend">
-            <SectionPlaceholder label="Table: date · zones reviewed · active hrs · zones/hr · operators active (chart deferred to PR #3)" />
+            <ThroughputTrendTable rows={data.throughputTrend} />
           </TimesheetSection>
         </>
       )}
@@ -134,13 +327,5 @@ function TimesheetSection({ title, children }: { title: string; children: React.
       </header>
       <div className="p-4">{children}</div>
     </section>
-  );
-}
-
-function SectionPlaceholder({ label }: { label: string }) {
-  return (
-    <div className="rounded border border-dashed border-gray-300 bg-gray-50 px-4 py-6 text-center text-xs text-gray-500">
-      {label}
-    </div>
   );
 }

--- a/src/services/corpus-summary.service.ts
+++ b/src/services/corpus-summary.service.ts
@@ -51,11 +51,18 @@ export const corpusSummaryService = {
       rangeFilename(range, 'corpus-lineage-summary', 'csv'),
     ),
 
-  downloadTimesheetCsv: (range: DateRange) =>
+  downloadTimesheetPerOperatorCsv: (range: DateRange) =>
     downloadFile(
-      '/calibration/corpus/timesheet-summary/export/csv',
+      '/calibration/corpus/timesheet-summary/export/per-operator-csv',
       rangeParams(range),
-      rangeFilename(range, 'corpus-timesheet-summary', 'csv'),
+      rangeFilename(range, 'corpus-timesheet-per-operator', 'csv'),
+    ),
+
+  downloadTimesheetPerTitleCsv: (range: DateRange) =>
+    downloadFile(
+      '/calibration/corpus/timesheet-summary/export/per-title-csv',
+      rangeParams(range),
+      rangeFilename(range, 'corpus-timesheet-per-title', 'csv'),
     ),
 
   downloadTimesheetPdf: (range: DateRange) =>


### PR DESCRIPTION
## Summary

Follow-up to #246 (merged). Fills in the skeleton tab bodies with real data rendering and fixes the timesheet export paths.

- **`fix: correct timesheet export paths`** — backend uses `/export/per-operator-csv` and `/export/per-title-csv`, not `/export/csv`. Discovered during staging curl checks. Adds a third CSV export button on the Timesheet tab.
- **`feat: implement Lineage and Timesheet tab bodies`** — replaces all 11 placeholder sections with real data rendering, verified against live staging responses (16 runs, 113K zones, 17-label confusion matrix, 4 operators, 34-day trend).

### Lineage tab (6 sections)
- Headline cards (4 tiles with rates as %)
- Confusion matrix (17×17, color-coded, sticky labels)
- Per zone type table
- Bucket flow (green/amber/red bar strips)
- Issues log drilldown (collapsed accordion per category)
- Extractor disagreement table

### Timesheet tab (5 sections)
- Totals cards (6 tiles)
- Per operator table (9 columns)
- Per title table (display-only, no row click)
- Per zone type timing table
- Throughput trend table (zero-activity days hidden, chart deferred to PR #3)

## Test plan

- [ ] `npx vitest run src/components/calibration/__tests__/corpusDateRange.test.ts` — 18/18
- [ ] Staging: Corpus Summary → Lineage tab renders all 6 sections with real data
- [ ] Staging: Corpus Summary → Timesheet tab renders all 5 sections with real data
- [ ] Staging: Export CSV (per operator), CSV (per title), and PDF buttons download files
- [ ] Staging: Export CSV on Lineage tab downloads file
- [ ] Staging: Empty date range shows "No completed runs" message on both tabs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Timesheet reports now display complete operational metrics including totals, per-operator and per-title data, zone type timing, and throughput trends.
  * Lineage reports now show detailed metrics: confusion matrix, zone-type analysis, bucket flow, issues log, and extractor disagreement.
  * CSV export functionality expanded with separate per-operator and per-title download options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->