### PR TITLE
fix: expand zone label dropdown to all 11 YOLO classes + heading levels

### DIFF
--- a/src/components/bootstrap/ZoneLabelDropdown.tsx
+++ b/src/components/bootstrap/ZoneLabelDropdown.tsx
@@ -5,14 +5,24 @@ interface ZoneLabelDropdownProps {
 }
 
 const ZONE_LABELS: Record<string, string> = {
-  paragraph: 'Body Text',
-  'section-header': 'Heading',
-  table: 'Table',
-  figure: 'Figure / Image',
-  caption: 'Caption',
-  footnote: 'Footnote',
-  header: 'Page Header',
-  footer: 'Page Footer',
+  // Content zones
+  paragraph: 'P — Body Text',
+  h1: 'H1 — Title',
+  h2: 'H2 — Section',
+  h3: 'H3 — Sub-section',
+  h4: 'H4',
+  h5: 'H5',
+  h6: 'H6',
+  'list-item': 'LI — List Item',
+  table: 'TBL — Table',
+  figure: 'FIG — Figure / Image',
+  caption: 'CAP — Caption',
+  footnote: 'FN — Footnote',
+  formula: 'Formula',
+  toci: 'TOCI — Table of Contents Item',
+  // Page chrome zones
+  header: 'HDR — Page Header',
+  footer: 'FTR — Page Footer',
 };
 
 export default function ZoneLabelDropdown({ value, onChange, disabled }: ZoneLabelDropdownProps) {

--- a/src/components/bootstrap/__tests__/ZoneLabelDropdown.test.tsx
+++ b/src/components/bootstrap/__tests__/ZoneLabelDropdown.test.tsx
@@ -3,24 +3,24 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import ZoneLabelDropdown from '../ZoneLabelDropdown';
 
 describe('ZoneLabelDropdown', () => {
-  it('renders all 8 zone types as option elements', () => {
+  it('renders all 16 zone types as option elements', () => {
     render(<ZoneLabelDropdown value="" onChange={() => {}} />);
     const select = screen.getByLabelText('Zone type');
-    // 8 zone types + 1 placeholder = 9 options
+    // 16 zone types + 1 placeholder = 17 options
     const options = select.querySelectorAll('option');
-    expect(options.length).toBe(9);
+    expect(options.length).toBe(17);
   });
 
-  it('"section-header" option shows label "Heading"', () => {
+  it('"toci" option shows label "TOCI — Table of Contents Item"', () => {
     render(<ZoneLabelDropdown value="" onChange={() => {}} />);
-    const option = screen.getByText('Heading');
+    const option = screen.getByText('TOCI — Table of Contents Item');
     expect(option).toBeInTheDocument();
-    expect((option as HTMLOptionElement).value).toBe('section-header');
+    expect((option as HTMLOptionElement).value).toBe('toci');
   });
 
-  it('"paragraph" option shows label "Body Text"', () => {
+  it('"paragraph" option shows label "P — Body Text"', () => {
     render(<ZoneLabelDropdown value="" onChange={() => {}} />);
-    const option = screen.getByText('Body Text');
+    const option = screen.getByText('P — Body Text');
     expect(option).toBeInTheDocument();
     expect((option as HTMLOptionElement).value).toBe('paragraph');
   });


### PR DESCRIPTION
## Summary
- Expands `ZoneLabelDropdown` from 8 options to 16, adding TOCI, list-item, formula, H1–H6 heading levels
- All 10 titles reported "TOC option not available in dropdown" — this fixes that
- Labels now match the operator training guide exactly (canonical keys stored as `operatorLabel` in DB)

## Before / After
| Before (8 options) | After (16 options) |
|---|---|
| Body Text, Heading, Table, Figure/Image, Caption, Footnote, Page Header, Page Footer | P — Body Text, H1–H6, LI — List Item, TBL — Table, FIG — Figure/Image, CAP — Caption, FN — Footnote, Formula, TOCI — Table of Contents Item, HDR — Page Header, FTR — Page Footer |

## Test plan
- [ ] Open Zone Review for any title → click a zone → open label dropdown → all 16 options appear
- [ ] Select **TOCI** → confirm it saves correctly
- [ ] Select **H3** → confirm it saves correctly
- [ ] Select **list-item** → confirm it saves correctly
- [ ] Verify existing labels (paragraph, table, figure, etc.) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Zone label dropdown refreshed with new shorthand prefixes and expanded labels (e.g., "P — Body Text", "H1 — Title", "HDR — Page Header").
  * Additional zone types supported: heading levels (H1–H6), list items, formulas, and table-of-contents items.
  * Figure, caption, footnote, and table labels updated to abbreviated forms (FIG, CAP, FN, TBL).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->