### PR TITLE
fix: add TOCI and Formula to ZoneComparisonDetailBar dropdown

### DIFF
--- a/src/components/bootstrap/ZoneComparisonDetailBar.tsx
+++ b/src/components/bootstrap/ZoneComparisonDetailBar.tsx
@@ -16,6 +16,8 @@ const ZONE_TYPE_OPTIONS = [
   { value: 'caption', label: 'Caption' },
   { value: 'footnote', label: 'Footnote' },
   { value: 'list-item', label: 'List Item' },
+  { value: 'toci', label: 'TOCI — Table of Contents Item' },
+  { value: 'formula', label: 'Formula' },
   { value: 'header', label: 'Page Header' },
   { value: 'footer', label: 'Page Footer' },
 ];


### PR DESCRIPTION
## Summary
- The `ZoneComparisonDetailBar` component (the actual dropdown annotators use to reclassify zones) had its own `ZONE_TYPE_OPTIONS` array missing `toci` and `formula`
- PR #248 fixed `ZoneLabelDropdown.tsx` but that component is not used in the zone detail bar
- Adds both missing entries so annotators can now select TOCI and Formula when correcting zone labels

## Test plan
- [ ] Open Bootstrap Console, click a zone — verify dropdown now shows 17 options including TOCI and Formula
- [ ] Select TOCI on a TOC page zone — verify it saves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added two new zone classification options: "TOCI (Table of Contents Item)" and "Formula" for zone reclassification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->