### PR TITLE
feat(admin): empty-pages indicator on corpus page

### DIFF
--- a/src/pages/admin/AdminCorpusPage.tsx
+++ b/src/pages/admin/AdminCorpusPage.tsx
@@ -3,6 +3,14 @@ import { Navigate, Link } from 'react-router-dom';
 import { Upload, Database, RefreshCw, Loader2, Trash2, Sparkles, Download } from 'lucide-react';
 import * as pdfjsLib from 'pdfjs-dist';
 import { useAuthStore } from '@/stores/auth.store';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogClose,
+} from '@/components/ui/Dialog';
 
 pdfjsLib.GlobalWorkerOptions.workerSrc = '/pdf.worker.min.js';
 import {
@@ -73,12 +81,124 @@ function RunStatusBadge({ status }: { status: string | undefined }) {
 function SkeletonRow() {
   return (
     <tr>
-      {Array.from({ length: 7 }).map((_, i) => (
+      {Array.from({ length: 8 }).map((_, i) => (
         <td key={i} className="px-4 py-3">
           <div className="h-4 bg-gray-200 rounded animate-pulse" />
         </td>
       ))}
     </tr>
+  );
+}
+
+function compactPageRanges(pages: number[]): string {
+  if (!pages.length) return '';
+  const sorted = [...pages].sort((a, b) => a - b);
+  const ranges: string[] = [];
+  let start = sorted[0];
+  let prev = sorted[0];
+  for (let i = 1; i < sorted.length; i++) {
+    const n = sorted[i];
+    if (n === prev + 1) {
+      prev = n;
+      continue;
+    }
+    ranges.push(start === prev ? `${start}` : `${start}–${prev}`);
+    start = n;
+    prev = n;
+  }
+  ranges.push(start === prev ? `${start}` : `${start}–${prev}`);
+  return ranges.join(', ');
+}
+
+function EmptyPagesIndicator({
+  emptyPages,
+  totalPages,
+  onClick,
+}: {
+  emptyPages: number | undefined;
+  totalPages: number | undefined;
+  onClick: () => void;
+}) {
+  if (emptyPages == null || !totalPages) {
+    return <span className="text-sm text-gray-400">—</span>;
+  }
+  if (emptyPages === 0) {
+    return (
+      <span className="px-2 py-0.5 text-xs rounded-full bg-green-100 text-green-700">
+        0
+      </span>
+    );
+  }
+  const pct = Math.round((emptyPages / totalPages) * 100);
+  const tone =
+    pct >= 25
+      ? 'bg-red-100 text-red-700 hover:bg-red-200'
+      : pct >= 10
+      ? 'bg-amber-100 text-amber-700 hover:bg-amber-200'
+      : 'bg-gray-100 text-gray-600 hover:bg-gray-200';
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`px-2 py-0.5 text-xs rounded-full transition-colors ${tone}`}
+      title={`${emptyPages} of ${totalPages} pages have no detected zones (${pct}%) — click for details`}
+    >
+      {emptyPages} ({pct}%)
+    </button>
+  );
+}
+
+function EmptyPagesModal({
+  doc,
+  onClose,
+}: {
+  doc: CorpusDocument | null;
+  onClose: () => void;
+}) {
+  const summary = doc?.calibrationRuns?.[0]?.summary;
+  const emptyPages = summary?.emptyPages;
+  const emptyPageCount = summary?.emptyPageCount ?? emptyPages?.length ?? 0;
+  const totalPages = doc?.pageCount;
+  const pct =
+    totalPages && totalPages > 0
+      ? Math.round((emptyPageCount / totalPages) * 100)
+      : 0;
+
+  return (
+    <Dialog open={doc !== null} onOpenChange={(open) => !open && onClose()}>
+      <DialogContent className="max-w-2xl p-6">
+        <DialogHeader>
+          <DialogTitle>Empty pages — {doc?.filename ?? ''}</DialogTitle>
+          <DialogDescription>
+            {emptyPageCount} of {totalPages ?? '?'} pages ({pct}%) had no zones
+            detected by the calibration run.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogClose />
+        <div className="mt-4">
+          {emptyPages && emptyPages.length > 0 ? (
+            <>
+              <div className="text-xs font-medium text-gray-500 uppercase mb-2">
+                Page numbers
+              </div>
+              <div className="max-h-80 overflow-y-auto rounded border border-gray-200 bg-gray-50 p-3 text-sm font-mono text-gray-800 break-words">
+                {compactPageRanges(emptyPages)}
+              </div>
+              <p className="mt-3 text-xs text-gray-500">
+                Spot-check the PDF at these pages to distinguish legitimately
+                empty content (front matter, blank dividers, image plates) from
+                detection failures that warrant a re-run.
+              </p>
+            </>
+          ) : (
+            <p className="text-sm text-gray-500">
+              The backend did not return a page list for this run. Ask the
+              calibration service to include <code>summary.emptyPages</code>.
+            </p>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
   );
 }
 
@@ -111,6 +231,8 @@ export default function AdminCorpusPage() {
   const [bulkAnnotateResult, setBulkAnnotateResult] = useState<string | null>(null);
   const [exportingTraining, setExportingTraining] = useState(false);
   const [exportResult, setExportResult] = useState<string | null>(null);
+  const [emptyPagesModalDoc, setEmptyPagesModalDoc] =
+    useState<CorpusDocument | null>(null);
 
   const debounceRef = useRef<ReturnType<typeof setTimeout>>();
 
@@ -657,6 +779,9 @@ export default function AdminCorpusPage() {
                   <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">
                     Last Run
                   </th>
+                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">
+                    Empty Pages
+                  </th>
                   <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase">
                     Actions
                   </th>
@@ -704,6 +829,16 @@ export default function AdminCorpusPage() {
                       <td className="px-4 py-3">
                         <RunStatusBadge status={lastRun?.status} />
                       </td>
+                      <td className="px-4 py-3">
+                        <EmptyPagesIndicator
+                          emptyPages={
+                            doc.calibrationRuns?.[0]?.summary?.emptyPageCount ??
+                            doc.calibrationRuns?.[0]?.summary?.emptyPages?.length
+                          }
+                          totalPages={doc.pageCount}
+                          onClick={() => setEmptyPagesModalDoc(doc)}
+                        />
+                      </td>
                       <td className="px-4 py-3 text-right space-x-2">
                         {doc.calibrationRuns?.[0]?.id && (
                           <Link
@@ -729,6 +864,10 @@ export default function AdminCorpusPage() {
           </div>
         )}
       </div>
+      <EmptyPagesModal
+        doc={emptyPagesModalDoc}
+        onClose={() => setEmptyPagesModalDoc(null)}
+      />
     </div>
   );
 }

--- a/src/pages/admin/AdminCorpusPage.tsx
+++ b/src/pages/admin/AdminCorpusPage.tsx
@@ -129,11 +129,12 @@ function EmptyPagesIndicator({
       </span>
     );
   }
-  const pct = Math.round((emptyPages / totalPages) * 100);
+  const rawPct = (emptyPages / totalPages) * 100;
+  const pct = Math.round(rawPct);
   const tone =
-    pct >= 25
+    rawPct >= 25
       ? 'bg-red-100 text-red-700 hover:bg-red-200'
-      : pct >= 10
+      : rawPct >= 10
       ? 'bg-amber-100 text-amber-700 hover:bg-amber-200'
       : 'bg-gray-100 text-gray-600 hover:bg-gray-200';
   return (
@@ -733,6 +734,7 @@ export default function AdminCorpusPage() {
                   <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Content Type</th>
                   <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Pages</th>
                   <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Last Run</th>
+                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Empty Pages</th>
                   <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase">Actions</th>
                 </tr>
               </thead>

--- a/src/services/adminApi.ts
+++ b/src/services/adminApi.ts
@@ -23,7 +23,7 @@ export interface CorpusDocument {
   calibrationRuns?: Array<{
     id: string;
     completedAt: string | null;
-    summary: (Record<string, unknown> & {
+    summary?: (Record<string, unknown> & {
       emptyPageCount?: number;
       emptyPages?: number[];
       pagesWithZonesCount?: number;

--- a/src/services/adminApi.ts
+++ b/src/services/adminApi.ts
@@ -23,7 +23,11 @@ export interface CorpusDocument {
   calibrationRuns?: Array<{
     id: string;
     completedAt: string | null;
-    summary: Record<string, unknown> | null;
+    summary: (Record<string, unknown> & {
+      emptyPageCount?: number;
+      emptyPages?: number[];
+      pagesWithZonesCount?: number;
+    }) | null;
   }>;
 }
 


### PR DESCRIPTION
## Summary

- Adds an **Empty Pages** column to `/admin/corpus` showing how many pages came back with no detected zones from the latest calibration run (green `0` / gray `<10%` / amber `10–24%` / red `≥25%`).
- Clickable indicator opens a modal listing the specific empty page numbers, compacted into ranges (`1–3, 45, 67–89`) so large sets like Govoni_Lovell's 332 empty pages are readable.
- Reads `summary.emptyPageCount` and `summary.emptyPages: number[]` from the existing `calibrationRuns[0].summary` field — **no new API endpoint**.
- Degrades to `—` when the backend fields are absent, so this is safe to deploy ahead of the backend change.

## Context

Annotation team reported that across 5 titles (Aulakh, CrossbillsAndConifers, Govoni_Lovell, Acharya, Logan-Scholer) a subset of pages in each PDF had no zones to annotate. There was no UI affordance to see which or how many — admins had to inspect PDFs manually. This column + drill-down gives admins a triage signal at list-level and exact page numbers at detail-level.

## Dependencies

Backend needs to populate on calibration-run summary:

- `summary.emptyPageCount: number`
- `summary.emptyPages: number[]` — sorted, 1-indexed
- `summary.pagesWithZonesCount: number` (optional, typed but not yet read by UI)

Separately tracked; a backfill script will populate these for historical runs without re-running detection.

## Test plan

- [ ] Visit `/admin/corpus` before backend ships — every row shows `—` in the Empty Pages column (graceful degradation)
- [ ] After backend ships, a run with 0 empty pages shows a green `0` badge
- [ ] A run with some empty pages shows a coloured count + `%`; tooltip shows `X of Y pages have no detected zones (Z%)`
- [ ] Clicking the indicator opens a modal listing the page numbers as compact ranges
- [ ] Close-on-Escape and close-on-backdrop-click both work
- [ ] Skeleton loader has 8 columns (one more than before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Empty Pages" column to the corpus documents table with visual indicator badges and percentage thresholds.
  * Click a badge to open a modal showing filename, empty-page count/percentage, and compacted page-number ranges when available.

* **Bug Fixes / UI**
  * Table loading skeleton updated to include the new column; cells show a fallback "—" and modal displays a fallback message when detailed page data isn't provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->