### PR TITLE
feat(bootstrap): surface empty-pages triage on Document Queue

### DIFF
--- a/src/components/bootstrap/DocumentQueueView.tsx
+++ b/src/components/bootstrap/DocumentQueueView.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { Loader2 } from 'lucide-react';
 import { useCorpusDocumentsWithPolling, useUploadTaggedPdf, useTriggerCorpusCalibrationRun } from '@/hooks/useCalibration';
 import { DocumentStatusBadge } from './DocumentStatusBadge';
+import { EmptyPagesModal } from './EmptyPagesModal';
 import { getCorpusDocumentStatus, resetCorpus } from '@/services/calibration.service';
 import type { CorpusDocument, CorpusDocumentStatus } from '@/services/calibration.service';
 
@@ -19,7 +20,7 @@ function SkeletonRows() {
     <>
       {Array.from({ length: 5 }, (_, i) => (
         <tr key={i}>
-          {Array.from({ length: 9 }, (_, j) => (
+          {Array.from({ length: 10 }, (_, j) => (
             <td key={j} className="px-6 py-4">
               <div className="h-4 bg-gray-200 rounded animate-pulse" />
             </td>
@@ -157,6 +158,7 @@ export default function DocumentQueueView() {
   const [resetting, setResetting] = useState(false);
   const navigate = useNavigate();
   const fileInputRefs = useRef<Record<string, HTMLInputElement | null>>({});
+  const [emptyPagesModalDocId, setEmptyPagesModalDocId] = useState<string | null>(null);
 
   const { data, isLoading, isError, error } = useCorpusDocumentsWithPolling();
   const uploadMutation = useUploadTaggedPdf();
@@ -388,6 +390,7 @@ export default function DocumentQueueView() {
                 <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Publisher</th>
                 <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Content Type</th>
                 <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Pages</th>
+                <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Empty Pages</th>
                 <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Extraction</th>
                 <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Annotation Status</th>
                 <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Annotation Progress</th>
@@ -414,6 +417,27 @@ export default function DocumentQueueView() {
                       </td>
                       <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
                         {doc.pageCount ?? '—'}
+                      </td>
+                      <td className="px-6 py-4 whitespace-nowrap text-sm">
+                        {(() => {
+                          const summary = doc.calibrationRuns?.[0]?.summary;
+                          const count = summary?.emptyPageCount;
+                          if (count === undefined || count === null) {
+                            return <span className="text-gray-400">—</span>;
+                          }
+                          if (count === 0) {
+                            return <span className="text-gray-500">0</span>;
+                          }
+                          return (
+                            <button
+                              onClick={() => setEmptyPagesModalDocId(doc.id)}
+                              className="text-amber-700 font-medium hover:text-amber-900 hover:underline"
+                              aria-label={`View ${count} empty pages for ${doc.filename}`}
+                            >
+                              {count}
+                            </button>
+                          );
+                        })()}
                       </td>
                       <td className="px-6 py-4 whitespace-nowrap">
                         <OperatorStatusBadge status={opStatus} />
@@ -512,6 +536,19 @@ export default function DocumentQueueView() {
           </table>
         </div>
       )}
+      {emptyPagesModalDocId && (() => {
+        const doc = documents.find((d) => d.id === emptyPagesModalDocId);
+        const summary = doc?.calibrationRuns?.[0]?.summary;
+        if (!doc || !summary?.emptyPages) return null;
+        return (
+          <EmptyPagesModal
+            filename={doc.filename}
+            pageCount={doc.pageCount ?? 0}
+            emptyPages={summary.emptyPages}
+            onClose={() => setEmptyPagesModalDocId(null)}
+          />
+        );
+      })()}
     </div>
   );
 }

--- a/src/components/bootstrap/DocumentQueueView.tsx
+++ b/src/components/bootstrap/DocumentQueueView.tsx
@@ -421,7 +421,7 @@ export default function DocumentQueueView() {
                       <td className="px-6 py-4 whitespace-nowrap text-sm">
                         {(() => {
                           const summary = doc.calibrationRuns?.[0]?.summary;
-                          const count = summary?.emptyPageCount;
+                          const count = summary?.emptyPageCount ?? summary?.emptyPages?.length;
                           if (count === undefined || count === null) {
                             return <span className="text-gray-400">—</span>;
                           }

--- a/src/components/bootstrap/EmptyPagesModal.tsx
+++ b/src/components/bootstrap/EmptyPagesModal.tsx
@@ -8,12 +8,15 @@ interface EmptyPagesModalProps {
 }
 
 function formatPageRanges(pages: number[]): string {
-  if (pages.length === 0) return '';
+  const normalized = Array.from(new Set(pages))
+    .filter((p) => Number.isInteger(p) && p > 0)
+    .sort((a, b) => a - b);
+  if (normalized.length === 0) return '';
   const ranges: string[] = [];
-  let start = pages[0];
-  let prev = pages[0];
-  for (let i = 1; i <= pages.length; i++) {
-    const curr = pages[i];
+  let start = normalized[0];
+  let prev = normalized[0];
+  for (let i = 1; i <= normalized.length; i++) {
+    const curr = normalized[i];
     if (curr !== prev + 1) {
       ranges.push(start === prev ? `${start}` : `${start}–${prev}`);
       start = curr;

--- a/src/components/bootstrap/EmptyPagesModal.tsx
+++ b/src/components/bootstrap/EmptyPagesModal.tsx
@@ -1,0 +1,94 @@
+import { X } from 'lucide-react';
+
+interface EmptyPagesModalProps {
+  filename: string;
+  pageCount: number;
+  emptyPages: number[];
+  onClose: () => void;
+}
+
+function formatPageRanges(pages: number[]): string {
+  if (pages.length === 0) return '';
+  const ranges: string[] = [];
+  let start = pages[0];
+  let prev = pages[0];
+  for (let i = 1; i <= pages.length; i++) {
+    const curr = pages[i];
+    if (curr !== prev + 1) {
+      ranges.push(start === prev ? `${start}` : `${start}–${prev}`);
+      start = curr;
+    }
+    prev = curr;
+  }
+  return ranges.join(', ');
+}
+
+export function EmptyPagesModal({ filename, pageCount, emptyPages, onClose }: EmptyPagesModalProps) {
+  const pct = pageCount > 0 ? ((emptyPages.length / pageCount) * 100).toFixed(1) : '0';
+  const ranges = formatPageRanges(emptyPages);
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+      onClick={onClose}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="empty-pages-title"
+    >
+      <div
+        className="bg-white rounded-lg shadow-xl max-w-2xl w-full max-h-[80vh] flex flex-col"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-start justify-between px-6 py-4 border-b border-gray-200">
+          <div>
+            <h2 id="empty-pages-title" className="text-lg font-semibold text-gray-900">
+              Empty Pages
+            </h2>
+            <p className="mt-0.5 text-sm text-gray-500 truncate max-w-md" title={filename}>
+              {filename}
+            </p>
+          </div>
+          <button
+            onClick={onClose}
+            aria-label="Close"
+            className="text-gray-400 hover:text-gray-600 transition-colors"
+          >
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+
+        <div className="px-6 py-4 border-b border-gray-200 bg-gray-50">
+          <p className="text-sm text-gray-700">
+            <span className="font-semibold">{emptyPages.length}</span> of{' '}
+            <span className="font-semibold">{pageCount}</span> pages have no detected zones
+            <span className="text-gray-500"> ({pct}%)</span>
+          </p>
+        </div>
+
+        <div className="px-6 py-4 overflow-y-auto flex-1">
+          {emptyPages.length === 0 ? (
+            <p className="text-sm text-gray-500 italic">No empty pages — every page has at least one detected zone.</p>
+          ) : (
+            <>
+              <p className="text-xs font-medium text-gray-500 uppercase tracking-wide mb-2">
+                Page numbers
+              </p>
+              <p className="text-sm font-mono text-gray-800 leading-relaxed break-words">
+                {ranges}
+              </p>
+            </>
+          )}
+        </div>
+
+        <div className="px-6 py-3 border-t border-gray-200 bg-gray-50 flex justify-end">
+          <button
+            onClick={onClose}
+            className="px-4 py-1.5 text-sm font-medium rounded bg-gray-200 text-gray-700 hover:bg-gray-300 transition-colors"
+          >
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/services/calibration.service.ts
+++ b/src/services/calibration.service.ts
@@ -13,7 +13,16 @@ export interface CorpusDocument {
   taggedPdfPath?: string;
   status?: 'PENDING' | 'IN_PROGRESS' | 'NEEDS_REVIEW' | 'COMPLETE';
   bootstrapJobs?: Array<{ id: string; status: string; completedAt?: string; error?: string }>;
-  calibrationRuns?: Array<{ id: string; runDate: string; completedAt?: string; summary?: Record<string, unknown> }>;
+  calibrationRuns?: Array<{
+    id: string;
+    runDate: string;
+    completedAt?: string;
+    summary?: Record<string, unknown> & {
+      emptyPages?: number[];
+      emptyPageCount?: number;
+      pagesWithZonesCount?: number;
+    };
+  }>;
   annotationProgress?: {
     totalZones: number;
     annotatedZones: number;


### PR DESCRIPTION
## Summary

- Adds an **Empty Pages** column to the Bootstrap Console's Document Queue (`DocumentQueueView`) — between Pages and Extraction. Shows `—` when the backfill hasn't run yet, plain `0` when no pages are empty, and a clickable amber count when there are empty pages.
- New `EmptyPagesModal` opens on click with a range-compressed list of the empty page numbers (e.g. `1–3, 47–49, 120`).
- Tightens `CorpusDocument.calibrationRuns[].summary` to know about `emptyPages` / `emptyPageCount` / `pagesWithZonesCount` (populated by backend PR #351).

**No backend changes** — `summary` already flows through `/calibration/corpus-docs`; this just displays what's there.

## Expected behaviour on staging (5 docs backfilled today)

| Document | Empty Pages |
|---|---|
| Govoni_Lovell_Bookmarked_6da5_v5 | **74** (clickable, amber) |
| Acharya_188080_6d06_v6 | **15** |
| Aulakh_Bookmarked_5215_v2 | **7** |
| Logan-Scholer_Bookmarked_b851_v2 | **9** |
| CrossbillsAndConifers-SRDP_0c40_v2 | `0` (plain gray) |
| (remaining 11 docs) | `—` (backfill pending) |

## Test plan

- [ ] `npm run typecheck` passes
- [ ] Visit Bootstrap Console → documents table now shows the **Empty Pages** column between Pages and Extraction
- [ ] Govoni_Lovell shows `74` as a clickable amber link
- [ ] Clicking `74` opens the modal with:
  - filename in header
  - `74 of 452 pages have no detected zones (16.4%)` summary
  - comma-separated page-number list with consecutive ranges collapsed
  - close via X button, Close button, and click-outside all work
- [ ] CrossbillsAndConifers shows plain `0` (not a button)
- [ ] Rows without backfill show `—` (also not a button)
- [ ] Skeleton loader aligns (10 cols)
- [ ] Accessibility: modal has `role="dialog"` + `aria-modal`; button has `aria-label` with filename

## Follow-up

After merge, run the full-corpus backfill (no `--filter`) so the remaining 11 rows populate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Empty Pages" column to the document queue showing empty-page counts per document.
  * Click non-zero counts to open a modal listing which pages are empty.
  * Modal shows filename, empty-page count and percentage, formatted page ranges, and clear close controls.
  * Updated loading skeleton to include the new column and added accessibility attributes to the modal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->