### PR TITLE
fix(bootstrap): paginate zone fetches in zone-review workspace

### DIFF
--- a/src/components/bootstrap/ZoneListSidebar.tsx
+++ b/src/components/bootstrap/ZoneListSidebar.tsx
@@ -9,6 +9,10 @@ interface ZoneListSidebarProps {
   onZoneClick: (zoneId: string) => void;
   zoneNumberMap?: Map<string, number>;
   hideAiBadges?: boolean;
+  // True while paginated fetches are still streaming in. When the page has zero
+  // zones AND we're still streaming, render a "Loading more…" affordance rather
+  // than "No zones on this page" (which would be a false negative).
+  isStreaming?: boolean;
 }
 
 const BUCKET_COLOR = {
@@ -24,6 +28,7 @@ export default function ZoneListSidebar({
   onZoneClick,
   zoneNumberMap,
   hideAiBadges,
+  isStreaming,
 }: ZoneListSidebarProps) {
   const pageZones = useMemo(
     () => zones.filter((z) => z.pageNumber === currentPage),
@@ -33,7 +38,7 @@ export default function ZoneListSidebar({
   if (pageZones.length === 0) {
     return (
       <div className="w-56 border-l border-gray-200 bg-white flex items-center justify-center text-xs text-gray-400">
-        No zones on this page
+        {isStreaming ? 'Loading zones…' : 'No zones on this page'}
       </div>
     );
   }

--- a/src/components/bootstrap/ZoneReviewWorkspace.tsx
+++ b/src/components/bootstrap/ZoneReviewWorkspace.tsx
@@ -109,13 +109,15 @@ export default function ZoneReviewWorkspace({
   const runId = runIdProp || runsData?.runs?.[0]?.id || '';
 
   const filterParam = bucketFilter === 'ALL' ? undefined : { bucket: bucketFilter };
-  const { data: zonesData } = useCalibrationZones(runId, filterParam);
-  const zones: CalibrationZone[] = useMemo(() => zonesData?.zones ?? [], [zonesData]);
+  const {
+    zones,
+    isComplete: zonesComplete,
+    isFetchingMore: zonesFetchingMore,
+  } = useCalibrationZones(runId, filterParam);
 
   // Unfiltered zones — used for Mark Complete eligibility so that switching
   // bucket tabs does not undercount how many pages have been reviewed.
-  const { data: allZonesData } = useCalibrationZones(runId);
-  const allZones: CalibrationZone[] = useMemo(() => allZonesData?.zones ?? [], [allZonesData]);
+  const { zones: allZones } = useCalibrationZones(runId);
 
   // Zone mutations
   const confirmZone = useConfirmZone(runId);
@@ -875,6 +877,7 @@ export default function ZoneReviewWorkspace({
               onZoneClick={setSelectedZoneId}
               zoneNumberMap={zoneNumberMap}
               hideAiBadges={isOperator}
+              isStreaming={!zonesComplete || zonesFetchingMore}
             />
           )}
       </div>

--- a/src/hooks/useZoneReview.ts
+++ b/src/hooks/useZoneReview.ts
@@ -1,4 +1,10 @@
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useEffect, useMemo } from 'react';
+import {
+  useInfiniteQuery,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from '@tanstack/react-query';
 import {
   getCalibrationZones,
   confirmZone,
@@ -13,6 +19,7 @@ import {
   getAnnotationGuide,
   getAnnotationFeedback,
   getAggregateComparison,
+  type CalibrationZone,
 } from '../services/zone-correction.service';
 
 export const ZONE_KEYS = {
@@ -20,15 +27,73 @@ export const ZONE_KEYS = {
     ['calibration', 'zones', runId, params] as const,
 };
 
+const ZONE_PAGE_SIZE = 2000;
+// Defensive guard: stop draining after this many pages.
+// Hitting it implies the backend cursor isn't terminating — bug to investigate,
+// not a normal condition. At ZONE_PAGE_SIZE=2000 this caps at 100k zones.
+const ZONE_MAX_PAGES = 50;
+
 export function useCalibrationZones(
   runId: string,
-  params?: { bucket?: string; limit?: number; cursor?: string }
+  params?: { bucket?: string; limit?: number }
 ) {
-  return useQuery({
+  const pageSize = params?.limit ?? ZONE_PAGE_SIZE;
+  const bucket = params?.bucket;
+
+  const query = useInfiniteQuery({
     queryKey: ZONE_KEYS.zones(runId, params),
-    queryFn: () => getCalibrationZones(runId, { ...params, limit: 2000 }),
+    queryFn: ({ pageParam }) =>
+      getCalibrationZones(runId, {
+        bucket,
+        limit: pageSize,
+        cursor: pageParam,
+      }),
+    initialPageParam: undefined as string | undefined,
+    getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
     enabled: !!runId,
   });
+
+  const pagesLoaded = query.data?.pages.length ?? 0;
+  const hitMaxPages = pagesLoaded >= ZONE_MAX_PAGES && (query.hasNextPage ?? false);
+
+  // Auto-drain: keep fetching pages until exhausted or guard hits.
+  useEffect(() => {
+    if (
+      query.hasNextPage &&
+      !query.isFetchingNextPage &&
+      pagesLoaded < ZONE_MAX_PAGES
+    ) {
+      query.fetchNextPage();
+    }
+  }, [query.hasNextPage, query.isFetchingNextPage, pagesLoaded, query]);
+
+  // Surface guard hits so we notice cursor-loop bugs in staging.
+  useEffect(() => {
+    if (hitMaxPages) {
+      console.warn(
+        `[useCalibrationZones] Hit ZONE_MAX_PAGES=${ZONE_MAX_PAGES} for run ${runId}; ` +
+          'backend nextCursor may not be terminating.'
+      );
+    }
+  }, [hitMaxPages, runId]);
+
+  // Flatten pages so consumers see CalibrationZone[].
+  const zones = useMemo<CalibrationZone[]>(
+    () => query.data?.pages.flatMap((p) => p.zones) ?? [],
+    [query.data]
+  );
+
+  return {
+    zones,
+    isLoading: query.isLoading,
+    isError: query.isError,
+    error: query.error,
+    isFetchingMore: query.isFetchingNextPage,
+    isComplete:
+      !query.isLoading && !query.isError && (query.hasNextPage === false || hitMaxPages),
+    pagesLoaded,
+    hitMaxPages,
+  };
 }
 
 export function useConfirmZone(runId: string) {

--- a/src/hooks/useZoneReview.ts
+++ b/src/hooks/useZoneReview.ts
@@ -57,15 +57,24 @@ export function useCalibrationZones(
   const hitMaxPages = pagesLoaded >= ZONE_MAX_PAGES && (query.hasNextPage ?? false);
 
   // Auto-drain: keep fetching pages until exhausted or guard hits.
+  // Bail on error so a transient 5xx on a mid-stream fetch doesn't loop
+  // outside React Query's retry budget.
   useEffect(() => {
     if (
       query.hasNextPage &&
       !query.isFetchingNextPage &&
+      !query.isError &&
       pagesLoaded < ZONE_MAX_PAGES
     ) {
       query.fetchNextPage();
     }
-  }, [query.hasNextPage, query.isFetchingNextPage, pagesLoaded, query]);
+  }, [
+    query.hasNextPage,
+    query.isFetchingNextPage,
+    query.isError,
+    pagesLoaded,
+    query,
+  ]);
 
   // Surface guard hits so we notice cursor-loop bugs in staging.
   useEffect(() => {


### PR DESCRIPTION
## Summary

Fixes the root cause of the "no zones in this page" reports across the entire staging corpus.

The zone-review hook (`useCalibrationZones` in `src/hooks/useZoneReview.ts`) fetched a single page with `limit=2000` and ignored `nextCursor` entirely. The backend returns zones in `pageNumber`-ascending order, so for any document with >2000 zones — which is **every document in the staging corpus** — the operator could only see zones in roughly the first ~75 pages of the book. Beyond that the UI rendered "No zones on this page" because the data simply wasn't fetched.

This is what poornakala has been reporting. Page 96 of Logan-Scholer (her "last 103" range starts at page 96) was visible-but-empty in the operator UI; the database has 37 zones on that page.

## Severity — every document affected

| Document | Total zones | Visible cap (approx) |
|---|---:|---|
| Briggs | 30,048 | first ~50 pages of 720 |
| Flanagan | 13,277 | first ~62 pages of 416 |
| Patton | 11,576 | first ~93 pages of 537 |
| Burton | 10,849 | first ~71 pages of 384 |
| Logan-Scholer | 5,260 | first ~75 pages of 198 |
| Aulakh | 2,991 | first ~197 pages of 295 |
| Nora | 2,960 | first ~87 pages of 129 |

(Briggs is the worst — annotators have been seeing roughly the first 50 pages and 670 are completely invisible.)

## Approach — Option A: client-side pagination with `useInfiniteQuery`

Considered alternatives:

- **Bump the limit to 50000** — one-line fix but a 30k-zone payload is ~10–15 MB JSON, holds peak memory in both backend and frontend, doesn't actually fix the bug class (re-breaks on the next 10× density growth).
- **Add a server-side `?paginated=false` mode** — same payload problems; awkward asymmetric API surface.
- **Drain `nextCursor` client-side via `useInfiniteQuery`** — same total bytes as today, but streamed in incrementally; first page renders within one round-trip (same as before); subsequent pages stream in over 2–4s for large books (Briggs ~15 RTTs); right architectural shape against future growth.

Chose the third.

## Implementation notes

Three pitfalls deliberately addressed:

1. **Consumer shape change.** New return shape: `{ zones, isLoading, isError, error, isFetchingMore, isComplete, pagesLoaded, hitMaxPages }`. Both call sites in `ZoneReviewWorkspace.tsx` updated; `useMemo` wrappers dropped (zones already memoized inside the hook).
2. **"Loading" state distinguishable from "empty" state.** `ZoneListSidebar` accepts an `isStreaming` prop and renders **"Loading zones…"** instead of **"No zones on this page"** while fetches are in flight. Without this, the same UI surface that produced the original bug would have produced silent partial rendering for the first 2–4s of any session.
3. **Defensive guard against non-terminating cursors.** `ZONE_MAX_PAGES = 50` (≈100k zones) caps blast radius if the backend cursor implementation has a bug. Hits log a `console.warn` so it's visible in staging — never expected to fire in practice.

## Out of scope

- **Backend `summary.emptyPages` algorithm bug.** Page 96 of Logan-Scholer has zero `Zone` rows in DB but isn't in `summary.emptyPages` (which is `[5, 21, 25, 53, 61, 73, 77, 101, 129]`). Separate investigation prompt has been handed off to the backend team. If confirmed, that's a backend PR + a `--force` re-backfill — does not block this fix from landing.
- **Telemetry routing.** `console.warn` is fine for staging diagnostics; if/when a logging service is wired into this repo, the warn should route there.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] 93 hook + bootstrap tests pass
- [ ] Manual on staging: open zone-review for **Briggs** (worst case at 30k zones), confirm zones load progressively past page 50, confirm zones eventually appear on a page like 600 that was previously invisible
- [ ] Manual on staging: navigate to a page that's truly empty (e.g. page 5 of Logan-Scholer per the `summary.emptyPages` list); confirm "No zones on this page" still renders correctly *after* loading completes
- [ ] Manual on staging: confirm "Loading zones…" message appears briefly on first paint for large books, then resolves to actual content
- [ ] Manual on staging: switching bucket filter (GREEN/AMBER/RED) re-streams the filtered set without breaking

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced loading indicators: zone list now shows "Loading zones…" while new zones stream in.
  * Pagination and incremental fetching for zone lists to handle larger datasets more smoothly.
  * Safety limit on automatic page fetching to prevent excessive or endless loading when retrieving zones.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->