### PR TITLE
feat(bootstrap): empty-pages chip in zone-review toolbar

### DIFF
--- a/src/components/bootstrap/EmptyPagesChip.tsx
+++ b/src/components/bootstrap/EmptyPagesChip.tsx
@@ -1,0 +1,154 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { AlertTriangle, X } from 'lucide-react';
+import { formatPageRanges } from '@/lib/page-ranges';
+
+interface EmptyPagesChipProps {
+  emptyPages: number[] | undefined;
+  pageCount: number;
+  currentPage: number;
+  onJumpToPage: (page: number) => void;
+}
+
+interface RangeChunk {
+  display: string;
+  start: number;
+  end: number;
+}
+
+function parseRangeChunks(formatted: string): RangeChunk[] {
+  if (!formatted) return [];
+  return formatted.split(', ').map((chunk) => {
+    const parts = chunk.split('–');
+    const start = parseInt(parts[0], 10);
+    const end = parts.length === 2 ? parseInt(parts[1], 10) : start;
+    return { display: chunk, start, end };
+  });
+}
+
+export function EmptyPagesChip({
+  emptyPages,
+  pageCount,
+  currentPage,
+  onJumpToPage,
+}: EmptyPagesChipProps) {
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const sorted = useMemo(
+    () => [...(emptyPages ?? [])].sort((a, b) => a - b),
+    [emptyPages],
+  );
+
+  const rangeChunks = useMemo(
+    () => parseRangeChunks(formatPageRanges(sorted)),
+    [sorted],
+  );
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false);
+    };
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onMouseDown = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', onMouseDown);
+    return () => document.removeEventListener('mousedown', onMouseDown);
+  }, [open]);
+
+  // Hide entirely when undefined or zero — no clutter for healthy or unbackfilled docs.
+  if (sorted.length === 0) return null;
+
+  const pct =
+    pageCount > 0 ? ((sorted.length / pageCount) * 100).toFixed(1) : '0';
+  const next = sorted.find((p) => p > currentPage);
+
+  const handleJump = (page: number) => {
+    onJumpToPage(page);
+    setOpen(false);
+  };
+
+  return (
+    <div ref={containerRef} className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="inline-flex items-center gap-1 px-2 py-1.5 text-xs font-medium rounded border border-amber-300 bg-amber-50 text-amber-800 hover:bg-amber-100 transition-colors"
+        title={`${sorted.length} of ${pageCount} pages have no detected zones (${pct}%). Click for the list.`}
+        aria-label={`${sorted.length} empty pages — click for list`}
+        aria-expanded={open}
+      >
+        <AlertTriangle className="h-3 w-3" />
+        {sorted.length} empty
+      </button>
+
+      {open && (
+        <div
+          role="dialog"
+          aria-label="Empty pages"
+          className="absolute top-full right-0 mt-1 w-72 z-50 bg-white border border-gray-200 rounded-lg shadow-lg p-3"
+        >
+          <div className="flex items-start justify-between mb-2">
+            <div>
+              <div className="text-sm font-semibold text-gray-900">
+                Empty Pages
+              </div>
+              <div className="text-xs text-gray-500">
+                {sorted.length} of {pageCount} have no detected zones ({pct}%)
+              </div>
+            </div>
+            <button
+              type="button"
+              onClick={() => setOpen(false)}
+              aria-label="Close"
+              className="text-gray-400 hover:text-gray-600 -mr-1 -mt-1 p-1"
+            >
+              <X className="h-4 w-4" />
+            </button>
+          </div>
+
+          <div className="text-xs leading-relaxed break-words mb-3">
+            {rangeChunks.map((chunk, i) => {
+              const isCurrent =
+                currentPage >= chunk.start && currentPage <= chunk.end;
+              return (
+                <span key={`${chunk.start}-${chunk.end}`}>
+                  <button
+                    type="button"
+                    onClick={() => handleJump(chunk.start)}
+                    className={`px-1 py-0.5 rounded font-mono hover:underline ${
+                      isCurrent
+                        ? 'font-bold text-amber-900 bg-amber-100'
+                        : 'text-amber-700 hover:bg-amber-50'
+                    }`}
+                    title={`Jump to page ${chunk.start}`}
+                  >
+                    {chunk.display}
+                  </button>
+                  {i < rangeChunks.length - 1 ? ', ' : ''}
+                </span>
+              );
+            })}
+          </div>
+
+          <button
+            type="button"
+            onClick={() => next && handleJump(next)}
+            disabled={!next}
+            className="w-full text-xs px-2 py-1.5 rounded bg-amber-600 text-white hover:bg-amber-700 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+          >
+            {next ? `Next empty page → ${next}` : 'No more empty pages after this'}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/bootstrap/EmptyPagesChip.tsx
+++ b/src/components/bootstrap/EmptyPagesChip.tsx
@@ -3,6 +3,7 @@ import { AlertTriangle, X } from 'lucide-react';
 import { formatPageRanges } from '@/lib/page-ranges';
 
 interface EmptyPagesChipProps {
+  filename?: string;
   emptyPages: number[] | undefined;
   pageCount: number;
   currentPage: number;
@@ -26,6 +27,7 @@ function parseRangeChunks(formatted: string): RangeChunk[] {
 }
 
 export function EmptyPagesChip({
+  filename,
   emptyPages,
   pageCount,
   currentPage,
@@ -34,8 +36,14 @@ export function EmptyPagesChip({
   const [open, setOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
 
+  // Normalize once: dedupe, drop non-positive integers, sort ascending.
+  // Everything downstream (count, ranges, next-empty button) reads from here so
+  // the chip's number always matches the popover's range list.
   const sorted = useMemo(
-    () => [...(emptyPages ?? [])].sort((a, b) => a - b),
+    () =>
+      Array.from(new Set(emptyPages ?? []))
+        .filter((p) => Number.isInteger(p) && p > 0)
+        .sort((a, b) => a - b),
     [emptyPages],
   );
 
@@ -97,10 +105,18 @@ export function EmptyPagesChip({
           className="absolute top-full right-0 mt-1 w-72 z-50 bg-white border border-gray-200 rounded-lg shadow-lg p-3"
         >
           <div className="flex items-start justify-between mb-2">
-            <div>
+            <div className="min-w-0 flex-1">
               <div className="text-sm font-semibold text-gray-900">
                 Empty Pages
               </div>
+              {filename && (
+                <div
+                  className="text-xs text-gray-500 truncate"
+                  title={filename}
+                >
+                  {filename}
+                </div>
+              )}
               <div className="text-xs text-gray-500">
                 {sorted.length} of {pageCount} have no detected zones ({pct}%)
               </div>

--- a/src/components/bootstrap/EmptyPagesModal.tsx
+++ b/src/components/bootstrap/EmptyPagesModal.tsx
@@ -1,29 +1,11 @@
 import { X } from 'lucide-react';
+import { formatPageRanges } from '@/lib/page-ranges';
 
 interface EmptyPagesModalProps {
   filename: string;
   pageCount: number;
   emptyPages: number[];
   onClose: () => void;
-}
-
-function formatPageRanges(pages: number[]): string {
-  const normalized = Array.from(new Set(pages))
-    .filter((p) => Number.isInteger(p) && p > 0)
-    .sort((a, b) => a - b);
-  if (normalized.length === 0) return '';
-  const ranges: string[] = [];
-  let start = normalized[0];
-  let prev = normalized[0];
-  for (let i = 1; i <= normalized.length; i++) {
-    const curr = normalized[i];
-    if (curr !== prev + 1) {
-      ranges.push(start === prev ? `${start}` : `${start}–${prev}`);
-      start = curr;
-    }
-    prev = curr;
-  }
-  return ranges.join(', ');
 }
 
 export function EmptyPagesModal({ filename, pageCount, emptyPages, onClose }: EmptyPagesModalProps) {

--- a/src/components/bootstrap/ZoneReviewWorkspace.tsx
+++ b/src/components/bootstrap/ZoneReviewWorkspace.tsx
@@ -5,7 +5,7 @@ import { useAuthStore } from '@/stores/auth.store';
 import { Document, Page, pdfjs } from 'react-pdf';
 import 'react-pdf/dist/esm/Page/AnnotationLayer.css';
 import 'react-pdf/dist/esm/Page/TextLayer.css';
-import { useCalibrationRuns } from '@/hooks/useCalibration';
+import { useCalibrationRun, useCalibrationRuns } from '@/hooks/useCalibration';
 import {
   useCalibrationZones,
   useConfirmZone,
@@ -27,6 +27,7 @@ import ZonePdfPanel from './ZonePdfPanel';
 import ZoneComparisonDetailBar from './ZoneComparisonDetailBar';
 import ZoneOverlay from './ZoneOverlay';
 import ZoneListSidebar from './ZoneListSidebar';
+import { EmptyPagesChip } from './EmptyPagesChip';
 import { MarkCompleteModal, type MarkCompleteRequest } from './MarkCompleteModal';
 import { useZoneNumberMap } from '@/hooks/useZoneNumberMap';
 import { TableStructureEditor } from '../quickfix/TableStructureEditor';
@@ -107,6 +108,11 @@ export default function ZoneReviewWorkspace({
     runIdProp ? undefined : { documentId: docId, limit: 1 },
   );
   const runId = runIdProp || runsData?.runs?.[0]?.id || '';
+
+  // Pull the run's summary specifically so emptyPages reflects the run we're
+  // showing zones for (not the latest run, which may differ from runIdProp).
+  const { data: runDetail } = useCalibrationRun(runId);
+  const emptyPages = runDetail?.summary?.emptyPages;
 
   const filterParam = bucketFilter === 'ALL' ? undefined : { bucket: bucketFilter };
   const {
@@ -614,6 +620,16 @@ export default function ZoneReviewWorkspace({
           >
             {showZoneList ? 'Hide List' : 'Show List'}
           </button>
+
+          <EmptyPagesChip
+            emptyPages={emptyPages}
+            pageCount={numPages}
+            currentPage={currentPage}
+            onJumpToPage={(page) => {
+              setCurrentPage(page);
+              setSelectedZoneId(null);
+            }}
+          />
 
           {/* Page navigation */}
           <div className="flex items-center gap-1 text-sm text-gray-600">

--- a/src/components/bootstrap/ZoneReviewWorkspace.tsx
+++ b/src/components/bootstrap/ZoneReviewWorkspace.tsx
@@ -5,7 +5,11 @@ import { useAuthStore } from '@/stores/auth.store';
 import { Document, Page, pdfjs } from 'react-pdf';
 import 'react-pdf/dist/esm/Page/AnnotationLayer.css';
 import 'react-pdf/dist/esm/Page/TextLayer.css';
-import { useCalibrationRun, useCalibrationRuns } from '@/hooks/useCalibration';
+import {
+  useCalibrationRun,
+  useCalibrationRuns,
+  useCorpusDocuments,
+} from '@/hooks/useCalibration';
 import {
   useCalibrationZones,
   useConfirmZone,
@@ -113,6 +117,12 @@ export default function ZoneReviewWorkspace({
   // showing zones for (not the latest run, which may differ from runIdProp).
   const { data: runDetail } = useCalibrationRun(runId);
   const emptyPages = runDetail?.summary?.emptyPages;
+
+  // Filename for the empty-pages popover header. Pulled from the cached corpus
+  // document list (DocumentQueueView populates this cache on the screen the
+  // user typically comes from); when stale or uncached, falls back to fetching.
+  const { data: docsData } = useCorpusDocuments();
+  const docFilename = docsData?.documents?.find((d) => d.id === docId)?.filename;
 
   const filterParam = bucketFilter === 'ALL' ? undefined : { bucket: bucketFilter };
   const {
@@ -622,6 +632,7 @@ export default function ZoneReviewWorkspace({
           </button>
 
           <EmptyPagesChip
+            filename={docFilename}
             emptyPages={emptyPages}
             pageCount={numPages}
             currentPage={currentPage}

--- a/src/hooks/useCalibration.ts
+++ b/src/hooks/useCalibration.ts
@@ -2,6 +2,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import {
   getCorpusDocuments,
   startCalibration,
+  getCalibrationRun,
   getCalibrationRuns,
   getCorpusStats,
   uploadTaggedPdf,
@@ -45,6 +46,14 @@ export function useCalibrationRuns(params?: {
   return useQuery({
     queryKey: CALIBRATION_KEYS.runs(params),
     queryFn: () => getCalibrationRuns(params),
+  });
+}
+
+export function useCalibrationRun(runId: string) {
+  return useQuery({
+    queryKey: CALIBRATION_KEYS.run(runId),
+    queryFn: () => getCalibrationRun(runId),
+    enabled: !!runId,
   });
 }
 

--- a/src/lib/page-ranges.ts
+++ b/src/lib/page-ranges.ts
@@ -1,0 +1,28 @@
+/**
+ * Compress a list of page numbers into a comma-separated string with
+ * consecutive runs collapsed into ranges.
+ *
+ *   formatPageRanges([1, 2, 3, 7, 10, 11, 12])  // "1–3, 7, 10–12"
+ *
+ * Input is normalized first — duplicates removed, non-positive-integers
+ * dropped, then sorted ascending — so the output is stable regardless of
+ * payload order.
+ */
+export function formatPageRanges(pages: number[]): string {
+  const normalized = Array.from(new Set(pages))
+    .filter((p) => Number.isInteger(p) && p > 0)
+    .sort((a, b) => a - b);
+  if (normalized.length === 0) return '';
+  const ranges: string[] = [];
+  let start = normalized[0];
+  let prev = normalized[0];
+  for (let i = 1; i <= normalized.length; i++) {
+    const curr = normalized[i];
+    if (curr !== prev + 1) {
+      ranges.push(start === prev ? `${start}` : `${start}–${prev}`);
+      start = curr;
+    }
+    prev = curr;
+  }
+  return ranges.join(', ');
+}

--- a/src/services/calibration.service.ts
+++ b/src/services/calibration.service.ts
@@ -84,7 +84,11 @@ export interface CalibrationRun {
   greenCount?: number;
   amberCount?: number;
   redCount?: number;
-  summary?: object;
+  summary?: Record<string, unknown> & {
+    emptyPages?: number[];
+    emptyPageCount?: number;
+    pagesWithZonesCount?: number;
+  };
 }
 
 export interface CorpusStats {


### PR DESCRIPTION
## Summary

Adds a compact **N empty** chip to the zone-review workspace toolbar that opens a popover listing the empty pages for the displayed run. Each range is clickable to jump to that page; a *Next empty page* button jumps forward through them.

Until now, the only way to find out which pages of a document have no detected zones was to leave the workspace, go to the Bootstrap Console's documents table, click the amber count, read the modal, then come back and manually navigate. This surfaces the same information where the work is actually happening.

## Behaviour

| State | What you see |
|---|---|
| Run has empty pages and is backfilled | Amber **"N empty"** chip in the toolbar between *Hide List* and the page navigator |
| Run has zero empty pages | Chip hidden (no clutter for healthy docs) |
| Run hasn't been backfilled (`summary.emptyPages` absent) | Chip hidden (no misleading state) |
| Chip clicked | Popover opens with: filename context, summary line ("N of M pages have no detected zones (X%)"), compact range list (`1–3, 47–49, 120`), and a "Next empty page → N" button |
| Page in the list clicked | Workspace navigates to that page; popover closes |
| Currently on an empty page | That page's range is highlighted in the popover |
| Esc / click outside | Popover closes |

## Implementation notes

- `formatPageRanges` extracted from `EmptyPagesModal.tsx` to a shared `src/lib/page-ranges.ts` util — both the modal and the new chip use the same function.
- New `useCalibrationRun(runId)` hook in `src/hooks/useCalibration.ts` fetches the *specific* run's summary, so the chip always reflects the run being shown rather than whatever run is most recent. Matters when `runIdProp` points at a historical run.
- `CalibrationRun.summary` type tightened to expose `emptyPages` / `emptyPageCount` / `pagesWithZonesCount`, mirroring the shape already on `CorpusDocument.calibrationRuns[].summary`.

## Out of scope

**In-workspace categorization (Option C in the design discussion).** This PR only adds navigation — clicking an empty page in the popover lands you on it, but recording the `legit_empty` / `detection_failure` decision still happens in the Google Sheet. Bringing categorization into the workspace requires a backend persistence model + endpoint and is being scoped as a follow-up.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] 105 related tests pass
- [ ] Manual on staging:
  - Open `/bootstrap/zone-review/{docId}` for a backfilled doc with empty pages (e.g. Govoni_Lovell, 74 empty) — chip appears showing "74 empty"
  - Click chip → popover opens with compact ranges
  - Click a range → workspace navigates to that page
  - Click "Next empty page" → workspace advances to next empty page
  - Press Esc / click outside → popover closes
  - Open a doc with `emptyPageCount = 0` (e.g. Crossbills) — no chip rendered
  - Open a doc that hasn't been backfilled yet — no chip rendered (graceful degradation)
  - Navigate to an empty page directly via the page input — popover (when opened) highlights that page in the list

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an empty-pages summary chip in the calibration workspace showing counts, percentages, interactive range buttons, and a "Next empty page" shortcut for quick navigation.
* **Improvements**
  * Consolidated page-range formatting into a shared utility for consistent display.
  * Workspace now fetches and surfaces per-run empty-page data and document filenames to the chip.
  * Strengthened typing for calibration run summary metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->