### PR TITLE
feat(bootstrap): in-workspace empty-page categorization

### DIFF
--- a/src/components/bootstrap/EmptyPageReviewSidebar.tsx
+++ b/src/components/bootstrap/EmptyPageReviewSidebar.tsx
@@ -1,0 +1,440 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Loader2, Save, Trash2 } from 'lucide-react';
+import {
+  DETECTION_FAILURE_PAGE_TYPES,
+  EMPTY_PAGE_CATEGORIES,
+  EMPTY_PAGE_TYPES,
+  LEGIT_EMPTY_PAGE_TYPES,
+  type EmptyPageCategory,
+  type EmptyPageType,
+} from '@/services/empty-page-review.service';
+import {
+  useDeleteEmptyPageReview,
+  useEmptyPageReview,
+  useSaveEmptyPageReview,
+} from '@/hooks/useEmptyPageReviews';
+import { trackEvent } from '@/lib/telemetry';
+
+interface EmptyPageReviewSidebarProps {
+  runId: string;
+  pageNumber: number;
+  filename?: string;
+}
+
+const CATEGORY_LABEL: Record<EmptyPageCategory, string> = {
+  LEGIT_EMPTY: 'Legit empty',
+  DETECTION_FAILURE: 'Detection failure',
+  UNSURE: 'Unsure',
+};
+
+const CATEGORY_DESCRIPTION: Record<EmptyPageCategory, string> = {
+  LEGIT_EMPTY: 'Page is meant to be empty (blank, image plate, copyright, etc.)',
+  DETECTION_FAILURE: 'Page has content the model should have detected',
+  UNSURE: 'Borderline — flag for joint review',
+};
+
+function formatPageTypeLabel(value: string): string {
+  return value.replace(/_/g, ' ');
+}
+
+function pageTypesForCategory(
+  category: EmptyPageCategory | null,
+): ReadonlyArray<EmptyPageType> {
+  if (category === 'LEGIT_EMPTY') return LEGIT_EMPTY_PAGE_TYPES;
+  if (category === 'DETECTION_FAILURE' || category === 'UNSURE') {
+    // DETECTION_FAILURE_PAGE_TYPES already includes 'mixed'; append 'other' as catch-all.
+    return [...DETECTION_FAILURE_PAGE_TYPES, 'other'];
+  }
+  return EMPTY_PAGE_TYPES;
+}
+
+export function EmptyPageReviewSidebar({
+  runId,
+  pageNumber,
+  filename,
+}: EmptyPageReviewSidebarProps) {
+  const { data: existing, isLoading } = useEmptyPageReview(runId, pageNumber);
+  const saveMutation = useSaveEmptyPageReview(runId);
+  const deleteMutation = useDeleteEmptyPageReview(runId);
+
+  const [category, setCategory] = useState<EmptyPageCategory | null>(null);
+  const [pageType, setPageType] = useState<string>('');
+  const [expectedContent, setExpectedContent] = useState('');
+  const [notes, setNotes] = useState('');
+  const [feedback, setFeedback] = useState<{
+    kind: 'success' | 'error';
+    text: string;
+  } | null>(null);
+  const [pendingDelete, setPendingDelete] = useState(false);
+
+  // Reset form when navigating to a different page or when the loaded review changes.
+  useEffect(() => {
+    if (existing) {
+      setCategory(existing.category);
+      setPageType(existing.pageType);
+      setExpectedContent(existing.expectedContent ?? '');
+      setNotes(existing.notes ?? '');
+    } else {
+      setCategory(null);
+      setPageType('');
+      setExpectedContent('');
+      setNotes('');
+    }
+    setFeedback(null);
+    setPendingDelete(false);
+  }, [existing, pageNumber, runId]);
+
+  // When category changes, ensure the selected pageType is still valid for that
+  // category. If not, clear it so the operator picks again.
+  useEffect(() => {
+    if (!category || !pageType) return;
+    const allowed = pageTypesForCategory(category);
+    if (!allowed.includes(pageType as EmptyPageType)) {
+      setPageType('');
+    }
+  }, [category, pageType]);
+
+  const isDirty = useMemo(() => {
+    if (!existing) {
+      return (
+        category !== null ||
+        pageType !== '' ||
+        expectedContent !== '' ||
+        notes !== ''
+      );
+    }
+    return (
+      category !== existing.category ||
+      pageType !== existing.pageType ||
+      expectedContent !== (existing.expectedContent ?? '') ||
+      notes !== (existing.notes ?? '')
+    );
+  }, [existing, category, pageType, expectedContent, notes]);
+
+  const requiresExpectedContent = category === 'DETECTION_FAILURE';
+  const isValid =
+    category !== null &&
+    pageType !== '' &&
+    (!requiresExpectedContent || expectedContent.trim().length > 0);
+
+  const isSaving = saveMutation.isPending;
+  const isDeleting = deleteMutation.isPending;
+
+  const handleSave = useCallback(async () => {
+    if (!category || !pageType || !isValid) return;
+    setFeedback(null);
+    const wasUpdate = !!existing;
+    try {
+      await saveMutation.mutateAsync({
+        pageNumber,
+        payload: {
+          category,
+          pageType,
+          expectedContent: expectedContent.trim() || undefined,
+          notes: notes.trim() || undefined,
+        },
+      });
+      setFeedback({ kind: 'success', text: 'Review saved.' });
+      trackEvent('empty-page-review.save', {
+        runId,
+        pageNumber,
+        category,
+        pageType,
+        wasUpdate,
+        expectedContentLength: expectedContent.trim().length,
+        notesLength: notes.trim().length,
+      });
+    } catch (err) {
+      setFeedback({
+        kind: 'error',
+        text: err instanceof Error ? err.message : 'Failed to save review.',
+      });
+      trackEvent('empty-page-review.save-error', {
+        runId,
+        pageNumber,
+        message: err instanceof Error ? err.message : 'unknown',
+      });
+    }
+  }, [
+    category,
+    pageType,
+    isValid,
+    existing,
+    saveMutation,
+    pageNumber,
+    expectedContent,
+    notes,
+    runId,
+  ]);
+
+  const handleDelete = async () => {
+    if (!existing) return;
+    setFeedback(null);
+    try {
+      await deleteMutation.mutateAsync(pageNumber);
+      setFeedback({ kind: 'success', text: 'Review cleared.' });
+      setPendingDelete(false);
+      trackEvent('empty-page-review.delete', { runId, pageNumber });
+    } catch (err) {
+      setFeedback({
+        kind: 'error',
+        text: err instanceof Error ? err.message : 'Failed to clear review.',
+      });
+      trackEvent('empty-page-review.delete-error', {
+        runId,
+        pageNumber,
+        message: err instanceof Error ? err.message : 'unknown',
+      });
+    }
+  };
+
+  // Cmd/Ctrl+S to save when this component is mounted on a focused page.
+  // Always preventDefault to suppress the browser's "save page" dialog —
+  // even when our own save would no-op (no category yet, etc).
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 's') {
+        e.preventDefault();
+        if (isValid && isDirty && !isSaving) handleSave();
+      }
+    };
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [isValid, isDirty, isSaving, handleSave]);
+
+  // Browser-level guard: warn before tab close / refresh / external nav while
+  // the form has unsaved changes. (In-app navigation between empty pages still
+  // discards changes silently — the visible "Unsaved changes" indicator is the
+  // mitigation there.)
+  useEffect(() => {
+    if (!isDirty) return;
+    const onBeforeUnload = (e: BeforeUnloadEvent) => {
+      e.preventDefault();
+      // Modern browsers ignore the returnValue text but require it to be set.
+      e.returnValue = '';
+    };
+    window.addEventListener('beforeunload', onBeforeUnload);
+    return () => window.removeEventListener('beforeunload', onBeforeUnload);
+  }, [isDirty]);
+
+  const allowedPageTypes = pageTypesForCategory(category);
+
+  return (
+    <div className="w-72 border-l border-gray-200 bg-white flex flex-col">
+      <div className="px-3 py-2 bg-amber-50 border-b border-amber-200">
+        <div className="text-xs font-semibold text-amber-900 uppercase tracking-wide">
+          Empty page {pageNumber}
+        </div>
+        {filename && (
+          <div
+            className="text-[11px] text-amber-700 truncate"
+            title={filename}
+          >
+            {filename}
+          </div>
+        )}
+      </div>
+
+      {isLoading ? (
+        <div className="flex-1 flex items-center justify-center text-xs text-gray-400">
+          <Loader2 className="h-4 w-4 animate-spin mr-1" />
+          Loading…
+        </div>
+      ) : (
+        <div className="flex-1 overflow-auto px-3 py-3 space-y-4 text-xs">
+          {/* Category */}
+          <fieldset className="space-y-1">
+            <legend className="font-semibold text-gray-700 mb-1">
+              Category
+            </legend>
+            {EMPTY_PAGE_CATEGORIES.map((c) => (
+              <label
+                key={c}
+                className={`flex items-start gap-2 px-2 py-1.5 rounded border cursor-pointer transition-colors ${
+                  category === c
+                    ? 'bg-blue-50 border-blue-300'
+                    : 'bg-white border-gray-200 hover:bg-gray-50'
+                }`}
+              >
+                <input
+                  type="radio"
+                  name="category"
+                  value={c}
+                  checked={category === c}
+                  onChange={() => setCategory(c)}
+                  className="mt-0.5"
+                />
+                <span className="flex-1">
+                  <span className="block font-medium text-gray-800">
+                    {CATEGORY_LABEL[c]}
+                  </span>
+                  <span className="block text-gray-500 leading-tight">
+                    {CATEGORY_DESCRIPTION[c]}
+                  </span>
+                </span>
+              </label>
+            ))}
+          </fieldset>
+
+          {/* Page type */}
+          <div className="space-y-1">
+            <label
+              htmlFor="empty-page-type"
+              className="block font-semibold text-gray-700"
+            >
+              Page type
+            </label>
+            <select
+              id="empty-page-type"
+              value={pageType}
+              onChange={(e) => setPageType(e.target.value)}
+              disabled={!category}
+              className="w-full border border-gray-300 rounded px-2 py-1 text-xs focus:outline-none focus:ring-1 focus:ring-blue-400 disabled:bg-gray-100 disabled:text-gray-400"
+            >
+              <option value="">
+                {category ? 'Select a page type…' : 'Pick a category first'}
+              </option>
+              {allowedPageTypes.map((pt) => (
+                <option key={pt} value={pt}>
+                  {formatPageTypeLabel(pt)}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {/* Expected content */}
+          {(category === 'DETECTION_FAILURE' || category === 'UNSURE') && (
+            <div className="space-y-1">
+              <label
+                htmlFor="empty-page-expected-content"
+                className="block font-semibold text-gray-700"
+              >
+                Expected content{' '}
+                {requiresExpectedContent && (
+                  <span className="text-red-600">*</span>
+                )}
+              </label>
+              <textarea
+                id="empty-page-expected-content"
+                value={expectedContent}
+                onChange={(e) => setExpectedContent(e.target.value)}
+                rows={3}
+                placeholder='e.g. "Two-column body text with footnotes"'
+                className="w-full border border-gray-300 rounded px-2 py-1 text-xs focus:outline-none focus:ring-1 focus:ring-blue-400 resize-y"
+              />
+            </div>
+          )}
+
+          {/* Notes */}
+          <div className="space-y-1">
+            <label
+              htmlFor="empty-page-notes"
+              className="block font-semibold text-gray-700"
+            >
+              Notes <span className="text-gray-400 font-normal">(optional)</span>
+            </label>
+            <textarea
+              id="empty-page-notes"
+              value={notes}
+              onChange={(e) => setNotes(e.target.value)}
+              rows={3}
+              maxLength={2000}
+              className="w-full border border-gray-300 rounded px-2 py-1 text-xs focus:outline-none focus:ring-1 focus:ring-blue-400 resize-y"
+            />
+          </div>
+
+          {feedback && (
+            <div
+              className={`text-xs px-2 py-1.5 rounded ${
+                feedback.kind === 'success'
+                  ? 'bg-green-50 text-green-800 border border-green-200'
+                  : 'bg-red-50 text-red-800 border border-red-200'
+              }`}
+            >
+              {feedback.text}
+            </div>
+          )}
+        </div>
+      )}
+
+      {!isLoading && (
+        <div className="border-t border-gray-200 px-3 py-2 space-y-2 bg-gray-50">
+          {existing && (
+            <div className="text-[11px] text-gray-500">
+              Last reviewed by{' '}
+              <span className="text-gray-700">
+                {existing.annotator.firstName} {existing.annotator.lastName}
+              </span>{' '}
+              on{' '}
+              <span className="text-gray-700">
+                {new Date(existing.reviewedAt).toLocaleDateString()}
+              </span>
+              {isDirty && (
+                <span className="ml-1 text-amber-700 font-medium">
+                  · unsaved changes
+                </span>
+              )}
+            </div>
+          )}
+          {!existing && isDirty && (
+            <div className="text-[11px] text-amber-700 font-medium">
+              Unsaved changes
+            </div>
+          )}
+          {pendingDelete ? (
+            <div className="flex gap-2">
+              <button
+                type="button"
+                onClick={handleDelete}
+                disabled={isDeleting}
+                className="flex-1 inline-flex items-center justify-center gap-1 px-3 py-1.5 text-xs font-medium rounded bg-red-600 text-white hover:bg-red-700 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+              >
+                {isDeleting ? (
+                  <Loader2 className="h-3 w-3 animate-spin" />
+                ) : (
+                  <Trash2 className="h-3 w-3" />
+                )}
+                Confirm clear
+              </button>
+              <button
+                type="button"
+                onClick={() => setPendingDelete(false)}
+                disabled={isDeleting}
+                className="px-3 py-1.5 text-xs font-medium rounded border border-gray-300 text-gray-700 hover:bg-gray-50 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+              >
+                Cancel
+              </button>
+            </div>
+          ) : (
+            <div className="flex gap-2">
+              <button
+                type="button"
+                onClick={handleSave}
+                disabled={!isValid || isSaving || (!isDirty && !!existing)}
+                title="Save (Ctrl/Cmd+S)"
+                className="flex-1 inline-flex items-center justify-center gap-1 px-3 py-1.5 text-xs font-medium rounded bg-[#006B6B] text-white hover:bg-[#005858] disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+              >
+                {isSaving ? (
+                  <Loader2 className="h-3 w-3 animate-spin" />
+                ) : (
+                  <Save className="h-3 w-3" />
+                )}
+                {existing ? 'Update' : 'Save'}
+              </button>
+              {existing && (
+                <button
+                  type="button"
+                  onClick={() => setPendingDelete(true)}
+                  title="Clear this review"
+                  className="inline-flex items-center justify-center px-2 py-1.5 text-xs rounded border border-red-300 text-red-700 hover:bg-red-50 transition-colors"
+                >
+                  <Trash2 className="h-3 w-3" />
+                </button>
+              )}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/bootstrap/EmptyPageReviewSidebar.tsx
+++ b/src/components/bootstrap/EmptyPageReviewSidebar.tsx
@@ -13,7 +13,7 @@ import {
   useEmptyPageReview,
   useSaveEmptyPageReview,
 } from '@/hooks/useEmptyPageReviews';
-import { trackEvent } from '@/lib/telemetry';
+import { classifyErrorForTelemetry, trackEvent } from '@/lib/telemetry';
 
 interface EmptyPageReviewSidebarProps {
   runId: string;
@@ -53,7 +53,12 @@ export function EmptyPageReviewSidebar({
   pageNumber,
   filename,
 }: EmptyPageReviewSidebarProps) {
-  const { data: existing, isLoading } = useEmptyPageReview(runId, pageNumber);
+  const {
+    data: existing,
+    isLoading,
+    isError: loadFailed,
+    refetch: refetchReview,
+  } = useEmptyPageReview(runId, pageNumber);
   const saveMutation = useSaveEmptyPageReview(runId);
   const deleteMutation = useDeleteEmptyPageReview(runId);
 
@@ -124,13 +129,19 @@ export function EmptyPageReviewSidebar({
     if (!category || !pageType || !isValid) return;
     setFeedback(null);
     const wasUpdate = !!existing;
+    // Drop expectedContent when category is LEGIT_EMPTY — it's hidden in the UI,
+    // so any value left in state from a prior DETECTION_FAILURE session would be
+    // stale and meaningless on a legit-empty record.
+    const trimmedExpected = expectedContent.trim();
+    const expectedContentForSave =
+      category === 'LEGIT_EMPTY' || !trimmedExpected ? undefined : trimmedExpected;
     try {
       await saveMutation.mutateAsync({
         pageNumber,
         payload: {
           category,
           pageType,
-          expectedContent: expectedContent.trim() || undefined,
+          expectedContent: expectedContentForSave,
           notes: notes.trim() || undefined,
         },
       });
@@ -141,7 +152,7 @@ export function EmptyPageReviewSidebar({
         category,
         pageType,
         wasUpdate,
-        expectedContentLength: expectedContent.trim().length,
+        expectedContentLength: expectedContentForSave?.length ?? 0,
         notesLength: notes.trim().length,
       });
     } catch (err) {
@@ -152,7 +163,7 @@ export function EmptyPageReviewSidebar({
       trackEvent('empty-page-review.save-error', {
         runId,
         pageNumber,
-        message: err instanceof Error ? err.message : 'unknown',
+        ...classifyErrorForTelemetry(err),
       });
     }
   }, [
@@ -183,7 +194,7 @@ export function EmptyPageReviewSidebar({
       trackEvent('empty-page-review.delete-error', {
         runId,
         pageNumber,
-        message: err instanceof Error ? err.message : 'unknown',
+        ...classifyErrorForTelemetry(err),
       });
     }
   };
@@ -235,7 +246,24 @@ export function EmptyPageReviewSidebar({
         )}
       </div>
 
-      {isLoading ? (
+      {loadFailed ? (
+        <div className="flex-1 flex flex-col items-center justify-center px-4 text-center gap-2">
+          <div className="text-xs text-red-700 font-medium">
+            Couldn't load this page's review.
+          </div>
+          <div className="text-[11px] text-gray-500 leading-tight">
+            Editing is disabled to avoid overwriting an existing review by
+            mistake. Retry to load it.
+          </div>
+          <button
+            type="button"
+            onClick={() => refetchReview()}
+            className="mt-1 px-3 py-1.5 text-xs font-medium rounded bg-[#006B6B] text-white hover:bg-[#005858] transition-colors"
+          >
+            Retry
+          </button>
+        </div>
+      ) : isLoading ? (
         <div className="flex-1 flex items-center justify-center text-xs text-gray-400">
           <Loader2 className="h-4 w-4 animate-spin mr-1" />
           Loading…
@@ -357,7 +385,7 @@ export function EmptyPageReviewSidebar({
         </div>
       )}
 
-      {!isLoading && (
+      {!isLoading && !loadFailed && (
         <div className="border-t border-gray-200 px-3 py-2 space-y-2 bg-gray-50">
           {existing && (
             <div className="text-[11px] text-gray-500">

--- a/src/components/bootstrap/EmptyPagesChip.tsx
+++ b/src/components/bootstrap/EmptyPagesChip.tsx
@@ -1,13 +1,15 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 import { AlertTriangle, Check, CheckCircle2, Loader2, Wand2, X } from 'lucide-react';
 import { formatPageRanges } from '@/lib/page-ranges';
 import { trackEvent } from '@/lib/telemetry';
 import {
+  EMPTY_PAGE_REVIEW_KEYS,
   useEmptyPageReviews,
-  useSaveEmptyPageReview,
 } from '@/hooks/useEmptyPageReviews';
 import {
   LEGIT_EMPTY_PAGE_TYPES,
+  saveEmptyPageReview,
   type EmptyPageType,
 } from '@/services/empty-page-review.service';
 
@@ -65,7 +67,7 @@ export function EmptyPagesChip({
     [reviewsData],
   );
 
-  const saveMutation = useSaveEmptyPageReview(runId);
+  const queryClient = useQueryClient();
   const [bulkOpen, setBulkOpen] = useState(false);
   const [bulkPageType, setBulkPageType] = useState<EmptyPageType>('blank');
   const [bulkProgress, setBulkProgress] = useState<{
@@ -126,21 +128,27 @@ export function EmptyPagesChip({
       pageType: bulkPageType,
     });
     let failed = 0;
-    // Sequential to avoid hammering the backend or fighting React Query's
-    // mutation queue. ~74 pages × ~150ms each ≈ 11s for the worst case in
-    // staging today; acceptable for an operator-initiated action.
+    // Sequential to avoid hammering the backend. ~74 pages × ~150ms each ≈ 11s
+    // for the worst case in staging today; acceptable for an operator-initiated
+    // action. Calls the service directly (bypassing useSaveEmptyPageReview)
+    // so we don't re-invalidate the list on every iteration — invalidation
+    // happens once at the end.
     for (let i = 0; i < unreviewedPages.length; i++) {
       const page = unreviewedPages[i];
       try {
-        await saveMutation.mutateAsync({
-          pageNumber: page,
-          payload: { category: 'LEGIT_EMPTY', pageType: bulkPageType },
+        await saveEmptyPageReview(runId, page, {
+          category: 'LEGIT_EMPTY',
+          pageType: bulkPageType,
         });
       } catch {
         failed += 1;
       }
       setBulkProgress({ current: i + 1, total, failed });
     }
+    // Refresh the list and any per-page caches in one shot post-loop.
+    queryClient.invalidateQueries({
+      queryKey: EMPTY_PAGE_REVIEW_KEYS.list(runId),
+    });
     trackEvent('empty-page-review.bulk-complete', {
       runId,
       total,

--- a/src/components/bootstrap/EmptyPagesChip.tsx
+++ b/src/components/bootstrap/EmptyPagesChip.tsx
@@ -1,8 +1,18 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { AlertTriangle, X } from 'lucide-react';
+import { AlertTriangle, Check, CheckCircle2, Loader2, Wand2, X } from 'lucide-react';
 import { formatPageRanges } from '@/lib/page-ranges';
+import { trackEvent } from '@/lib/telemetry';
+import {
+  useEmptyPageReviews,
+  useSaveEmptyPageReview,
+} from '@/hooks/useEmptyPageReviews';
+import {
+  LEGIT_EMPTY_PAGE_TYPES,
+  type EmptyPageType,
+} from '@/services/empty-page-review.service';
 
 interface EmptyPagesChipProps {
+  runId: string;
   filename?: string;
   emptyPages: number[] | undefined;
   pageCount: number;
@@ -27,6 +37,7 @@ function parseRangeChunks(formatted: string): RangeChunk[] {
 }
 
 export function EmptyPagesChip({
+  runId,
   filename,
   emptyPages,
   pageCount,
@@ -46,6 +57,22 @@ export function EmptyPagesChip({
         .sort((a, b) => a - b),
     [emptyPages],
   );
+
+  // Reviewed pages — used to show progress and skip to next unreviewed.
+  const { data: reviewsData } = useEmptyPageReviews(runId);
+  const reviewedSet = useMemo(
+    () => new Set((reviewsData?.reviews ?? []).map((r) => r.pageNumber)),
+    [reviewsData],
+  );
+
+  const saveMutation = useSaveEmptyPageReview(runId);
+  const [bulkOpen, setBulkOpen] = useState(false);
+  const [bulkPageType, setBulkPageType] = useState<EmptyPageType>('blank');
+  const [bulkProgress, setBulkProgress] = useState<{
+    current: number;
+    total: number;
+    failed: number;
+  } | null>(null);
 
   const rangeChunks = useMemo(
     () => parseRangeChunks(formatPageRanges(sorted)),
@@ -77,25 +104,99 @@ export function EmptyPagesChip({
 
   const pct =
     pageCount > 0 ? ((sorted.length / pageCount) * 100).toFixed(1) : '0';
-  const next = sorted.find((p) => p > currentPage);
+  const reviewedCount = sorted.filter((p) => reviewedSet.has(p)).length;
+  const unreviewedPages = sorted.filter((p) => !reviewedSet.has(p));
+  const unreviewedCount = unreviewedPages.length;
+  const allReviewed = unreviewedCount === 0;
+  // Skip already-reviewed pages — operator wants "next thing to do."
+  const nextUnreviewed = sorted.find(
+    (p) => p > currentPage && !reviewedSet.has(p),
+  );
+  // Fall back to first unreviewed in the document if nothing follows current page.
+  const firstUnreviewed = unreviewedPages[0];
+  const nextTarget = nextUnreviewed ?? firstUnreviewed;
+
+  const handleBulkApply = async () => {
+    const total = unreviewedPages.length;
+    if (total === 0) return;
+    setBulkProgress({ current: 0, total, failed: 0 });
+    trackEvent('empty-page-review.bulk-start', {
+      runId,
+      total,
+      pageType: bulkPageType,
+    });
+    let failed = 0;
+    // Sequential to avoid hammering the backend or fighting React Query's
+    // mutation queue. ~74 pages × ~150ms each ≈ 11s for the worst case in
+    // staging today; acceptable for an operator-initiated action.
+    for (let i = 0; i < unreviewedPages.length; i++) {
+      const page = unreviewedPages[i];
+      try {
+        await saveMutation.mutateAsync({
+          pageNumber: page,
+          payload: { category: 'LEGIT_EMPTY', pageType: bulkPageType },
+        });
+      } catch {
+        failed += 1;
+      }
+      setBulkProgress({ current: i + 1, total, failed });
+    }
+    trackEvent('empty-page-review.bulk-complete', {
+      runId,
+      total,
+      failed,
+      pageType: bulkPageType,
+    });
+    // Leave the progress visible for a moment so the operator sees the result,
+    // then collapse the bulk panel.
+    setTimeout(() => {
+      setBulkProgress(null);
+      setBulkOpen(false);
+    }, 1500);
+  };
+
+  const bulkBusy = bulkProgress !== null;
+
+  const isChunkReviewed = (chunk: RangeChunk) => {
+    for (let p = chunk.start; p <= chunk.end; p++) {
+      if (!reviewedSet.has(p)) return false;
+    }
+    return true;
+  };
 
   const handleJump = (page: number) => {
     onJumpToPage(page);
     setOpen(false);
   };
 
+  const chipClass = allReviewed
+    ? 'inline-flex items-center gap-1 px-2 py-1.5 text-xs font-medium rounded border border-green-300 bg-green-50 text-green-800 hover:bg-green-100 transition-colors'
+    : 'inline-flex items-center gap-1 px-2 py-1.5 text-xs font-medium rounded border border-amber-300 bg-amber-50 text-amber-800 hover:bg-amber-100 transition-colors';
+  const chipTitle = allReviewed
+    ? `All ${sorted.length} empty pages reviewed.`
+    : `${sorted.length} of ${pageCount} pages have no detected zones (${pct}%). ${reviewedCount} of ${sorted.length} reviewed. Click for the list.`;
+
   return (
     <div ref={containerRef} className="relative">
       <button
         type="button"
         onClick={() => setOpen((v) => !v)}
-        className="inline-flex items-center gap-1 px-2 py-1.5 text-xs font-medium rounded border border-amber-300 bg-amber-50 text-amber-800 hover:bg-amber-100 transition-colors"
-        title={`${sorted.length} of ${pageCount} pages have no detected zones (${pct}%). Click for the list.`}
-        aria-label={`${sorted.length} empty pages — click for list`}
+        className={chipClass}
+        title={chipTitle}
+        aria-label={chipTitle}
         aria-expanded={open}
       >
-        <AlertTriangle className="h-3 w-3" />
+        {allReviewed ? (
+          <CheckCircle2 className="h-3 w-3" />
+        ) : (
+          <AlertTriangle className="h-3 w-3" />
+        )}
         {sorted.length} empty
+        {!allReviewed && reviewedCount > 0 && (
+          <span className="text-[10px] opacity-75 ml-0.5">
+            · {reviewedCount}/{sorted.length}
+          </span>
+        )}
       </button>
 
       {open && (
@@ -120,6 +221,20 @@ export function EmptyPagesChip({
               <div className="text-xs text-gray-500">
                 {sorted.length} of {pageCount} have no detected zones ({pct}%)
               </div>
+              <div className="text-xs text-gray-500">
+                {allReviewed ? (
+                  <span className="text-green-700 font-medium">
+                    All {sorted.length} reviewed
+                  </span>
+                ) : (
+                  <>
+                    <span className="text-gray-700 font-medium">
+                      {reviewedCount}
+                    </span>{' '}
+                    of {sorted.length} reviewed
+                  </>
+                )}
+              </div>
             </div>
             <button
               type="button"
@@ -135,18 +250,28 @@ export function EmptyPagesChip({
             {rangeChunks.map((chunk, i) => {
               const isCurrent =
                 currentPage >= chunk.start && currentPage <= chunk.end;
+              const reviewed = isChunkReviewed(chunk);
+              const baseClass = reviewed
+                ? 'text-green-700 hover:bg-green-50'
+                : 'text-amber-700 hover:bg-amber-50';
+              const currentClass = reviewed
+                ? 'font-bold text-green-900 bg-green-100'
+                : 'font-bold text-amber-900 bg-amber-100';
               return (
                 <span key={`${chunk.start}-${chunk.end}`}>
                   <button
                     type="button"
                     onClick={() => handleJump(chunk.start)}
-                    className={`px-1 py-0.5 rounded font-mono hover:underline ${
-                      isCurrent
-                        ? 'font-bold text-amber-900 bg-amber-100'
-                        : 'text-amber-700 hover:bg-amber-50'
+                    className={`px-1 py-0.5 rounded font-mono hover:underline inline-flex items-center gap-0.5 ${
+                      isCurrent ? currentClass : baseClass
                     }`}
-                    title={`Jump to page ${chunk.start}`}
+                    title={
+                      reviewed
+                        ? `Page ${chunk.start} reviewed — click to revisit`
+                        : `Jump to page ${chunk.start}`
+                    }
                   >
+                    {reviewed && <Check className="h-2.5 w-2.5" />}
                     {chunk.display}
                   </button>
                   {i < rangeChunks.length - 1 ? ', ' : ''}
@@ -157,12 +282,99 @@ export function EmptyPagesChip({
 
           <button
             type="button"
-            onClick={() => next && handleJump(next)}
-            disabled={!next}
+            onClick={() => nextTarget && handleJump(nextTarget)}
+            disabled={!nextTarget || bulkBusy}
             className="w-full text-xs px-2 py-1.5 rounded bg-amber-600 text-white hover:bg-amber-700 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
           >
-            {next ? `Next empty page → ${next}` : 'No more empty pages after this'}
+            {!nextTarget
+              ? 'All empty pages reviewed'
+              : nextUnreviewed
+              ? `Next unreviewed empty page → ${nextUnreviewed}`
+              : `Wrap to first unreviewed → ${firstUnreviewed}`}
           </button>
+
+          {/* Bulk-mark — only when there's enough work to justify the affordance */}
+          {!allReviewed && unreviewedCount > 1 && (
+            <div className="mt-2 pt-2 border-t border-gray-100">
+              {!bulkOpen && !bulkBusy && (
+                <button
+                  type="button"
+                  onClick={() => setBulkOpen(true)}
+                  className="w-full inline-flex items-center justify-center gap-1 text-xs px-2 py-1 rounded text-gray-600 hover:bg-gray-50 hover:text-gray-800 transition-colors"
+                >
+                  <Wand2 className="h-3 w-3" />
+                  Bulk mark {unreviewedCount} unreviewed as legit empty…
+                </button>
+              )}
+
+              {bulkOpen && !bulkBusy && (
+                <div className="space-y-2">
+                  <label className="block text-[11px] font-medium text-gray-700">
+                    Page type for all {unreviewedCount} unreviewed pages
+                  </label>
+                  <select
+                    value={bulkPageType}
+                    onChange={(e) =>
+                      setBulkPageType(e.target.value as EmptyPageType)
+                    }
+                    className="w-full border border-gray-300 rounded px-2 py-1 text-xs focus:outline-none focus:ring-1 focus:ring-blue-400"
+                  >
+                    {LEGIT_EMPTY_PAGE_TYPES.map((pt) => (
+                      <option key={pt} value={pt}>
+                        {pt.replace(/_/g, ' ')}
+                      </option>
+                    ))}
+                  </select>
+                  <div className="flex gap-1">
+                    <button
+                      type="button"
+                      onClick={handleBulkApply}
+                      className="flex-1 text-xs px-2 py-1.5 rounded bg-[#006B6B] text-white hover:bg-[#005858] transition-colors"
+                    >
+                      Apply to {unreviewedCount} pages
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => setBulkOpen(false)}
+                      className="text-xs px-2 py-1.5 rounded border border-gray-300 text-gray-700 hover:bg-gray-50 transition-colors"
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                  <p className="text-[10px] text-gray-500 leading-tight">
+                    Skips pages already reviewed. Each row is recorded under your
+                    user. Use the sidebar form to override individual pages
+                    afterwards.
+                  </p>
+                </div>
+              )}
+
+              {bulkBusy && bulkProgress && (
+                <div className="space-y-1.5">
+                  <div className="flex items-center gap-1.5 text-xs text-gray-700">
+                    <Loader2 className="h-3 w-3 animate-spin" />
+                    {bulkProgress.current < bulkProgress.total
+                      ? `Marking ${bulkProgress.current} of ${bulkProgress.total}…`
+                      : `Done — ${bulkProgress.total - bulkProgress.failed} of ${bulkProgress.total} marked${
+                          bulkProgress.failed > 0 ? `, ${bulkProgress.failed} failed` : ''
+                        }`}
+                  </div>
+                  <div className="h-1 w-full bg-gray-200 rounded overflow-hidden">
+                    <div
+                      className={`h-full transition-all ${
+                        bulkProgress.failed > 0 ? 'bg-amber-500' : 'bg-[#006B6B]'
+                      }`}
+                      style={{
+                        width: `${
+                          (bulkProgress.current / bulkProgress.total) * 100
+                        }%`,
+                      }}
+                    />
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/src/components/bootstrap/ZoneReviewWorkspace.tsx
+++ b/src/components/bootstrap/ZoneReviewWorkspace.tsx
@@ -32,6 +32,7 @@ import ZoneComparisonDetailBar from './ZoneComparisonDetailBar';
 import ZoneOverlay from './ZoneOverlay';
 import ZoneListSidebar from './ZoneListSidebar';
 import { EmptyPagesChip } from './EmptyPagesChip';
+import { EmptyPageReviewSidebar } from './EmptyPageReviewSidebar';
 import { MarkCompleteModal, type MarkCompleteRequest } from './MarkCompleteModal';
 import { useZoneNumberMap } from '@/hooks/useZoneNumberMap';
 import { TableStructureEditor } from '../quickfix/TableStructureEditor';
@@ -632,6 +633,7 @@ export default function ZoneReviewWorkspace({
           </button>
 
           <EmptyPagesChip
+            runId={runId}
             filename={docFilename}
             emptyPages={emptyPages}
             pageCount={numPages}
@@ -895,18 +897,25 @@ export default function ZoneReviewWorkspace({
           </div>
         </div>
 
-          {/* Zone list sidebar */}
-          {showZoneList && (
-            <ZoneListSidebar
-              zones={zones}
-              currentPage={currentPage}
-              selectedZoneId={selectedZoneId}
-              onZoneClick={setSelectedZoneId}
-              zoneNumberMap={zoneNumberMap}
-              hideAiBadges={isOperator}
-              isStreaming={!zonesComplete || zonesFetchingMore}
-            />
-          )}
+          {/* Right-hand sidebar: zone list for normal pages, empty-page review form for empty pages. */}
+          {showZoneList &&
+            (emptyPages?.includes(currentPage) ? (
+              <EmptyPageReviewSidebar
+                runId={runId}
+                pageNumber={currentPage}
+                filename={docFilename}
+              />
+            ) : (
+              <ZoneListSidebar
+                zones={zones}
+                currentPage={currentPage}
+                selectedZoneId={selectedZoneId}
+                onZoneClick={setSelectedZoneId}
+                zoneNumberMap={zoneNumberMap}
+                hideAiBadges={isOperator}
+                isStreaming={!zonesComplete || zonesFetchingMore}
+              />
+            ))}
       </div>
 
       {/* Bottom detail bar — visible only when zone selected */}

--- a/src/components/bootstrap/__tests__/EmptyPageReviewSidebar.test.tsx
+++ b/src/components/bootstrap/__tests__/EmptyPageReviewSidebar.test.tsx
@@ -1,0 +1,257 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { EmptyPageReviewSidebar } from '../EmptyPageReviewSidebar';
+import type {
+  EmptyPageCategory,
+  EmptyPageReview,
+} from '@/services/empty-page-review.service';
+
+vi.mock('@/hooks/useEmptyPageReviews', () => ({
+  useEmptyPageReview: vi.fn(),
+  useSaveEmptyPageReview: vi.fn(),
+  useDeleteEmptyPageReview: vi.fn(),
+}));
+
+vi.mock('@/lib/telemetry', () => ({
+  trackEvent: vi.fn(),
+}));
+
+const {
+  useEmptyPageReview,
+  useSaveEmptyPageReview,
+  useDeleteEmptyPageReview,
+} = await import('@/hooks/useEmptyPageReviews');
+
+const mockUseExisting = vi.mocked(useEmptyPageReview);
+const mockUseSave = vi.mocked(useSaveEmptyPageReview);
+const mockUseDelete = vi.mocked(useDeleteEmptyPageReview);
+
+function makeReview(
+  overrides: Partial<EmptyPageReview> = {},
+): EmptyPageReview {
+  return {
+    pageNumber: 96,
+    category: 'LEGIT_EMPTY' as EmptyPageCategory,
+    pageType: 'blank',
+    expectedContent: null,
+    notes: null,
+    annotator: {
+      id: 'user-1',
+      firstName: 'Poornakala',
+      lastName: 'B',
+      email: 'p@example.com',
+    },
+    reviewedAt: '2026-04-28T10:00:00Z',
+    updatedAt: '2026-04-28T10:00:00Z',
+    ...overrides,
+  };
+}
+
+function renderSidebar(props: Partial<{ pageNumber: number; filename: string }> = {}) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <EmptyPageReviewSidebar
+        runId="run-1"
+        pageNumber={props.pageNumber ?? 96}
+        filename={props.filename}
+      />
+    </QueryClientProvider>,
+  );
+}
+
+describe('EmptyPageReviewSidebar', () => {
+  let saveMutate: ReturnType<typeof vi.fn>;
+  let deleteMutate: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    saveMutate = vi.fn().mockResolvedValue(makeReview());
+    deleteMutate = vi.fn().mockResolvedValue({ deleted: true });
+
+    mockUseSave.mockReturnValue({
+      mutateAsync: saveMutate,
+      isPending: false,
+    } as unknown as ReturnType<typeof useSaveEmptyPageReview>);
+
+    mockUseDelete.mockReturnValue({
+      mutateAsync: deleteMutate,
+      isPending: false,
+    } as unknown as ReturnType<typeof useDeleteEmptyPageReview>);
+
+    mockUseExisting.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+    } as unknown as ReturnType<typeof useEmptyPageReview>);
+  });
+
+  it('renders form fields when no existing review', () => {
+    renderSidebar();
+    expect(screen.getByText(/empty page 96/i)).toBeInTheDocument();
+    expect(screen.getByText('Legit empty')).toBeInTheDocument();
+    expect(screen.getByText('Detection failure')).toBeInTheDocument();
+    expect(screen.getByText('Unsure')).toBeInTheDocument();
+    expect(screen.getByLabelText(/page type/i)).toBeInTheDocument();
+  });
+
+  it('disables save until a category and page type are picked', () => {
+    renderSidebar();
+    const saveButton = screen.getByRole('button', { name: /save/i });
+    expect(saveButton).toBeDisabled();
+
+    fireEvent.click(screen.getByLabelText(/legit empty/i));
+    expect(saveButton).toBeDisabled(); // no page type yet
+
+    fireEvent.change(screen.getByLabelText(/page type/i), {
+      target: { value: 'blank' },
+    });
+    expect(saveButton).not.toBeDisabled();
+  });
+
+  it('requires expectedContent when category is detection failure', () => {
+    renderSidebar();
+    fireEvent.click(screen.getByLabelText(/detection failure/i));
+    fireEvent.change(screen.getByLabelText(/page type/i), {
+      target: { value: 'text_normal' },
+    });
+
+    const saveButton = screen.getByRole('button', { name: /save/i });
+    expect(saveButton).toBeDisabled(); // expectedContent empty
+
+    fireEvent.change(screen.getByLabelText(/expected content/i), {
+      target: { value: 'Two-column body text' },
+    });
+    expect(saveButton).not.toBeDisabled();
+  });
+
+  it('clears the page-type when switching to a category whose vocabulary differs', () => {
+    renderSidebar();
+    fireEvent.click(screen.getByLabelText(/legit empty/i));
+    fireEvent.change(screen.getByLabelText(/page type/i), {
+      target: { value: 'blank' },
+    });
+    expect((screen.getByLabelText(/page type/i) as HTMLSelectElement).value).toBe(
+      'blank',
+    );
+
+    fireEvent.click(screen.getByLabelText(/detection failure/i));
+    expect((screen.getByLabelText(/page type/i) as HTMLSelectElement).value).toBe(
+      '',
+    );
+  });
+
+  it('prefills form from an existing review', () => {
+    mockUseExisting.mockReturnValue({
+      data: makeReview({
+        category: 'DETECTION_FAILURE',
+        pageType: 'text_normal',
+        expectedContent: 'Two-column body',
+        notes: 'flagged earlier',
+      }),
+      isLoading: false,
+    } as unknown as ReturnType<typeof useEmptyPageReview>);
+
+    renderSidebar();
+    expect(
+      (screen.getByLabelText(/detection failure/i) as HTMLInputElement).checked,
+    ).toBe(true);
+    expect(
+      (screen.getByLabelText(/page type/i) as HTMLSelectElement).value,
+    ).toBe('text_normal');
+    expect(
+      (screen.getByLabelText(/expected content/i) as HTMLTextAreaElement).value,
+    ).toBe('Two-column body');
+    expect(
+      (screen.getByLabelText(/notes/i) as HTMLTextAreaElement).value,
+    ).toBe('flagged earlier');
+    expect(screen.getByRole('button', { name: /update/i })).toBeInTheDocument();
+    expect(screen.getByText(/Poornakala B/)).toBeInTheDocument();
+  });
+
+  it('calls saveMutateAsync with the trimmed payload', async () => {
+    renderSidebar();
+    fireEvent.click(screen.getByLabelText(/legit empty/i));
+    fireEvent.change(screen.getByLabelText(/page type/i), {
+      target: { value: 'image_plate' },
+    });
+    fireEvent.change(screen.getByLabelText(/notes/i), {
+      target: { value: '  full-page photo plate  ' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /save/i }));
+
+    await waitFor(() => {
+      expect(saveMutate).toHaveBeenCalledWith({
+        pageNumber: 96,
+        payload: {
+          category: 'LEGIT_EMPTY',
+          pageType: 'image_plate',
+          expectedContent: undefined,
+          notes: 'full-page photo plate',
+        },
+      });
+    });
+    await waitFor(() => {
+      expect(screen.getByText(/review saved/i)).toBeInTheDocument();
+    });
+  });
+
+  it('shows two-step inline confirm before deleting', async () => {
+    mockUseExisting.mockReturnValue({
+      data: makeReview(),
+      isLoading: false,
+    } as unknown as ReturnType<typeof useEmptyPageReview>);
+
+    renderSidebar();
+    // First click reveals the confirm row.
+    fireEvent.click(screen.getByTitle(/clear this review/i));
+    expect(deleteMutate).not.toHaveBeenCalled();
+    expect(
+      screen.getByRole('button', { name: /confirm clear/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /^cancel$/i }),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /confirm clear/i }));
+    await waitFor(() => {
+      expect(deleteMutate).toHaveBeenCalledWith(96);
+    });
+  });
+
+  it('cancel returns from the confirm row without deleting', () => {
+    mockUseExisting.mockReturnValue({
+      data: makeReview(),
+      isLoading: false,
+    } as unknown as ReturnType<typeof useEmptyPageReview>);
+
+    renderSidebar();
+    fireEvent.click(screen.getByTitle(/clear this review/i));
+    fireEvent.click(screen.getByRole('button', { name: /^cancel$/i }));
+    expect(deleteMutate).not.toHaveBeenCalled();
+    expect(
+      screen.getByRole('button', { name: /update/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('Ctrl+S triggers save when the form is valid and dirty', async () => {
+    renderSidebar();
+    fireEvent.click(screen.getByLabelText(/legit empty/i));
+    fireEvent.change(screen.getByLabelText(/page type/i), {
+      target: { value: 'blank' },
+    });
+
+    fireEvent.keyDown(document, { key: 's', ctrlKey: true });
+    await waitFor(() => {
+      expect(saveMutate).toHaveBeenCalled();
+    });
+  });
+
+  it('Ctrl+S is a no-op when save is disabled', () => {
+    renderSidebar();
+    fireEvent.keyDown(document, { key: 's', ctrlKey: true });
+    expect(saveMutate).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useEmptyPageReviews.ts
+++ b/src/hooks/useEmptyPageReviews.ts
@@ -1,0 +1,62 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  deleteEmptyPageReview,
+  getEmptyPageReview,
+  listEmptyPageReviews,
+  saveEmptyPageReview,
+  type SaveEmptyPageReviewPayload,
+} from '../services/empty-page-review.service';
+
+export const EMPTY_PAGE_REVIEW_KEYS = {
+  list: (runId: string) => ['calibration', 'empty-page-reviews', runId] as const,
+  one: (runId: string, pageNumber: number) =>
+    ['calibration', 'empty-page-reviews', runId, pageNumber] as const,
+};
+
+export function useEmptyPageReviews(runId: string) {
+  return useQuery({
+    queryKey: EMPTY_PAGE_REVIEW_KEYS.list(runId),
+    queryFn: () => listEmptyPageReviews(runId),
+    enabled: !!runId,
+  });
+}
+
+export function useEmptyPageReview(runId: string, pageNumber: number) {
+  return useQuery({
+    queryKey: EMPTY_PAGE_REVIEW_KEYS.one(runId, pageNumber),
+    queryFn: () => getEmptyPageReview(runId, pageNumber),
+    enabled: !!runId && Number.isInteger(pageNumber) && pageNumber > 0,
+  });
+}
+
+export function useSaveEmptyPageReview(runId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      pageNumber,
+      payload,
+    }: {
+      pageNumber: number;
+      payload: SaveEmptyPageReviewPayload;
+    }) => saveEmptyPageReview(runId, pageNumber, payload),
+    onSuccess: (_data, { pageNumber }) => {
+      qc.invalidateQueries({ queryKey: EMPTY_PAGE_REVIEW_KEYS.list(runId) });
+      qc.invalidateQueries({
+        queryKey: EMPTY_PAGE_REVIEW_KEYS.one(runId, pageNumber),
+      });
+    },
+  });
+}
+
+export function useDeleteEmptyPageReview(runId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (pageNumber: number) => deleteEmptyPageReview(runId, pageNumber),
+    onSuccess: (_data, pageNumber) => {
+      qc.invalidateQueries({ queryKey: EMPTY_PAGE_REVIEW_KEYS.list(runId) });
+      qc.invalidateQueries({
+        queryKey: EMPTY_PAGE_REVIEW_KEYS.one(runId, pageNumber),
+      });
+    },
+  });
+}

--- a/src/lib/telemetry.ts
+++ b/src/lib/telemetry.ts
@@ -24,3 +24,29 @@ export function trackEvent(event: string, props: TelemetryProps = {}): void {
   // Tag for grep + future routing.
   console.info('[telemetry]', event, props);
 }
+
+/**
+ * Classify an unknown error into PII-safe primitives suitable for telemetry.
+ * Returns the HTTP status (when available) and the error kind, never the raw
+ * message body — backend error messages can contain document or user details.
+ */
+export function classifyErrorForTelemetry(err: unknown): {
+  errorStatus: number | string;
+  errorKind: string;
+} {
+  if (typeof err === 'object' && err !== null) {
+    if ('response' in err) {
+      const status = (err as { response?: { status?: number } }).response
+        ?.status;
+      return {
+        errorStatus: status ?? 'no-response',
+        errorKind: 'http',
+      };
+    }
+    return {
+      errorStatus: 'no-response',
+      errorKind: err instanceof Error ? err.name : 'unknown',
+    };
+  }
+  return { errorStatus: 'no-response', errorKind: 'unknown' };
+}

--- a/src/lib/telemetry.ts
+++ b/src/lib/telemetry.ts
@@ -1,0 +1,26 @@
+/**
+ * Lightweight telemetry stub.
+ *
+ * Today this is a structured `console.info` with a stable schema. When a real
+ * telemetry destination (Sentry, Datadog, Amplitude, etc.) is wired in, swap
+ * the implementation here — the call sites use the same `trackEvent(name, props)`
+ * shape regardless.
+ *
+ * Conventions:
+ * - `event` is a short kebab-cased namespaced string: `area.action` or
+ *   `area.subarea.action`. Keep them grep-able.
+ * - `props` is a flat object of primitives. Avoid nested objects so future
+ *   transports don't have to flatten.
+ * - Avoid PII. Use IDs, not free-text where possible. Free-text fields like
+ *   `notes` should be measured by length, not transmitted verbatim.
+ */
+export type TelemetryProps = Record<
+  string,
+  string | number | boolean | null | undefined
+>;
+
+export function trackEvent(event: string, props: TelemetryProps = {}): void {
+  if (typeof window === 'undefined') return;
+  // Tag for grep + future routing.
+  console.info('[telemetry]', event, props);
+}

--- a/src/services/__tests__/empty-page-review.service.test.ts
+++ b/src/services/__tests__/empty-page-review.service.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import {
+  deleteEmptyPageReview,
+  getEmptyPageReview,
+  listEmptyPageReviews,
+  saveEmptyPageReview,
+} from '../empty-page-review.service';
+import { api } from '../api';
+
+vi.mock('../api', () => ({
+  api: {
+    get: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+describe('empty-page-review.service', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('listEmptyPageReviews', () => {
+    it('returns the unwrapped reviews array', async () => {
+      const reviews = [
+        { pageNumber: 5, category: 'LEGIT_EMPTY', pageType: 'blank' },
+      ];
+      (api.get as Mock).mockResolvedValueOnce({
+        data: { data: { reviews } },
+      });
+
+      const result = await listEmptyPageReviews('run-1');
+      expect(result).toEqual({ reviews });
+      expect(api.get).toHaveBeenCalledWith(
+        '/calibration/runs/run-1/empty-page-reviews',
+      );
+    });
+  });
+
+  describe('getEmptyPageReview', () => {
+    it('returns the review when one exists', async () => {
+      const review = {
+        pageNumber: 96,
+        category: 'DETECTION_FAILURE',
+      };
+      (api.get as Mock).mockResolvedValueOnce({
+        data: { data: review },
+      });
+
+      const result = await getEmptyPageReview('run-1', 96);
+      expect(result).toEqual(review);
+    });
+
+    it('returns null when the backend responds with 404', async () => {
+      (api.get as Mock).mockRejectedValueOnce({ response: { status: 404 } });
+      const result = await getEmptyPageReview('run-1', 96);
+      expect(result).toBeNull();
+    });
+
+    it('rethrows non-404 errors', async () => {
+      (api.get as Mock).mockRejectedValueOnce({ response: { status: 500 } });
+      await expect(getEmptyPageReview('run-1', 96)).rejects.toMatchObject({
+        response: { status: 500 },
+      });
+    });
+
+    it('rethrows network errors with no response', async () => {
+      const networkErr = new Error('Network down');
+      (api.get as Mock).mockRejectedValueOnce(networkErr);
+      await expect(getEmptyPageReview('run-1', 96)).rejects.toThrow(
+        'Network down',
+      );
+    });
+  });
+
+  describe('saveEmptyPageReview', () => {
+    it('PUTs the payload and returns the upserted review', async () => {
+      const upserted = {
+        pageNumber: 96,
+        category: 'LEGIT_EMPTY',
+        pageType: 'blank',
+      };
+      (api.put as Mock).mockResolvedValueOnce({
+        data: { data: upserted },
+      });
+
+      const result = await saveEmptyPageReview('run-1', 96, {
+        category: 'LEGIT_EMPTY',
+        pageType: 'blank',
+      });
+      expect(result).toEqual(upserted);
+      expect(api.put).toHaveBeenCalledWith(
+        '/calibration/runs/run-1/empty-page-reviews/96',
+        { category: 'LEGIT_EMPTY', pageType: 'blank' },
+      );
+    });
+  });
+
+  describe('deleteEmptyPageReview', () => {
+    it('DELETEs and returns the unwrapped success body', async () => {
+      (api.delete as Mock).mockResolvedValueOnce({
+        data: { data: { deleted: true } },
+      });
+
+      const result = await deleteEmptyPageReview('run-1', 96);
+      expect(result).toEqual({ deleted: true });
+      expect(api.delete).toHaveBeenCalledWith(
+        '/calibration/runs/run-1/empty-page-reviews/96',
+      );
+    });
+  });
+});

--- a/src/services/empty-page-review.service.ts
+++ b/src/services/empty-page-review.service.ts
@@ -1,0 +1,121 @@
+import { api } from './api';
+
+export type EmptyPageCategory = 'LEGIT_EMPTY' | 'DETECTION_FAILURE' | 'UNSURE';
+
+export const EMPTY_PAGE_CATEGORIES: ReadonlyArray<EmptyPageCategory> = [
+  'LEGIT_EMPTY',
+  'DETECTION_FAILURE',
+  'UNSURE',
+];
+
+// Mirror of the backend's controlled vocabulary. Order matters — used as the
+// drop-down option order. Keep in lockstep with the backend's pageType enum
+// validation and with `ninja-frontend/docs/empty-pages-review/sheet-setup.gs`.
+export const EMPTY_PAGE_TYPES = [
+  'blank',
+  'cover',
+  'copyright',
+  'dedication',
+  'colophon',
+  'chapter_divider',
+  'toc_divider',
+  'image_plate',
+  'ornament',
+  'text_normal',
+  'text_complex',
+  'table',
+  'figure',
+  'mixed',
+  'other',
+] as const;
+
+export type EmptyPageType = (typeof EMPTY_PAGE_TYPES)[number];
+
+// Page types that are valid only when category === 'LEGIT_EMPTY'.
+export const LEGIT_EMPTY_PAGE_TYPES: ReadonlyArray<EmptyPageType> = [
+  'blank',
+  'cover',
+  'copyright',
+  'dedication',
+  'colophon',
+  'chapter_divider',
+  'toc_divider',
+  'image_plate',
+  'ornament',
+];
+
+// Page types that are valid when category is DETECTION_FAILURE or UNSURE.
+export const DETECTION_FAILURE_PAGE_TYPES: ReadonlyArray<EmptyPageType> = [
+  'text_normal',
+  'text_complex',
+  'table',
+  'figure',
+  'mixed',
+];
+
+export interface EmptyPageReviewAnnotator {
+  id: string;
+  firstName: string;
+  lastName: string;
+  email: string;
+}
+
+export interface EmptyPageReview {
+  pageNumber: number;
+  category: EmptyPageCategory;
+  pageType: EmptyPageType | string;
+  expectedContent: string | null;
+  notes: string | null;
+  annotator: EmptyPageReviewAnnotator;
+  reviewedAt: string;
+  updatedAt: string;
+}
+
+export interface SaveEmptyPageReviewPayload {
+  category: EmptyPageCategory;
+  pageType: EmptyPageType | string;
+  expectedContent?: string;
+  notes?: string;
+}
+
+const basePath = (runId: string) =>
+  `/calibration/runs/${encodeURIComponent(runId)}/empty-page-reviews`;
+
+export const listEmptyPageReviews = async (
+  runId: string,
+): Promise<{ reviews: EmptyPageReview[] }> =>
+  (await api.get(basePath(runId))).data.data;
+
+export const getEmptyPageReview = async (
+  runId: string,
+  pageNumber: number,
+): Promise<EmptyPageReview | null> => {
+  try {
+    const res = await api.get(`${basePath(runId)}/${pageNumber}`);
+    return res.data.data;
+  } catch (err) {
+    // 404 = "no review yet for this page" — not an error from the caller's POV.
+    if (
+      typeof err === 'object' &&
+      err !== null &&
+      'response' in err &&
+      (err as { response?: { status?: number } }).response?.status === 404
+    ) {
+      return null;
+    }
+    throw err;
+  }
+};
+
+export const saveEmptyPageReview = async (
+  runId: string,
+  pageNumber: number,
+  payload: SaveEmptyPageReviewPayload,
+): Promise<EmptyPageReview> =>
+  (await api.put(`${basePath(runId)}/${pageNumber}`, payload)).data.data;
+
+export const deleteEmptyPageReview = async (
+  runId: string,
+  pageNumber: number,
+): Promise<{ deleted: boolean }> =>
+  (await api.delete(`${basePath(runId)}/${pageNumber}`)).data.data;


### PR DESCRIPTION
## Summary

Implements **Option C** of the empty-pages workflow: when an annotator navigates to a page in `summary.emptyPages`, the right-hand sidebar of the zone-review workspace swaps from the zone list to a categorization form. Decisions persist to the `EmptyPageReview` backend model (already merged in `ninja-backend`). DB is canonical — no relationship to the Google Sheet.

Builds on the earlier chip from PR #254 by surfacing reviewed-vs-unreviewed progress in the popover and adding a bulk-mark workflow for the high-volume legit-empty case.

## Deliverables

### Form (`EmptyPageReviewSidebar.tsx`)

- Category radio (legit_empty / detection_failure / unsure) with one-line descriptions
- Page-type dropdown filtered to the subset valid for the chosen category
- `expectedContent` textarea required when DETECTION_FAILURE; shown but optional for UNSURE; hidden for LEGIT_EMPTY
- Notes textarea, capped at 2000 chars (matches backend)
- Auto-populates from existing review on mount; clears on navigation
- Save disabled until valid AND dirty (no-op saves blocked)
- "Last reviewed by" attribution when an existing review is loaded
- Inline two-step delete confirm — clicking Clear reveals "Confirm clear / Cancel" buttons in-place (replaces `window.confirm()`)
- **Cmd/Ctrl+S** triggers save; `preventDefault` suppresses the browser's save-page dialog
- **`window.beforeunload` guard** warns before tab close / refresh while dirty

### Chip popover progress + bulk mark

- Chip flips amber → green with check icon when all empty pages reviewed
- Counter "M of N reviewed" in the chip when partial
- Reviewed range chunks render with green tint + check icon in the popover list
- "Next empty page" → "Next unreviewed empty page" with wrap-around fallback
- **Bulk mark** — when 2+ unreviewed pages exist, an inline page-type chooser (limited to legit-empty types). Apply runs saves sequentially with a progress bar; surfaces a failed-count if any fail; auto-collapses 1.5s after completion

### Telemetry

New `src/lib/telemetry.ts` `trackEvent(name, props)` stub (structured `console.info` today, easy to swap for a real transport later). Wired through:
- `empty-page-review.save` / `save-error`
- `empty-page-review.delete` / `delete-error`
- `empty-page-review.bulk-start` / `bulk-complete`

PII-safe — text fields measured by length only, never transmitted verbatim.

## Tests

**179 tests pass** (162 before + **17 new**):

- `EmptyPageReviewSidebar.test.tsx` — 10 RTL tests covering empty/loaded/save/delete/dirty/category-switch/keyboard
- `empty-page-review.service.test.ts` — 7 tests covering each endpoint plus three error-path branches for `get` (404→null, 500 rethrow, network rethrow)

## Out of scope

- Reviewing pages that *have* zones — form only renders for pages in `summary.emptyPages`
- Review history / audit log beyond latest annotator + date
- Bulk DETECTION_FAILURE — bulk is restricted to LEGIT_EMPTY since blanket-marking N pages with a shared `expectedContent` would create low-value records for the ML team
- Per-page error reporting in bulk mode — only an aggregate failed-count surfaces; manual recovery via the sidebar form for affected pages

## Behaviour notes worth flagging in review

1. **Bulk runs sequentially.** Worst case in staging is 74 pages × ~150ms ≈ 11s. Parallelism (e.g. batches of 5) is a follow-up if this proves slow on bigger books.
2. **Cmd/Ctrl+S is only active while the empty-page sidebar is mounted.** No conflict with workspace ArrowLeft/Right page-nav shortcuts.
3. **`beforeunload` only catches browser-level navigation.** If the operator clicks the chip popover to jump pages with unsaved changes, the changes are silently lost. The "Unsaved changes" indicator in the form footer is the only visible warning. Lifting dirty state to `ZoneReviewWorkspace` to intercept chip navigation is a possible follow-up.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] 179 related tests pass
- [ ] Manual on staging — open `/bootstrap/zone-review/{docId}` for a backfilled doc
  - Navigate to a page in the empty list → sidebar shows the form (not the zone list)
  - Save flow: pick category → page type → save → "Review saved" + chip updates with green check on this page
  - Update flow: navigate back to a saved page → form prefills → make a change → Update → still saved
  - Delete flow: Clear → "Confirm clear / Cancel" → Cancel returns to normal; Clear → confirms → review removed
  - DETECTION_FAILURE: save button stays disabled until expectedContent has text
  - Cmd/Ctrl+S: triggers save when valid + dirty; no-op otherwise
  - Browser tab close with unsaved changes: warning prompt
  - Bulk mark: open popover with 2+ unreviewed → bulk picker → apply → progress bar → all marked → chip flips green
  - Navigate to a page that has zones → sidebar shows zone list (existing behaviour intact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Review empty pages with category, constrained page-type, expected-content validation, notes, and save/delete (two-step confirm).
  * Bulk-mark unreviewed pages with progress/failure counts; navigation disabled during bulk actions.
  * Keyboard shortcut (Ctrl/Cmd+S) to save (prevents browser save); beforeunload warning for unsaved changes.
  * Visual progress indicators, reviewed counts, and “Last reviewed” / “Unsaved changes” states; load-error disables editing.
  * Telemetry events emitted for save/delete and bulk actions.

* **Tests**
  * End-to-end unit/interaction tests covering form behavior, save/delete flows, shortcut, and bulk workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->