### PR TITLE
feat(calibration): status tracker tab on corpus summary

### DIFF
--- a/src/components/bootstrap/StatusPill.tsx
+++ b/src/components/bootstrap/StatusPill.tsx
@@ -12,6 +12,8 @@ interface StatusPillProps {
   isSaving?: boolean;
   disabled?: boolean;
   onChange?: (next: AnnotationStatus) => void;
+  /** Optional callback to clear a manual override (sends statusOverride: null). */
+  onClearOverride?: () => void;
 }
 
 const STATUS_TONE: Record<AnnotationStatus, string> = {
@@ -28,6 +30,7 @@ export function StatusPill({
   isSaving,
   disabled,
   onChange,
+  onClearOverride,
 }: StatusPillProps) {
   const [open, setOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -61,24 +64,33 @@ export function StatusPill({
   const tone = STATUS_TONE[status];
   const isReadOnly = !onChange || disabled;
 
+  // Tooltip: read-only branch wins over override branch when both are true.
+  // Otherwise: override → mention it; interactive → invite a click; read-only → label only.
+  const tooltip = isReadOnly
+    ? isOverride
+      ? `${STATUS_LABELS[status]} (manual override)`
+      : STATUS_LABELS[status]
+    : isOverride
+      ? `${STATUS_LABELS[status]} (manual override). Click to change.`
+      : `${STATUS_LABELS[status]}. Click to change.`;
+
+  const handleClearOverride = () => {
+    setOpen(false);
+    onClearOverride?.();
+  };
+
   return (
     <div ref={containerRef} className="relative inline-block">
       <button
         type="button"
         onClick={() => !isReadOnly && setOpen((v) => !v)}
         disabled={isReadOnly}
-        title={
-          isOverride
-            ? `${STATUS_LABELS[status]} (manual override). Click to change.`
-            : isReadOnly
-              ? STATUS_LABELS[status]
-              : `${STATUS_LABELS[status]}. Click to change.`
-        }
+        title={tooltip}
         className={`inline-flex items-center gap-1 px-2 py-0.5 text-xs font-medium rounded-full border transition-colors ${tone} ${
           isReadOnly ? 'cursor-default' : 'cursor-pointer'
         }`}
         aria-label={`Status: ${STATUS_LABELS[status]}`}
-        aria-haspopup={!isReadOnly}
+        aria-haspopup={!isReadOnly ? 'listbox' : undefined}
         aria-expanded={open}
       >
         {isSaving ? (
@@ -93,17 +105,17 @@ export function StatusPill({
       </button>
 
       {open && !isReadOnly && (
-        <div
-          role="menu"
-          className="absolute top-full left-0 mt-1 z-30 min-w-[10rem] bg-white border border-gray-200 rounded-md shadow-lg py-1"
-        >
+        // We use a plain dropdown rather than role="menu" / role="menuitem"
+        // because we don't implement the full WAI-ARIA Menu Button keyboard
+        // contract (focus-on-open, arrow-key navigation, etc.). Plain buttons
+        // give correct screen-reader behaviour for our actual implementation.
+        <div className="absolute top-full left-0 mt-1 z-30 min-w-[10rem] bg-white border border-gray-200 rounded-md shadow-lg py-1">
           {ANNOTATION_STATUSES.map((value) => {
             const isCurrent = value === status;
             return (
               <button
                 key={value}
                 type="button"
-                role="menuitem"
                 onClick={() => handleSelect(value)}
                 className={`w-full text-left px-3 py-1.5 text-xs hover:bg-gray-50 transition-colors ${
                   isCurrent ? 'font-semibold text-gray-900' : 'text-gray-700'
@@ -119,6 +131,19 @@ export function StatusPill({
               </button>
             );
           })}
+          {isOverride && onClearOverride && (
+            <>
+              <div className="border-t border-gray-100 my-1" />
+              <button
+                type="button"
+                onClick={handleClearOverride}
+                className="w-full text-left px-3 py-1.5 text-xs text-blue-600 hover:bg-blue-50 transition-colors"
+                title="Remove the manual override and revert to the derived status"
+              >
+                Clear override (use derived status)
+              </button>
+            </>
+          )}
         </div>
       )}
     </div>

--- a/src/components/bootstrap/StatusPill.tsx
+++ b/src/components/bootstrap/StatusPill.tsx
@@ -1,0 +1,141 @@
+import { useEffect, useRef, useState } from 'react';
+import { ChevronDown, Loader2 } from 'lucide-react';
+import {
+  ANNOTATION_STATUSES,
+  STATUS_LABELS,
+  type AnnotationStatus,
+} from '@/services/corpus-status.service';
+
+interface StatusPillProps {
+  status: AnnotationStatus;
+  isOverride?: boolean;
+  isSaving?: boolean;
+  disabled?: boolean;
+  onChange?: (next: AnnotationStatus) => void;
+}
+
+const STATUS_TONE: Record<AnnotationStatus, string> = {
+  NOT_STARTED: 'bg-gray-100 text-gray-700 border-gray-300 hover:bg-gray-200',
+  IN_PROGRESS: 'bg-amber-100 text-amber-800 border-amber-300 hover:bg-amber-200',
+  PENDING_REVIEW: 'bg-violet-100 text-violet-800 border-violet-300 hover:bg-violet-200',
+  COMPLETED: 'bg-green-100 text-green-800 border-green-300 hover:bg-green-200',
+  BLOCKED: 'bg-red-100 text-red-800 border-red-300 hover:bg-red-200',
+};
+
+export function StatusPill({
+  status,
+  isOverride,
+  isSaving,
+  disabled,
+  onChange,
+}: StatusPillProps) {
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false);
+    };
+    const onClick = (e: MouseEvent) => {
+      if (
+        containerRef.current &&
+        !containerRef.current.contains(e.target as Node)
+      ) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('keydown', onKey);
+    document.addEventListener('mousedown', onClick);
+    return () => {
+      document.removeEventListener('keydown', onKey);
+      document.removeEventListener('mousedown', onClick);
+    };
+  }, [open]);
+
+  const handleSelect = (next: AnnotationStatus) => {
+    setOpen(false);
+    if (next !== status) onChange?.(next);
+  };
+
+  const tone = STATUS_TONE[status];
+  const isReadOnly = !onChange || disabled;
+
+  return (
+    <div ref={containerRef} className="relative inline-block">
+      <button
+        type="button"
+        onClick={() => !isReadOnly && setOpen((v) => !v)}
+        disabled={isReadOnly}
+        title={
+          isOverride
+            ? `${STATUS_LABELS[status]} (manual override). Click to change.`
+            : isReadOnly
+              ? STATUS_LABELS[status]
+              : `${STATUS_LABELS[status]}. Click to change.`
+        }
+        className={`inline-flex items-center gap-1 px-2 py-0.5 text-xs font-medium rounded-full border transition-colors ${tone} ${
+          isReadOnly ? 'cursor-default' : 'cursor-pointer'
+        }`}
+        aria-label={`Status: ${STATUS_LABELS[status]}`}
+        aria-haspopup={!isReadOnly}
+        aria-expanded={open}
+      >
+        {isSaving ? (
+          <Loader2 className="h-3 w-3 animate-spin" />
+        ) : isOverride ? (
+          <span className="text-[8px] leading-none" aria-hidden="true">
+            ●
+          </span>
+        ) : null}
+        {STATUS_LABELS[status]}
+        {!isReadOnly && <ChevronDown className="h-3 w-3" />}
+      </button>
+
+      {open && !isReadOnly && (
+        <div
+          role="menu"
+          className="absolute top-full left-0 mt-1 z-30 min-w-[10rem] bg-white border border-gray-200 rounded-md shadow-lg py-1"
+        >
+          {ANNOTATION_STATUSES.map((value) => {
+            const isCurrent = value === status;
+            return (
+              <button
+                key={value}
+                type="button"
+                role="menuitem"
+                onClick={() => handleSelect(value)}
+                className={`w-full text-left px-3 py-1.5 text-xs hover:bg-gray-50 transition-colors ${
+                  isCurrent ? 'font-semibold text-gray-900' : 'text-gray-700'
+                }`}
+              >
+                <span className={`inline-block w-2 h-2 rounded-full mr-2 align-middle ${pillDot(value)}`} />
+                {STATUS_LABELS[value]}
+                {isCurrent && (
+                  <span className="ml-2 text-[10px] uppercase tracking-wide text-gray-400">
+                    current
+                  </span>
+                )}
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function pillDot(status: AnnotationStatus): string {
+  switch (status) {
+    case 'NOT_STARTED':
+      return 'bg-gray-400';
+    case 'IN_PROGRESS':
+      return 'bg-amber-500';
+    case 'PENDING_REVIEW':
+      return 'bg-violet-500';
+    case 'COMPLETED':
+      return 'bg-green-500';
+    case 'BLOCKED':
+      return 'bg-red-500';
+  }
+}

--- a/src/components/bootstrap/StatusTrackerTab.tsx
+++ b/src/components/bootstrap/StatusTrackerTab.tsx
@@ -80,7 +80,26 @@ export function StatusTrackerTab() {
   const [filter, setFilter] = useState<StatusFilter>(DEFAULT_FILTER);
   const [sortKey, setSortKey] = useState<SortKey>('serialNumber');
   const [sortDir, setSortDir] = useState<SortDir>('asc');
-  const [pendingDocId, setPendingDocId] = useState<string | null>(null);
+  // Track per-row pending state so overlapping mutations don't clear each
+  // other's spinner/disabled state when one settles.
+  const [pendingDocIds, setPendingDocIds] = useState<Set<string>>(
+    () => new Set(),
+  );
+
+  const markPending = (documentId: string) =>
+    setPendingDocIds((prev) => {
+      const next = new Set(prev);
+      next.add(documentId);
+      return next;
+    });
+
+  const clearPending = (documentId: string) =>
+    setPendingDocIds((prev) => {
+      if (!prev.has(documentId)) return prev;
+      const next = new Set(prev);
+      next.delete(documentId);
+      return next;
+    });
 
   const rows = useMemo(() => data?.rows ?? [], [data]);
 
@@ -131,21 +150,31 @@ export function StatusTrackerTab() {
     documentId: string,
     next: AnnotationStatus,
   ) => {
-    setPendingDocId(documentId);
+    markPending(documentId);
     updateMutation.mutate(
       { documentId, payload: { statusOverride: next } },
       {
-        onSettled: () => setPendingDocId(null),
+        onSettled: () => clearPending(documentId),
+      },
+    );
+  };
+
+  const handleClearOverride = (documentId: string) => {
+    markPending(documentId);
+    updateMutation.mutate(
+      { documentId, payload: { statusOverride: null } },
+      {
+        onSettled: () => clearPending(documentId),
       },
     );
   };
 
   const handleNoteSave = (documentId: string, note: string) => {
-    setPendingDocId(documentId);
+    markPending(documentId);
     updateMutation.mutate(
       { documentId, payload: { statusNote: note } },
       {
-        onSettled: () => setPendingDocId(null),
+        onSettled: () => clearPending(documentId),
       },
     );
   };
@@ -177,10 +206,13 @@ export function StatusTrackerTab() {
         },
         {
           label: 'Last Updated',
-          value: (r: CorpusStatusRow) =>
-            r.lastUpdatedAt
-              ? new Date(r.lastUpdatedAt).toISOString().slice(0, 10)
-              : '',
+          value: (r: CorpusStatusRow) => {
+            if (!r.lastUpdatedAt) return '';
+            const d = new Date(r.lastUpdatedAt);
+            // Guard against invalid date strings — toISOString throws on those.
+            if (Number.isNaN(d.getTime())) return r.lastUpdatedAt;
+            return d.toISOString().slice(0, 10);
+          },
         },
         {
           label: 'Notes',
@@ -388,10 +420,11 @@ export function StatusTrackerTab() {
               <StatusRow
                 key={row.documentId}
                 row={row}
-                isPending={pendingDocId === row.documentId}
+                isPending={pendingDocIds.has(row.documentId)}
                 onStatusChange={(next) =>
                   handleStatusChange(row.documentId, next)
                 }
+                onClearOverride={() => handleClearOverride(row.documentId)}
                 onNoteSave={(note) => handleNoteSave(row.documentId, note)}
               />
             ))}
@@ -452,6 +485,7 @@ interface StatusRowProps {
   row: CorpusStatusRow;
   isPending: boolean;
   onStatusChange: (next: AnnotationStatus) => void;
+  onClearOverride: () => void;
   onNoteSave: (note: string) => void;
 }
 
@@ -459,6 +493,7 @@ function StatusRow({
   row,
   isPending,
   onStatusChange,
+  onClearOverride,
   onNoteSave,
 }: StatusRowProps) {
   const pct =
@@ -484,6 +519,7 @@ function StatusRow({
           isOverride={row.statusOverride !== null}
           isSaving={isPending}
           onChange={onStatusChange}
+          onClearOverride={onClearOverride}
         />
       </td>
       <td className="px-3 py-2 text-xs text-gray-700">

--- a/src/components/bootstrap/StatusTrackerTab.tsx
+++ b/src/components/bootstrap/StatusTrackerTab.tsx
@@ -1,0 +1,591 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { Download, Loader2, RefreshCw } from 'lucide-react';
+import {
+  STATUS_LABELS,
+  type AnnotationStatus,
+  type CorpusStatusRow,
+} from '@/services/corpus-status.service';
+import {
+  useCorpusStatus,
+  useUpdateCorpusStatus,
+} from '@/hooks/useCorpusStatus';
+import { StatusPill } from './StatusPill';
+import { downloadCsv } from '@/lib/csv-export';
+
+type SortKey =
+  | 'serialNumber'
+  | 'filename'
+  | 'pages'
+  | 'status'
+  | 'annotator'
+  | 'hours'
+  | 'lastUpdated';
+type SortDir = 'asc' | 'desc';
+
+interface StatusFilter {
+  status: AnnotationStatus | 'ALL';
+  annotator: string | 'ALL';
+  search: string;
+}
+
+const DEFAULT_FILTER: StatusFilter = {
+  status: 'ALL',
+  annotator: 'ALL',
+  search: '',
+};
+
+function cmp(a: number | string, b: number | string): number {
+  if (a < b) return -1;
+  if (a > b) return 1;
+  return 0;
+}
+
+function rowSortValue(row: CorpusStatusRow, key: SortKey): string | number {
+  switch (key) {
+    case 'serialNumber':
+      return row.serialNumber;
+    case 'filename':
+      return row.filename.toLowerCase();
+    case 'pages':
+      return row.pageCount > 0 ? row.pagesAnnotated / row.pageCount : 0;
+    case 'status':
+      return row.status;
+    case 'annotator':
+      return row.primaryAnnotator?.displayName.toLowerCase() ?? '';
+    case 'hours':
+      return row.hoursSpent;
+    case 'lastUpdated':
+      return row.lastUpdatedAt ?? '';
+  }
+}
+
+function formatDate(iso: string | null): string {
+  if (!iso) return '—';
+  const d = new Date(iso);
+  if (isNaN(d.getTime())) return '—';
+  return d.toLocaleDateString();
+}
+
+function formatHours(hours: number): string {
+  if (hours === 0) return '0';
+  if (hours < 0.1) return '<0.1';
+  return hours.toFixed(1);
+}
+
+export function StatusTrackerTab() {
+  const { data, isLoading, isError, error, refetch, isFetching } =
+    useCorpusStatus();
+  const updateMutation = useUpdateCorpusStatus();
+
+  const [filter, setFilter] = useState<StatusFilter>(DEFAULT_FILTER);
+  const [sortKey, setSortKey] = useState<SortKey>('serialNumber');
+  const [sortDir, setSortDir] = useState<SortDir>('asc');
+  const [pendingDocId, setPendingDocId] = useState<string | null>(null);
+
+  const rows = useMemo(() => data?.rows ?? [], [data]);
+
+  const annotatorOptions = useMemo(() => {
+    const set = new Set<string>();
+    for (const row of rows) {
+      if (row.primaryAnnotator?.displayName) {
+        set.add(row.primaryAnnotator.displayName);
+      }
+    }
+    return Array.from(set).sort();
+  }, [rows]);
+
+  const filtered = useMemo(() => {
+    const search = filter.search.trim().toLowerCase();
+    return rows.filter((row) => {
+      if (filter.status !== 'ALL' && row.status !== filter.status) return false;
+      if (
+        filter.annotator !== 'ALL' &&
+        row.primaryAnnotator?.displayName !== filter.annotator
+      ) {
+        return false;
+      }
+      if (search && !row.filename.toLowerCase().includes(search)) return false;
+      return true;
+    });
+  }, [rows, filter]);
+
+  const sorted = useMemo(() => {
+    const copy = [...filtered];
+    copy.sort((a, b) => {
+      const result = cmp(rowSortValue(a, sortKey), rowSortValue(b, sortKey));
+      return sortDir === 'asc' ? result : -result;
+    });
+    return copy;
+  }, [filtered, sortKey, sortDir]);
+
+  const toggleSort = (key: SortKey) => {
+    if (sortKey === key) {
+      setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'));
+    } else {
+      setSortKey(key);
+      setSortDir('asc');
+    }
+  };
+
+  const handleStatusChange = (
+    documentId: string,
+    next: AnnotationStatus,
+  ) => {
+    setPendingDocId(documentId);
+    updateMutation.mutate(
+      { documentId, payload: { statusOverride: next } },
+      {
+        onSettled: () => setPendingDocId(null),
+      },
+    );
+  };
+
+  const handleNoteSave = (documentId: string, note: string) => {
+    setPendingDocId(documentId);
+    updateMutation.mutate(
+      { documentId, payload: { statusNote: note } },
+      {
+        onSettled: () => setPendingDocId(null),
+      },
+    );
+  };
+
+  const handleDownload = () => {
+    const today = new Date().toISOString().slice(0, 10);
+    downloadCsv({
+      filename: `annotation-status-${today}.csv`,
+      columns: [
+        { label: '#', value: (r: CorpusStatusRow) => r.serialNumber },
+        { label: 'Title', value: (r: CorpusStatusRow) => r.filename },
+        { label: 'Total Pages', value: (r: CorpusStatusRow) => r.pageCount },
+        {
+          label: 'Pages Annotated',
+          value: (r: CorpusStatusRow) => r.pagesAnnotated,
+        },
+        {
+          label: 'Status',
+          value: (r: CorpusStatusRow) => STATUS_LABELS[r.status],
+        },
+        {
+          label: 'Primary Annotator',
+          value: (r: CorpusStatusRow) =>
+            r.primaryAnnotator?.displayName ?? '',
+        },
+        {
+          label: 'Hours Spent',
+          value: (r: CorpusStatusRow) => Number(r.hoursSpent.toFixed(2)),
+        },
+        {
+          label: 'Last Updated',
+          value: (r: CorpusStatusRow) =>
+            r.lastUpdatedAt
+              ? new Date(r.lastUpdatedAt).toISOString().slice(0, 10)
+              : '',
+        },
+        {
+          label: 'Notes',
+          value: (r: CorpusStatusRow) => r.statusNote ?? '',
+        },
+      ],
+      rows: sorted,
+    });
+  };
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center py-16 text-sm text-gray-500">
+        <Loader2 className="h-4 w-4 animate-spin mr-2" />
+        Loading corpus status…
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div className="px-4 py-8 text-sm text-red-700 bg-red-50 border border-red-200 rounded-lg">
+        Failed to load corpus status:{' '}
+        {error instanceof Error ? error.message : 'Unknown error'}.{' '}
+        <button
+          type="button"
+          onClick={() => refetch()}
+          className="ml-2 text-red-800 underline hover:text-red-900"
+        >
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  if (rows.length === 0) {
+    return (
+      <div className="px-4 py-12 text-center text-sm text-gray-500 border border-dashed border-gray-200 rounded-lg">
+        No documents in the corpus yet.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between gap-3 flex-wrap">
+        <div className="flex items-center gap-2 flex-wrap">
+          <select
+            value={filter.status}
+            onChange={(e) =>
+              setFilter((f) => ({
+                ...f,
+                status: e.target.value as StatusFilter['status'],
+              }))
+            }
+            className="text-xs border border-gray-300 rounded px-2 py-1.5 focus:outline-none focus:ring-1 focus:ring-blue-400"
+            aria-label="Filter by status"
+          >
+            <option value="ALL">All statuses</option>
+            {(
+              Object.keys(STATUS_LABELS) as AnnotationStatus[]
+            ).map((s) => (
+              <option key={s} value={s}>
+                {STATUS_LABELS[s]}
+              </option>
+            ))}
+          </select>
+
+          <select
+            value={filter.annotator}
+            onChange={(e) =>
+              setFilter((f) => ({ ...f, annotator: e.target.value }))
+            }
+            className="text-xs border border-gray-300 rounded px-2 py-1.5 focus:outline-none focus:ring-1 focus:ring-blue-400"
+            aria-label="Filter by annotator"
+          >
+            <option value="ALL">All annotators</option>
+            {annotatorOptions.map((a) => (
+              <option key={a} value={a}>
+                {a}
+              </option>
+            ))}
+          </select>
+
+          <input
+            type="text"
+            placeholder="Search title…"
+            value={filter.search}
+            onChange={(e) =>
+              setFilter((f) => ({ ...f, search: e.target.value }))
+            }
+            className="text-xs border border-gray-300 rounded px-2 py-1.5 w-48 focus:outline-none focus:ring-1 focus:ring-blue-400"
+            aria-label="Search title"
+          />
+
+          {(filter.status !== 'ALL' ||
+            filter.annotator !== 'ALL' ||
+            filter.search !== '') && (
+            <button
+              type="button"
+              onClick={() => setFilter(DEFAULT_FILTER)}
+              className="text-xs text-blue-600 hover:underline"
+            >
+              Reset
+            </button>
+          )}
+
+          <span className="text-xs text-gray-500 ml-1">
+            Showing {sorted.length} of {rows.length} titles
+          </span>
+        </div>
+
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={() => refetch()}
+            disabled={isFetching}
+            className="inline-flex items-center gap-1 px-3 py-1.5 text-xs font-medium rounded border border-gray-300 text-gray-700 hover:bg-gray-50 disabled:opacity-40 transition-colors"
+            title="Refresh data"
+          >
+            <RefreshCw
+              className={`h-3 w-3 ${isFetching ? 'animate-spin' : ''}`}
+            />
+            Refresh
+          </button>
+          <button
+            type="button"
+            onClick={handleDownload}
+            className="inline-flex items-center gap-1 px-3 py-1.5 text-xs font-medium rounded bg-[#006B6B] text-white hover:bg-[#005858] transition-colors"
+            title="Download visible rows as CSV"
+          >
+            <Download className="h-3 w-3" />
+            Download CSV
+          </button>
+        </div>
+      </div>
+
+      <div className="overflow-x-auto rounded-lg border border-gray-200">
+        <table className="min-w-full divide-y divide-gray-200">
+          <thead className="bg-gray-50">
+            <tr>
+              <SortHeader
+                label="#"
+                sortKey="serialNumber"
+                currentKey={sortKey}
+                currentDir={sortDir}
+                onSort={toggleSort}
+                className="w-12"
+              />
+              <SortHeader
+                label="Title"
+                sortKey="filename"
+                currentKey={sortKey}
+                currentDir={sortDir}
+                onSort={toggleSort}
+              />
+              <SortHeader
+                label="Pages"
+                sortKey="pages"
+                currentKey={sortKey}
+                currentDir={sortDir}
+                onSort={toggleSort}
+                className="w-32"
+              />
+              <SortHeader
+                label="Status"
+                sortKey="status"
+                currentKey={sortKey}
+                currentDir={sortDir}
+                onSort={toggleSort}
+                className="w-40"
+              />
+              <SortHeader
+                label="Annotator"
+                sortKey="annotator"
+                currentKey={sortKey}
+                currentDir={sortDir}
+                onSort={toggleSort}
+                className="w-36"
+              />
+              <SortHeader
+                label="Hours"
+                sortKey="hours"
+                currentKey={sortKey}
+                currentDir={sortDir}
+                onSort={toggleSort}
+                className="w-20 text-right"
+                align="right"
+              />
+              <SortHeader
+                label="Last Updated"
+                sortKey="lastUpdated"
+                currentKey={sortKey}
+                currentDir={sortDir}
+                onSort={toggleSort}
+                className="w-28"
+              />
+              <th className="px-3 py-2 text-left text-xs font-semibold text-gray-700">
+                Notes
+              </th>
+            </tr>
+          </thead>
+          <tbody className="bg-white divide-y divide-gray-200">
+            {sorted.map((row) => (
+              <StatusRow
+                key={row.documentId}
+                row={row}
+                isPending={pendingDocId === row.documentId}
+                onStatusChange={(next) =>
+                  handleStatusChange(row.documentId, next)
+                }
+                onNoteSave={(note) => handleNoteSave(row.documentId, note)}
+              />
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {data?.generatedAt && (
+        <div className="text-[11px] text-gray-400">
+          Last refreshed: {new Date(data.generatedAt).toLocaleString()}
+        </div>
+      )}
+    </div>
+  );
+}
+
+interface SortHeaderProps {
+  label: string;
+  sortKey: SortKey;
+  currentKey: SortKey;
+  currentDir: SortDir;
+  onSort: (key: SortKey) => void;
+  className?: string;
+  align?: 'left' | 'right';
+}
+
+function SortHeader({
+  label,
+  sortKey,
+  currentKey,
+  currentDir,
+  onSort,
+  className,
+  align,
+}: SortHeaderProps) {
+  const isActive = sortKey === currentKey;
+  const arrow = isActive ? (currentDir === 'asc' ? '▲' : '▼') : '';
+  return (
+    <th
+      scope="col"
+      className={`px-3 py-2 text-${align ?? 'left'} text-xs font-semibold text-gray-700 ${className ?? ''}`}
+    >
+      <button
+        type="button"
+        onClick={() => onSort(sortKey)}
+        className="inline-flex items-center gap-1 hover:text-gray-900"
+      >
+        {label}
+        <span className="text-[9px] text-gray-400 w-2 inline-block">
+          {arrow}
+        </span>
+      </button>
+    </th>
+  );
+}
+
+interface StatusRowProps {
+  row: CorpusStatusRow;
+  isPending: boolean;
+  onStatusChange: (next: AnnotationStatus) => void;
+  onNoteSave: (note: string) => void;
+}
+
+function StatusRow({
+  row,
+  isPending,
+  onStatusChange,
+  onNoteSave,
+}: StatusRowProps) {
+  const pct =
+    row.pageCount > 0 ? Math.round((row.pagesAnnotated / row.pageCount) * 100) : 0;
+  return (
+    <tr className="hover:bg-gray-50">
+      <td className="px-3 py-2 text-xs text-gray-500">{row.serialNumber}</td>
+      <td
+        className="px-3 py-2 text-xs font-medium text-gray-900 truncate max-w-md"
+        title={row.filename}
+      >
+        {row.filename}
+      </td>
+      <td className="px-3 py-2 text-xs text-gray-700">
+        <span className="font-mono">
+          {row.pagesAnnotated} / {row.pageCount}
+        </span>
+        <span className="text-gray-400 ml-1">({pct}%)</span>
+      </td>
+      <td className="px-3 py-2">
+        <StatusPill
+          status={row.status}
+          isOverride={row.statusOverride !== null}
+          isSaving={isPending}
+          onChange={onStatusChange}
+        />
+      </td>
+      <td className="px-3 py-2 text-xs text-gray-700">
+        {row.primaryAnnotator ? (
+          <span title={row.primaryAnnotator.email ?? undefined}>
+            {row.primaryAnnotator.displayName}
+            {row.otherAnnotatorCount > 0 && (
+              <span
+                className="ml-1 inline-flex items-center px-1 py-0.5 text-[10px] rounded bg-gray-100 text-gray-500"
+                title={`${row.otherAnnotatorCount} additional annotator(s)`}
+              >
+                +{row.otherAnnotatorCount}
+              </span>
+            )}
+          </span>
+        ) : (
+          <span className="text-gray-400">—</span>
+        )}
+      </td>
+      <td className="px-3 py-2 text-xs text-gray-700 text-right tabular-nums">
+        {formatHours(row.hoursSpent)}
+      </td>
+      <td className="px-3 py-2 text-xs text-gray-500">
+        {formatDate(row.lastUpdatedAt)}
+      </td>
+      <td className="px-3 py-2 text-xs text-gray-700">
+        <NotesCell
+          initial={row.statusNote ?? ''}
+          onSave={onNoteSave}
+          disabled={isPending}
+        />
+      </td>
+    </tr>
+  );
+}
+
+interface NotesCellProps {
+  initial: string;
+  onSave: (note: string) => void;
+  disabled?: boolean;
+}
+
+const MAX_NOTE_LENGTH = 500;
+
+function NotesCell({ initial, onSave, disabled }: NotesCellProps) {
+  const [editing, setEditing] = useState(false);
+  const [value, setValue] = useState(initial);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    setValue(initial);
+  }, [initial]);
+
+  useEffect(() => {
+    if (editing) textareaRef.current?.focus();
+  }, [editing]);
+
+  const commit = () => {
+    setEditing(false);
+    const trimmed = value.trim();
+    if (trimmed === initial.trim()) return;
+    onSave(trimmed);
+  };
+
+  if (editing) {
+    return (
+      <textarea
+        ref={textareaRef}
+        value={value}
+        maxLength={MAX_NOTE_LENGTH}
+        onChange={(e) => setValue(e.target.value)}
+        onBlur={commit}
+        onKeyDown={(e) => {
+          if (e.key === 'Escape') {
+            setValue(initial);
+            setEditing(false);
+          } else if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) {
+            commit();
+          }
+        }}
+        rows={2}
+        className="w-full text-xs border border-blue-400 rounded px-2 py-1 resize-y focus:outline-none focus:ring-1 focus:ring-blue-400"
+        aria-label="Notes"
+      />
+    );
+  }
+
+  const preview = initial.length > 100 ? `${initial.slice(0, 100)}…` : initial;
+
+  return (
+    <button
+      type="button"
+      onClick={() => !disabled && setEditing(true)}
+      disabled={disabled}
+      title={initial || 'Click to add notes'}
+      className={`w-full text-left text-xs px-1 py-0.5 rounded transition-colors ${
+        initial
+          ? 'text-gray-700'
+          : 'text-gray-400 italic hover:text-gray-600'
+      } ${disabled ? 'cursor-default' : 'hover:bg-gray-50 cursor-text'}`}
+    >
+      {preview || 'Add notes…'}
+    </button>
+  );
+}

--- a/src/components/bootstrap/__tests__/StatusTrackerTab.test.tsx
+++ b/src/components/bootstrap/__tests__/StatusTrackerTab.test.tsx
@@ -226,8 +226,8 @@ describe('StatusTrackerTab', () => {
     renderTab();
     // Open the pill drop-down
     fireEvent.click(screen.getByRole('button', { name: /status: in progress/i }));
-    // Select the BLOCKED option from the menu
-    fireEvent.click(screen.getByRole('menuitem', { name: /blocked/i }));
+    // Select the BLOCKED option from the dropdown (plain buttons, not role="menuitem")
+    fireEvent.click(screen.getByRole('button', { name: /^Blocked$/i }));
 
     expect(mutate).toHaveBeenCalledWith(
       {

--- a/src/components/bootstrap/__tests__/StatusTrackerTab.test.tsx
+++ b/src/components/bootstrap/__tests__/StatusTrackerTab.test.tsx
@@ -1,0 +1,331 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { StatusTrackerTab } from '../StatusTrackerTab';
+import type {
+  CorpusStatusResponse,
+  CorpusStatusRow,
+} from '@/services/corpus-status.service';
+
+vi.mock('@/hooks/useCorpusStatus', () => ({
+  useCorpusStatus: vi.fn(),
+  useUpdateCorpusStatus: vi.fn(),
+}));
+
+vi.mock('@/lib/csv-export', () => ({
+  downloadCsv: vi.fn(),
+}));
+
+const { useCorpusStatus, useUpdateCorpusStatus } = await import(
+  '@/hooks/useCorpusStatus'
+);
+const { downloadCsv } = await import('@/lib/csv-export');
+
+const mockUseCorpusStatus = vi.mocked(useCorpusStatus);
+const mockUseUpdateCorpusStatus = vi.mocked(useUpdateCorpusStatus);
+const mockDownloadCsv = vi.mocked(downloadCsv);
+
+function makeRow(overrides: Partial<CorpusStatusRow> = {}): CorpusStatusRow {
+  return {
+    serialNumber: 1,
+    documentId: 'doc-1',
+    filename: 'Aulakh.pdf',
+    pageCount: 295,
+    pagesAnnotated: 295,
+    status: 'COMPLETED',
+    statusOverride: null,
+    primaryAnnotator: {
+      userId: 'u1',
+      displayName: 'Poornakala U',
+      email: 'p@example.com',
+    },
+    otherAnnotatorCount: 0,
+    hoursSpent: 5.5,
+    lastUpdatedAt: '2026-04-29T10:00:00Z',
+    statusNote: null,
+    ...overrides,
+  };
+}
+
+function makeResponse(rows: CorpusStatusRow[]): CorpusStatusResponse {
+  return { rows, generatedAt: '2026-05-08T12:00:00Z' };
+}
+
+function renderTab() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <StatusTrackerTab />
+    </QueryClientProvider>,
+  );
+}
+
+describe('StatusTrackerTab', () => {
+  let mutate: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mutate = vi.fn();
+    mockUseUpdateCorpusStatus.mockReturnValue({
+      mutate,
+      isPending: false,
+    } as unknown as ReturnType<typeof useUpdateCorpusStatus>);
+  });
+
+  it('renders a loading state', () => {
+    mockUseCorpusStatus.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      isError: false,
+      error: null,
+      refetch: vi.fn(),
+      isFetching: true,
+    } as unknown as ReturnType<typeof useCorpusStatus>);
+
+    renderTab();
+    expect(screen.getByText(/loading corpus status/i)).toBeInTheDocument();
+  });
+
+  it('renders an error state with retry', () => {
+    const refetch = vi.fn();
+    mockUseCorpusStatus.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      error: new Error('Network down'),
+      refetch,
+      isFetching: false,
+    } as unknown as ReturnType<typeof useCorpusStatus>);
+
+    renderTab();
+    expect(screen.getByText(/failed to load corpus status/i)).toBeInTheDocument();
+    expect(screen.getByText(/network down/i)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /retry/i }));
+    expect(refetch).toHaveBeenCalled();
+  });
+
+  it('renders the empty state when there are no rows', () => {
+    mockUseCorpusStatus.mockReturnValue({
+      data: makeResponse([]),
+      isLoading: false,
+      isError: false,
+      error: null,
+      refetch: vi.fn(),
+      isFetching: false,
+    } as unknown as ReturnType<typeof useCorpusStatus>);
+
+    renderTab();
+    expect(screen.getByText(/no documents in the corpus yet/i)).toBeInTheDocument();
+  });
+
+  it('renders rows with all key columns visible', () => {
+    mockUseCorpusStatus.mockReturnValue({
+      data: makeResponse([
+        makeRow(),
+        makeRow({
+          serialNumber: 2,
+          documentId: 'doc-2',
+          filename: 'Acharya.pdf',
+          status: 'IN_PROGRESS',
+          pagesAnnotated: 50,
+          hoursSpent: 2.3,
+          primaryAnnotator: {
+            userId: 'u2',
+            displayName: 'Nambi T',
+            email: 'n@example.com',
+          },
+        }),
+      ]),
+      isLoading: false,
+      isError: false,
+      error: null,
+      refetch: vi.fn(),
+      isFetching: false,
+    } as unknown as ReturnType<typeof useCorpusStatus>);
+
+    const { container } = renderTab();
+    expect(screen.getByText('Aulakh.pdf')).toBeInTheDocument();
+    expect(screen.getByText('Acharya.pdf')).toBeInTheDocument();
+    expect(screen.getByText(/295 \/ 295/)).toBeInTheDocument();
+    expect(screen.getByText(/50 \/ 295/)).toBeInTheDocument();
+    // Annotator names appear in both the dropdown filter AND the row cells; assert
+    // at least once each rather than getByText (which fails on >1 match).
+    expect(screen.getAllByText('Poornakala U').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Nambi T').length).toBeGreaterThan(0);
+    expect(screen.getByText(/Showing 2 of 2 titles/)).toBeInTheDocument();
+    // Confirm both names appear inside the table specifically
+    const tbody = container.querySelector('tbody');
+    expect(tbody?.textContent).toContain('Poornakala U');
+    expect(tbody?.textContent).toContain('Nambi T');
+  });
+
+  it('filters rows by status', () => {
+    mockUseCorpusStatus.mockReturnValue({
+      data: makeResponse([
+        makeRow({ filename: 'Done.pdf', status: 'COMPLETED' }),
+        makeRow({
+          serialNumber: 2,
+          documentId: 'doc-2',
+          filename: 'WIP.pdf',
+          status: 'IN_PROGRESS',
+        }),
+      ]),
+      isLoading: false,
+      isError: false,
+      error: null,
+      refetch: vi.fn(),
+      isFetching: false,
+    } as unknown as ReturnType<typeof useCorpusStatus>);
+
+    renderTab();
+    fireEvent.change(screen.getByLabelText(/filter by status/i), {
+      target: { value: 'COMPLETED' },
+    });
+    expect(screen.getByText('Done.pdf')).toBeInTheDocument();
+    expect(screen.queryByText('WIP.pdf')).not.toBeInTheDocument();
+    expect(screen.getByText(/Showing 1 of 2 titles/)).toBeInTheDocument();
+  });
+
+  it('filters rows by title search (case-insensitive)', () => {
+    mockUseCorpusStatus.mockReturnValue({
+      data: makeResponse([
+        makeRow({ filename: 'Aulakh.pdf' }),
+        makeRow({
+          serialNumber: 2,
+          documentId: 'doc-2',
+          filename: 'Boyd-Hamill.pdf',
+        }),
+      ]),
+      isLoading: false,
+      isError: false,
+      error: null,
+      refetch: vi.fn(),
+      isFetching: false,
+    } as unknown as ReturnType<typeof useCorpusStatus>);
+
+    renderTab();
+    fireEvent.change(screen.getByLabelText(/search title/i), {
+      target: { value: 'BOYD' },
+    });
+    expect(screen.getByText('Boyd-Hamill.pdf')).toBeInTheDocument();
+    expect(screen.queryByText('Aulakh.pdf')).not.toBeInTheDocument();
+  });
+
+  it('triggers status mutation on pill change', () => {
+    mockUseCorpusStatus.mockReturnValue({
+      data: makeResponse([makeRow({ status: 'IN_PROGRESS' })]),
+      isLoading: false,
+      isError: false,
+      error: null,
+      refetch: vi.fn(),
+      isFetching: false,
+    } as unknown as ReturnType<typeof useCorpusStatus>);
+
+    renderTab();
+    // Open the pill drop-down
+    fireEvent.click(screen.getByRole('button', { name: /status: in progress/i }));
+    // Select the BLOCKED option from the menu
+    fireEvent.click(screen.getByRole('menuitem', { name: /blocked/i }));
+
+    expect(mutate).toHaveBeenCalledWith(
+      {
+        documentId: 'doc-1',
+        payload: { statusOverride: 'BLOCKED' },
+      },
+      expect.objectContaining({ onSettled: expect.any(Function) }),
+    );
+  });
+
+  it('saves a note via inline edit on blur', () => {
+    mockUseCorpusStatus.mockReturnValue({
+      data: makeResponse([makeRow({ statusNote: null })]),
+      isLoading: false,
+      isError: false,
+      error: null,
+      refetch: vi.fn(),
+      isFetching: false,
+    } as unknown as ReturnType<typeof useCorpusStatus>);
+
+    renderTab();
+    // Click the empty notes cell to enter edit mode
+    fireEvent.click(screen.getByRole('button', { name: /add notes/i }));
+    const textarea = screen.getByRole('textbox', { name: /notes/i });
+    fireEvent.change(textarea, { target: { value: 'Re-extraction needed' } });
+    fireEvent.blur(textarea);
+
+    expect(mutate).toHaveBeenCalledWith(
+      {
+        documentId: 'doc-1',
+        payload: { statusNote: 'Re-extraction needed' },
+      },
+      expect.objectContaining({ onSettled: expect.any(Function) }),
+    );
+  });
+
+  it('downloads CSV with the visible (filtered) rows', () => {
+    mockUseCorpusStatus.mockReturnValue({
+      data: makeResponse([
+        makeRow({ filename: 'Aulakh.pdf', status: 'COMPLETED' }),
+        makeRow({
+          serialNumber: 2,
+          documentId: 'doc-2',
+          filename: 'WIP.pdf',
+          status: 'IN_PROGRESS',
+        }),
+      ]),
+      isLoading: false,
+      isError: false,
+      error: null,
+      refetch: vi.fn(),
+      isFetching: false,
+    } as unknown as ReturnType<typeof useCorpusStatus>);
+
+    renderTab();
+    // Filter to COMPLETED only
+    fireEvent.change(screen.getByLabelText(/filter by status/i), {
+      target: { value: 'COMPLETED' },
+    });
+    // Click download
+    fireEvent.click(screen.getByRole('button', { name: /download csv/i }));
+
+    expect(mockDownloadCsv).toHaveBeenCalledTimes(1);
+    const args = mockDownloadCsv.mock.calls[0][0] as unknown as {
+      filename: string;
+      rows: CorpusStatusRow[];
+    };
+    expect(args.filename).toMatch(/^annotation-status-\d{4}-\d{2}-\d{2}\.csv$/);
+    expect(args.rows.length).toBe(1);
+    expect(args.rows[0].filename).toBe('Aulakh.pdf');
+  });
+
+  it('toggles sort direction when the same column header is clicked twice', () => {
+    mockUseCorpusStatus.mockReturnValue({
+      data: makeResponse([
+        makeRow({ filename: 'Aaaa.pdf' }),
+        makeRow({
+          serialNumber: 2,
+          documentId: 'doc-2',
+          filename: 'Zzzz.pdf',
+        }),
+      ]),
+      isLoading: false,
+      isError: false,
+      error: null,
+      refetch: vi.fn(),
+      isFetching: false,
+    } as unknown as ReturnType<typeof useCorpusStatus>);
+
+    const { container } = renderTab();
+    // Initially serialNumber asc → row order Aaaa, Zzzz
+    let rows = container.querySelectorAll('tbody tr');
+    expect(within(rows[0] as HTMLElement).getByText('Aaaa.pdf')).toBeInTheDocument();
+
+    // Click Title twice to reverse sort
+    fireEvent.click(screen.getByRole('button', { name: /^Title/ }));
+    fireEvent.click(screen.getByRole('button', { name: /^Title/ }));
+    rows = container.querySelectorAll('tbody tr');
+    expect(within(rows[0] as HTMLElement).getByText('Zzzz.pdf')).toBeInTheDocument();
+  });
+});

--- a/src/hooks/useCorpusStatus.ts
+++ b/src/hooks/useCorpusStatus.ts
@@ -1,0 +1,90 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  fetchCorpusStatus,
+  updateCorpusStatus,
+  type CorpusStatusResponse,
+  type CorpusStatusRow,
+  type UpdateCorpusStatusPayload,
+} from '../services/corpus-status.service';
+
+export const CORPUS_STATUS_KEYS = {
+  list: () => ['calibration', 'corpus-status'] as const,
+};
+
+export function useCorpusStatus() {
+  return useQuery({
+    queryKey: CORPUS_STATUS_KEYS.list(),
+    queryFn: fetchCorpusStatus,
+  });
+}
+
+interface UpdateVariables {
+  documentId: string;
+  payload: UpdateCorpusStatusPayload;
+}
+
+/**
+ * Optimistic update on the corpus-status list cache. On success, the server
+ * row replaces our optimistic patch; on error, we roll back to the snapshot.
+ */
+export function useUpdateCorpusStatus() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ documentId, payload }: UpdateVariables) =>
+      updateCorpusStatus(documentId, payload),
+    onMutate: async ({ documentId, payload }) => {
+      await queryClient.cancelQueries({ queryKey: CORPUS_STATUS_KEYS.list() });
+      const previous = queryClient.getQueryData<CorpusStatusResponse>(
+        CORPUS_STATUS_KEYS.list(),
+      );
+      if (previous) {
+        queryClient.setQueryData<CorpusStatusResponse>(
+          CORPUS_STATUS_KEYS.list(),
+          {
+            ...previous,
+            rows: previous.rows.map((row) =>
+              row.documentId === documentId
+                ? applyOptimisticPatch(row, payload)
+                : row,
+            ),
+          },
+        );
+      }
+      return { previous };
+    },
+    onError: (_err, _variables, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(CORPUS_STATUS_KEYS.list(), context.previous);
+      }
+    },
+    onSettled: () => {
+      // Always re-fetch after the mutation settles so derived fields
+      // (lastUpdatedAt, derived status, hoursSpent) reflect server state.
+      queryClient.invalidateQueries({ queryKey: CORPUS_STATUS_KEYS.list() });
+    },
+  });
+}
+
+/**
+ * Build an optimistic version of the row given a partial update payload.
+ * Mirrors what we expect the server to do: when statusOverride is set,
+ * surface it as the row's `status`; when cleared, leave the existing
+ * derived status in place until the refetch lands.
+ */
+function applyOptimisticPatch(
+  row: CorpusStatusRow,
+  payload: UpdateCorpusStatusPayload,
+): CorpusStatusRow {
+  const next: CorpusStatusRow = { ...row };
+  if (payload.statusOverride !== undefined) {
+    next.statusOverride = payload.statusOverride;
+    if (payload.statusOverride !== null) {
+      next.status = payload.statusOverride;
+    }
+  }
+  if (payload.statusNote !== undefined) {
+    next.statusNote = payload.statusNote.trim() || null;
+  }
+  next.lastUpdatedAt = new Date().toISOString();
+  return next;
+}

--- a/src/lib/__tests__/csv-export.test.ts
+++ b/src/lib/__tests__/csv-export.test.ts
@@ -66,4 +66,27 @@ describe('buildCsv', () => {
     });
     expect(csv).toBe('A\r\n');
   });
+
+  it('neutralizes formula-trigger characters to prevent CSV injection', () => {
+    const csv = buildCsv({
+      columns: [
+        { label: 'A', value: (r: { a: string }) => r.a },
+      ],
+      rows: [
+        { a: '=1+1' },           // = formula
+        { a: '+lookup()' },       // + formula
+        { a: '-cmd|/c calc' },    // - formula (the classic CSV injection)
+        { a: '@SUM(A1:A10)' },    // @ formula
+        { a: 'safe value' },      // benign — should not be prefixed
+      ],
+    });
+    expect(csv).toContain("'=1+1");
+    expect(csv).toContain("'+lookup()");
+    // The '-cmd|/c calc' value is escaped — needs quoting for the | being safe but the string still gets the single-quote prefix
+    expect(csv).toContain("'-cmd|/c calc");
+    expect(csv).toContain("'@SUM(A1:A10)");
+    // Benign value stays unmodified
+    expect(csv).toContain('safe value');
+    expect(csv).not.toContain("'safe value");
+  });
 });

--- a/src/lib/__tests__/csv-export.test.ts
+++ b/src/lib/__tests__/csv-export.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import { buildCsv } from '../csv-export';
+
+describe('buildCsv', () => {
+  it('emits a header row followed by data rows', () => {
+    const csv = buildCsv({
+      columns: [
+        { label: 'Title', value: (r: { title: string; pages: number }) => r.title },
+        { label: 'Pages', value: (r: { title: string; pages: number }) => r.pages },
+      ],
+      rows: [
+        { title: 'Aulakh', pages: 295 },
+        { title: 'Acharya', pages: 144 },
+      ],
+    });
+    expect(csv).toBe('Title,Pages\r\nAulakh,295\r\nAcharya,144\r\n');
+  });
+
+  it('quotes fields containing commas, quotes, or newlines', () => {
+    const csv = buildCsv({
+      columns: [
+        { label: 'A', value: (r: { a: string }) => r.a },
+      ],
+      rows: [
+        { a: 'simple' },
+        { a: 'has, comma' },
+        { a: 'has "quote"' },
+        { a: 'has\nnewline' },
+      ],
+    });
+    expect(csv).toContain('simple');
+    expect(csv).toContain('"has, comma"');
+    expect(csv).toContain('"has ""quote"""');
+    expect(csv).toContain('"has\nnewline"');
+  });
+
+  it('renders null/undefined as empty cells', () => {
+    const csv = buildCsv({
+      columns: [
+        { label: 'A', value: (r: { a: string | null | undefined }) => r.a },
+        { label: 'B', value: () => 'fixed' },
+      ],
+      rows: [
+        { a: null },
+        { a: undefined },
+      ],
+    });
+    expect(csv).toBe('A,B\r\n,fixed\r\n,fixed\r\n');
+  });
+
+  it('handles boolean and number cell values', () => {
+    const csv = buildCsv({
+      columns: [
+        { label: 'Done', value: (r: { done: boolean }) => r.done },
+        { label: 'Pages', value: (r: { pages: number }) => r.pages },
+      ],
+      rows: [{ done: true, pages: 42 }],
+    });
+    expect(csv).toBe('Done,Pages\r\ntrue,42\r\n');
+  });
+
+  it('handles an empty rows array (header only)', () => {
+    const csv = buildCsv({
+      columns: [{ label: 'A', value: () => '' }],
+      rows: [],
+    });
+    expect(csv).toBe('A\r\n');
+  });
+});

--- a/src/lib/csv-export.ts
+++ b/src/lib/csv-export.ts
@@ -32,10 +32,20 @@ export interface DownloadCsvOptions<TRow> {
  * Quote a single CSV field per RFC 4180:
  * - if the field contains a comma, double-quote, or newline, wrap in double quotes
  * - escape internal double quotes by doubling them
+ *
+ * Also neutralizes leading formula-trigger characters (=, +, -, @, \t, \r) by
+ * prefixing them with a single quote — protects against CSV injection when the
+ * file is opened in Excel or Google Sheets. Mirrors the convention used by
+ * `csvSafeEscape` in src/utils/format.ts.
  */
 function escapeCsvField(value: string | number | boolean | null | undefined): string {
   if (value === null || value === undefined) return '';
-  const str = String(value);
+  let str = String(value);
+  // Formula-trigger neutralization: any value starting with =, +, -, @, tab,
+  // or carriage return could be interpreted as a formula by spreadsheet apps.
+  if (/^[=+\-@\t\r]/.test(str)) {
+    str = `'${str}`;
+  }
   const needsQuoting = /[",\r\n]/.test(str);
   if (!needsQuoting) return str;
   return `"${str.replace(/"/g, '""')}"`;

--- a/src/lib/csv-export.ts
+++ b/src/lib/csv-export.ts
@@ -1,0 +1,80 @@
+/**
+ * Client-side CSV export.
+ *
+ * Takes a column definition + row data and triggers a browser download via
+ * Blob + URL.createObjectURL. Reusable across tables.
+ *
+ * Example:
+ *   downloadCsv({
+ *     columns: [
+ *       { key: 'title', label: 'Title' },
+ *       { key: 'pages', label: 'Total Pages', format: (v) => String(v) },
+ *     ],
+ *     rows: [{ title: 'Aulakh', pages: 295 }, ...],
+ *     filename: 'export.csv',
+ *   });
+ */
+
+export interface CsvColumn<TRow> {
+  /** The label that appears in the header row of the CSV. */
+  label: string;
+  /** A function that extracts the cell value from a row. */
+  value: (row: TRow) => string | number | boolean | null | undefined;
+}
+
+export interface DownloadCsvOptions<TRow> {
+  columns: ReadonlyArray<CsvColumn<TRow>>;
+  rows: ReadonlyArray<TRow>;
+  filename: string;
+}
+
+/**
+ * Quote a single CSV field per RFC 4180:
+ * - if the field contains a comma, double-quote, or newline, wrap in double quotes
+ * - escape internal double quotes by doubling them
+ */
+function escapeCsvField(value: string | number | boolean | null | undefined): string {
+  if (value === null || value === undefined) return '';
+  const str = String(value);
+  const needsQuoting = /[",\r\n]/.test(str);
+  if (!needsQuoting) return str;
+  return `"${str.replace(/"/g, '""')}"`;
+}
+
+/**
+ * Generate the CSV text for a set of columns + rows. Useful for testing
+ * (downloadCsv triggers a browser-only side effect).
+ */
+export function buildCsv<TRow>(options: Omit<DownloadCsvOptions<TRow>, 'filename'>): string {
+  const { columns, rows } = options;
+  const lines: string[] = [];
+  lines.push(columns.map((c) => escapeCsvField(c.label)).join(','));
+  for (const row of rows) {
+    lines.push(columns.map((c) => escapeCsvField(c.value(row))).join(','));
+  }
+  // Trailing newline per RFC 4180 convention
+  return lines.join('\r\n') + '\r\n';
+}
+
+/**
+ * Build the CSV and trigger a browser download.
+ *
+ * Skips silently if `window` is unavailable (server-side rendering, tests
+ * without jsdom). Caller should ensure rows are already filtered/sorted to
+ * match the visible table state.
+ */
+export function downloadCsv<TRow>(options: DownloadCsvOptions<TRow>): void {
+  if (typeof window === 'undefined' || typeof document === 'undefined') return;
+  const csv = buildCsv(options);
+  // BOM helps Excel detect UTF-8
+  const blob = new Blob(['﻿' + csv], { type: 'text/csv;charset=utf-8' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = options.filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  // Revoke async so the click has time to register
+  setTimeout(() => URL.revokeObjectURL(url), 0);
+}

--- a/src/pages/calibration/CorpusSummaryPage.tsx
+++ b/src/pages/calibration/CorpusSummaryPage.tsx
@@ -13,14 +13,16 @@ import { CorpusLineageTab } from '@/components/calibration/CorpusLineageTab';
 import { CorpusTimesheetTab } from '@/components/calibration/CorpusTimesheetTab';
 import type { DateRange } from '@/types/corpus-summary.types';
 import { renderMarkdown } from '@/lib/markdown';
+import { StatusTrackerTab } from '@/components/bootstrap/StatusTrackerTab';
 
-type CorpusTab = 'summary' | 'lineage' | 'timesheet' | 'cost';
+type CorpusTab = 'summary' | 'lineage' | 'timesheet' | 'cost' | 'status';
 
 const TABS: ReadonlyArray<{ id: CorpusTab; label: string }> = [
   { id: 'summary', label: 'Summary Report' },
   { id: 'lineage', label: 'Lineage' },
   { id: 'timesheet', label: 'Timesheet' },
   { id: 'cost', label: 'Cost Summary' },
+  { id: 'status', label: 'Status Tracker' },
 ];
 
 const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
@@ -69,7 +71,11 @@ export default function CorpusSummaryPage() {
   // URL state: ?tab, ?from, ?to. Defaults: summary tab, last 30 days.
   const initialTab: CorpusTab = useMemo(() => {
     const t = searchParams.get('tab');
-    return t === 'lineage' || t === 'timesheet' || t === 'cost' || t === 'summary'
+    return t === 'lineage' ||
+      t === 'timesheet' ||
+      t === 'cost' ||
+      t === 'summary' ||
+      t === 'status'
       ? t
       : 'summary';
   }, [searchParams]);
@@ -185,6 +191,8 @@ export default function CorpusSummaryPage() {
           error={summaryError}
         />
       )}
+
+      {activeTab === 'status' && <StatusTrackerTab />}
     </div>
   );
 }

--- a/src/services/__tests__/corpus-status.service.test.ts
+++ b/src/services/__tests__/corpus-status.service.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import { api } from '../api';
+import {
+  fetchCorpusStatus,
+  updateCorpusStatus,
+  ANNOTATION_STATUSES,
+  STATUS_LABELS,
+} from '../corpus-status.service';
+
+vi.mock('../api', () => ({
+  api: {
+    get: vi.fn(),
+    put: vi.fn(),
+  },
+}));
+
+describe('corpus-status.service', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('fetchCorpusStatus calls GET /calibration/corpus-status and returns unwrapped data', async () => {
+    const mockResponse = {
+      rows: [
+        {
+          serialNumber: 1,
+          documentId: 'doc-1',
+          filename: 'Aulakh.pdf',
+          pageCount: 295,
+          pagesAnnotated: 295,
+          status: 'COMPLETED',
+          statusOverride: null,
+          primaryAnnotator: { userId: 'u1', displayName: 'Poornakala U', email: 'p@example.com' },
+          otherAnnotatorCount: 0,
+          hoursSpent: 5.5,
+          lastUpdatedAt: '2026-04-29T10:00:00Z',
+          statusNote: null,
+        },
+      ],
+      generatedAt: '2026-05-08T12:00:00Z',
+    };
+    (api.get as Mock).mockResolvedValueOnce({ data: { data: mockResponse } });
+
+    const result = await fetchCorpusStatus();
+
+    expect(api.get).toHaveBeenCalledWith('/calibration/corpus-status');
+    expect(result).toEqual(mockResponse);
+    expect(result.rows[0].status).toBe('COMPLETED');
+  });
+
+  it('updateCorpusStatus PUTs to the right path and encodes documentId', async () => {
+    const mockRow = {
+      serialNumber: 2,
+      documentId: 'doc/with/slashes',
+      filename: 'Foo.pdf',
+      pageCount: 100,
+      pagesAnnotated: 50,
+      status: 'BLOCKED' as const,
+      statusOverride: 'BLOCKED' as const,
+      primaryAnnotator: null,
+      otherAnnotatorCount: 0,
+      hoursSpent: 0,
+      lastUpdatedAt: '2026-05-08T12:00:00Z',
+      statusNote: 'Engineering investigation pending',
+    };
+    (api.put as Mock).mockResolvedValueOnce({ data: { data: mockRow } });
+
+    const result = await updateCorpusStatus('doc/with/slashes', {
+      statusOverride: 'BLOCKED',
+      statusNote: 'Engineering investigation pending',
+    });
+
+    expect(api.put).toHaveBeenCalledWith(
+      '/admin/corpus/documents/doc%2Fwith%2Fslashes/status',
+      { statusOverride: 'BLOCKED', statusNote: 'Engineering investigation pending' },
+    );
+    expect(result).toEqual(mockRow);
+  });
+
+  it('updateCorpusStatus accepts null statusOverride to clear', async () => {
+    (api.put as Mock).mockResolvedValueOnce({ data: { data: {} } });
+    await updateCorpusStatus('doc-1', { statusOverride: null });
+    expect(api.put).toHaveBeenCalledWith(
+      '/admin/corpus/documents/doc-1/status',
+      { statusOverride: null },
+    );
+  });
+
+  it('exports the 5 expected statuses', () => {
+    expect(ANNOTATION_STATUSES).toEqual([
+      'NOT_STARTED',
+      'IN_PROGRESS',
+      'PENDING_REVIEW',
+      'COMPLETED',
+      'BLOCKED',
+    ]);
+  });
+
+  it('exports human-readable labels for each status', () => {
+    expect(STATUS_LABELS.NOT_STARTED).toBe('Not Started');
+    expect(STATUS_LABELS.IN_PROGRESS).toBe('In Progress');
+    expect(STATUS_LABELS.PENDING_REVIEW).toBe('Pending Review');
+    expect(STATUS_LABELS.COMPLETED).toBe('Complete');
+    expect(STATUS_LABELS.BLOCKED).toBe('Blocked');
+  });
+});

--- a/src/services/corpus-status.service.ts
+++ b/src/services/corpus-status.service.ts
@@ -1,0 +1,71 @@
+import { api } from './api';
+
+export type AnnotationStatus =
+  | 'NOT_STARTED'
+  | 'IN_PROGRESS'
+  | 'PENDING_REVIEW'
+  | 'COMPLETED'
+  | 'BLOCKED';
+
+export const ANNOTATION_STATUSES: ReadonlyArray<AnnotationStatus> = [
+  'NOT_STARTED',
+  'IN_PROGRESS',
+  'PENDING_REVIEW',
+  'COMPLETED',
+  'BLOCKED',
+];
+
+export const STATUS_LABELS: Record<AnnotationStatus, string> = {
+  NOT_STARTED: 'Not Started',
+  IN_PROGRESS: 'In Progress',
+  PENDING_REVIEW: 'Pending Review',
+  COMPLETED: 'Complete',
+  BLOCKED: 'Blocked',
+};
+
+export interface CorpusStatusAnnotator {
+  userId: string | null;
+  displayName: string;
+  email: string | null;
+}
+
+export interface CorpusStatusRow {
+  serialNumber: number;
+  documentId: string;
+  filename: string;
+  pageCount: number;
+  pagesAnnotated: number;
+  status: AnnotationStatus;
+  statusOverride: AnnotationStatus | null;
+  primaryAnnotator: CorpusStatusAnnotator | null;
+  otherAnnotatorCount: number;
+  hoursSpent: number;
+  lastUpdatedAt: string | null;
+  statusNote: string | null;
+}
+
+export interface CorpusStatusResponse {
+  rows: CorpusStatusRow[];
+  generatedAt: string;
+}
+
+export interface UpdateCorpusStatusPayload {
+  /** Pass null to clear the override and fall back to the derived status. */
+  statusOverride?: AnnotationStatus | null;
+  /** Max 500 characters; backend trims and validates. */
+  statusNote?: string;
+}
+
+export const fetchCorpusStatus = async (): Promise<CorpusStatusResponse> =>
+  (await api.get('/calibration/corpus-status')).data.data;
+
+export const updateCorpusStatus = async (
+  documentId: string,
+  payload: UpdateCorpusStatusPayload,
+): Promise<CorpusStatusRow> =>
+  (
+    await api.put(
+      `/admin/corpus/documents/${encodeURIComponent(documentId)}/status`,
+      payload,
+    )
+  ).data.data;


### PR DESCRIPTION
## Summary

Adds the **Status Tracker** tab to the Corpus Summary page — operational per-title status (pages annotated, status pill, primary annotator, hours, notes) alongside the existing analytical tabs. Replaces the manual CSV-via-email status workflow with an in-product, single-source-of-truth surface.

Consumes the new backend endpoints from `ninja-backend` PR #354 (deployed to staging earlier today):
- `GET /api/v1/calibration/corpus-status` — list aggregation
- `PUT /api/v1/admin/corpus/documents/:documentId/status` — status override + notes update

Spec: `Ninja-Documentation/Annotations/STATUS_TRACKER_TAB_SPEC.md`.

## Deliverables

### Service + types (`src/services/corpus-status.service.ts`)
- `AnnotationStatus` enum (5 values: `NOT_STARTED`, `IN_PROGRESS`, `PENDING_REVIEW`, `COMPLETED`, `BLOCKED`) + human-readable labels
- `CorpusStatusRow` shape matching the spec's API contract
- `fetchCorpusStatus()` + `updateCorpusStatus()` wrappers; documentId path-encoded for safety

### Hooks (`src/hooks/useCorpusStatus.ts`)
- `useCorpusStatus()` — list query
- `useUpdateCorpusStatus()` — mutation with optimistic update + rollback on error + invalidate on settle

### CSV export utility (`src/lib/csv-export.ts`)
- Reusable column-definition + row-data → download via Blob
- RFC 4180 quoting; UTF-8 BOM for Excel compatibility
- `buildCsv()` exported separately for testing

### UI components
- `StatusPill` — clickable pill with drop-down menu of the 5 statuses, colour-tone by status (gray / amber / violet / green / red), override indicator dot, saving spinner, click-outside / Escape to dismiss
- `StatusTrackerTab` — table with:
  - Sort on every column (toggle direction)
  - Filter by status, by annotator, search by title
  - Inline notes editing (textarea on click, save on blur or Cmd+Enter, max 500 chars)
  - CSV export of currently-filtered rows (filename: `annotation-status-YYYY-MM-DD.csv`)
  - Refresh button + last-refreshed timestamp footer
  - Loading / error / empty states

### Tests (20 new unit tests across 3 files, all passing)
- `corpus-status.service.test.ts` — 5 tests (path encoding, payload shape, exported constants)
- `csv-export.test.ts` — 5 tests (header, RFC 4180 escaping, null/undefined, empty rows)
- `StatusTrackerTab.test.tsx` — 10 RTL tests (loading, error, empty, render, filters, mutations, CSV download with filter, sort toggle)

### Wiring (`src/pages/calibration/CorpusSummaryPage.tsx`)
- 5th tab "Status Tracker" added to the existing `TABS` array
- URL state preserved (`?tab=status` survives reload)
- New render branch; no other tabs affected

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] 251 tests pass (20 new + 231 existing); 0 regressions
- [ ] Manual on staging — open `/corpus-summary?tab=status`:
  - All 17 corpus titles render with correct values for Pages, Status pill, Annotator, Hours
  - Sort toggles ascending / descending on every column
  - Filter by Status narrows visible rows; counter updates; combined filters AND
  - Status pill: click → dropdown opens → select → optimistic update + persist on refresh
  - Notes inline edit: click cell → textarea autofocus → blur saves; Cmd+Enter saves; Esc reverts
  - Long notes (600+ chars) truncate at 500; backend rejects invalid
  - CSV download with active filters → file contains only filtered rows; opens cleanly in Excel
  - Refresh button re-fetches without losing filter state
  - Status override fallback: clear override → row reverts to derived status

## Acceptance criteria from spec

All 12 criteria from the spec's "Acceptance criteria" section addressed; #5–#11 covered by automated tests, #1–#4 + #12 require staging walkthrough.

## Out of scope (per spec, deferred)

Audit trail / change log; Slack notifications; inline timesheet expansion on hover; bulk status edit; per-annotator dashboard view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Status Tracker tab with a searchable, filterable, sortable table of document statuses, pagination, loading/error states, and CSV export of the current view.
  * New interactive status pill UI with read-only/override indicators, save spinner, clear-override action, and inline note editing.

* **Tests**
  * Comprehensive tests added for status tracker behaviors, CSV export formatting, and service calls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->