### PR TITLE
fix(calibration): rein in logo size and table overflow in word export

### DIFF
--- a/src/lib/__tests__/word-export.test.ts
+++ b/src/lib/__tests__/word-export.test.ts
@@ -45,6 +45,22 @@ describe('buildCorpusSummaryWordDoc', () => {
     expect(out).toContain('alt="Ninja"');
   });
 
+  it('pins logo dimensions inline so Word respects the size cap', () => {
+    const out = buildCorpusSummaryWordDoc(baseInput);
+    // Word ignores class selectors on <img>; verify each logo carries inline
+    // height + max-width so the banner-shaped Ninja logo cannot blow past the
+    // page margin.
+    expect(out).toMatch(/alt="S4Carlisle"[^>]*style="[^"]*height:36pt[^"]*max-width:160pt/);
+    expect(out).toMatch(/alt="Ninja"[^>]*style="[^"]*height:36pt[^"]*max-width:200pt/);
+  });
+
+  it('uses fixed table-layout so wide content tables stay within page margins', () => {
+    const out = buildCorpusSummaryWordDoc(baseInput);
+    expect(out).toContain('table-layout: fixed');
+    // The header row must keep auto layout so logo cells size to content.
+    expect(out).toMatch(/table\.header-row\s*{[^}]*table-layout:\s*auto/);
+  });
+
   it('falls back to text labels when a logo data URI is null', () => {
     const out = buildCorpusSummaryWordDoc({
       ...baseInput,

--- a/src/lib/word-export.ts
+++ b/src/lib/word-export.ts
@@ -67,13 +67,17 @@ export function buildCorpusSummaryWordDoc(input: CorpusSummaryWordDocInput): str
   const safeModelName = escapeHtml(modelName);
   const safeToday = escapeHtml(today);
 
+  // Word's CSS support for class selectors on <img> is unreliable, so logo
+  // dimensions are pinned with inline `width`/`height` attributes (in pixels;
+  // ~1pt = 1.333px). Both logos are scaled to a similar visual height; the
+  // Ninja banner is wider so it gets a larger width budget.
   const s4HeaderCell = s4LogoDataUri
-    ? `<img class="header-logo" src="${s4LogoDataUri}" alt="S4Carlisle" />`
-    : `<span style="font-weight:bold;color:#1a1a1a;">S4Carlisle</span>`;
+    ? `<img src="${s4LogoDataUri}" alt="S4Carlisle" width="120" height="48" style="height:36pt;width:auto;max-width:160pt;" />`
+    : `<span style="font-weight:bold;color:#1a1a1a;font-size:14pt;">S4Carlisle</span>`;
 
   const ninjaHeaderCell = ninjaLogoDataUri
-    ? `<img class="header-logo" src="${ninjaLogoDataUri}" alt="Ninja" />`
-    : `<span style="font-weight:bold;color:#006B6B;">Ninja</span>`;
+    ? `<img src="${ninjaLogoDataUri}" alt="Ninja" width="160" height="48" style="height:36pt;width:auto;max-width:200pt;" />`
+    : `<span style="font-weight:bold;color:#006B6B;font-size:14pt;">Ninja</span>`;
 
   return `<html xmlns:o="urn:schemas-microsoft-com:office:office"
       xmlns:w="urn:schemas-microsoft-com:office:word"
@@ -88,14 +92,17 @@ export function buildCorpusSummaryWordDoc(input: CorpusSummaryWordDocInput): str
     h3 { font-size: 12pt; font-weight: 600; color: #1a1a1a; margin-top: 16pt; margin-bottom: 6pt; }
     h4 { font-size: 11pt; font-weight: 600; color: #1a1a1a; margin-top: 12pt; margin-bottom: 4pt; }
     p { font-size: 11pt; color: #374151; margin-bottom: 4pt; }
-    table { width: 100%; border-collapse: collapse; margin: 12pt 0; }
-    th { border: 1px solid #d1d5db; padding: 6pt 10pt; text-align: left; font-weight: 600; background-color: #f9fafb; color: #374151; font-size: 10pt; }
-    td { border: 1px solid #d1d5db; padding: 6pt 10pt; color: #4b5563; font-size: 10pt; }
+    /* table-layout:fixed forces Word to honor width:100% and distribute columns
+       evenly instead of letting content widths blow past the page margin. */
+    table { width: 100%; table-layout: fixed; border-collapse: collapse; margin: 12pt 0; word-wrap: break-word; }
+    th { border: 1px solid #d1d5db; padding: 4pt 6pt; text-align: left; font-weight: 600; background-color: #f9fafb; color: #374151; font-size: 9pt; word-wrap: break-word; }
+    td { border: 1px solid #d1d5db; padding: 4pt 6pt; color: #4b5563; font-size: 9pt; word-wrap: break-word; }
     li { font-size: 11pt; color: #374151; margin-left: 16pt; margin-bottom: 2pt; }
     hr { border: none; border-top: 1px solid #e5e7eb; margin: 16pt 0; }
-    table.header-row { width: 100%; margin: 0 0 24pt 0; padding-bottom: 12pt; border-bottom: 2px solid #006B6B; }
+    /* Header row uses auto layout (not fixed) so the logo cells size to the
+       images instead of being squeezed to 50/50. */
+    table.header-row { width: 100%; table-layout: auto; margin: 0 0 24pt 0; padding-bottom: 12pt; border-bottom: 2px solid #006B6B; }
     table.header-row td { border: none; padding: 0; vertical-align: middle; }
-    .header-logo { height: 50pt; }
     .title-block { margin-bottom: 24pt; }
     .title-block h1 { margin-top: 0; margin-bottom: 4pt; }
     .title-block .meta { color: #6b7280; font-size: 9pt; margin-bottom: 0; }


### PR DESCRIPTION
## Summary
Follow-up to PR #258 — fixes two layout regressions visible in the first export downloads:

- **Logos**: the Ninja banner-shaped logo rendered at native size and bled past the right page margin. Word ignores class selectors on `<img>`, so dimensions are now pinned with inline `style="height:36pt;width:auto;max-width:…"` plus HTML `width`/`height` attributes for fallback.
- **Tables**: wide multi-column tables (e.g. cost / zone breakdowns) overflowed the 6.5" content area because `width:100%` is ignored without `table-layout:fixed`. Added `table-layout:fixed` + `word-wrap:break-word`, dropped padding to `4pt 6pt`, and reduced cell font to 9pt. The branded header row keeps `table-layout:auto` so logo cells size to their content.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean (max-warnings 0)
- [x] `npx vitest run src/lib/__tests__/word-export.test.ts` — 9 passed (2 new tests assert inline logo sizing + fixed table-layout)
- [ ] Manual: re-export Corpus Summary on staging, open in Word — both logos sit on a single header row within the page margins; report tables fit within content area without horizontal overflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved Word document export with better logo image sizing and inline styling.
  * Enhanced table layout handling to ensure consistent formatting and proper page margins in Microsoft Word exports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->