### PR TITLE
fix(bootstrap): mark complete defaults to total page count

### DIFF
--- a/docs/ANNOTATORS_GUIDE.md
+++ b/docs/ANNOTATORS_GUIDE.md
@@ -48,7 +48,7 @@ Click **Mark Complete** in the Zone Review toolbar when you've finished reviewin
 The Mark Complete modal has three sections:
 
 1. **Pages reviewed** (required, integer ≥ 1).  
-   The modal pre-fills this with the count of pages where you actually corrected at least one zone — *not* the document's total page count. **You almost always need to raise this number** to reflect every page you reviewed, including pages where you implicitly accepted every AI decision (and so didn't touch any zone). For most titles, the right value is the document's total page count minus any pages categorized as Empty Pages or genuinely out-of-scope. Only leave it lower than that if you really did stop part-way through.
+   The modal pre-fills this with the document's total page count, which is the right value for the common case where you reviewed every page — including pages where you implicitly accepted every AI decision and didn't touch any zone. **Only adjust it downward if you genuinely stopped part-way through** (e.g., you reviewed pages 1–120 of a 295-page title and need to log progress before handing off). Leaving the default in place is correct for "I'm done with this title."
 
 2. **Issues encountered** (optional, repeatable).  
    Pick a category from the dropdown for any structural problem you ran into (page-alignment mismatch, single-extractor coverage, content divergence, etc.). The category list mirrors the patterns the calibration team rolls up into the corpus lineage report. **Mark an issue as "Blocking" only if the title cannot be considered done because of it.** Use the description field to add specific page numbers or workarounds.

--- a/docs/ANNOTATORS_GUIDE.md
+++ b/docs/ANNOTATORS_GUIDE.md
@@ -206,7 +206,7 @@ For each page, pick a category:
 - **Front matter / back matter** — title page, dedication, colophon, index page that doesn't need annotation.
 - **Other** — anything else; add a short note.
 
-The categorization is saved per-page and rolls up into the lineage report. Empty pages **do not** count toward the page total for completion — they are excluded from the `pageCount` denominator the Status Tracker uses, so they will not block a title from showing "Complete."
+The categorization is saved per-page and rolls up into the lineage report. Empty pages are still part of the document's `pageCount`, so the Mark Complete default of "total page count" includes them. That's intentional — categorizing a page as Empty is a form of reviewing it (you confirmed there's no content to annotate). The Status Tracker uses the same `pageCount`, so a title where every page is either zone-annotated or categorized empty will show as Complete on Mark Complete with the default value.
 
 ---
 

--- a/src/components/bootstrap/ZoneReviewWorkspace.tsx
+++ b/src/components/bootstrap/ZoneReviewWorkspace.tsx
@@ -957,7 +957,14 @@ export default function ZoneReviewWorkspace({
         onSubmit={handleSubmitMarkComplete}
         documentName={docId}
         totalPages={numPages}
-        defaultPagesReviewed={pagesReviewed}
+        // Default to the document's total page count: Mark Complete now drives
+        // the Status Tracker derivation, so "I reviewed everything" should be
+        // a single click. Annotators adjust down only on the rare title where
+        // they genuinely stopped part-way. (Previously defaulted to
+        // `pagesReviewed`, the count of pages with at least one corrected
+        // zone, which under-counted any page where the annotator implicitly
+        // accepted every AI decision.)
+        defaultPagesReviewed={numPages}
         zonesReviewed={allZones.filter((z) => z.operatorVerified).length}
         totalZones={allZones.length}
         isSubmitting={completing}


### PR DESCRIPTION
## Summary
One-line behaviour fix to the Mark Complete modal. Previously it pre-filled "Pages reviewed" with the count of pages that had at least one `operatorVerified` zone (`pagesReviewed`). That was fine when the field was informational, but after backend PR `#355` made it the load-bearing input for Status Tracker derivation, the under-counted default biases titles toward false "In Progress" unless the annotator manually raises the number every time.

Switches the default to `numPages` so:

- The common case ("I'm done with this title, including pages I implicitly accepted") becomes a single-click confirm.
- The exception case ("I stopped at page 120 of 295 and need to log progress") still works — annotators adjust downward.
- The Status Tracker no longer needs override compensation for the implicit-accept gap.

Updates `docs/ANNOTATORS_GUIDE.md` so the pre-fill section matches the new behaviour.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean (max-warnings 0)
- [x] `npx vitest run` — 712 passed, 10 skipped, no regressions
- [ ] Manual: open Zone Review on any title, click Mark Complete, confirm "Pages reviewed" pre-fills with the document's total page count (not the lower verified-zone count)
- [ ] Manual: confirm a Mark Complete using the default leaves the title at `Complete` on Status Tracker after refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The "Mark Complete" modal now pre-fills with the document's total page count, including pages already accepted by automated decisions; reduce the number only if you stop part-way.

* **Documentation**
  * Clarified "Mark Complete" guidance to match the new default.
  * Clarified empty-page triage now counts toward the document page total, and marking all pages reviewed or empty will show as Complete.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->