### PR TITLE
feat(audit): surface publisher profile badge on EPUB audit results

### DIFF
--- a/src/components/audit/PublisherProfileBadge.tsx
+++ b/src/components/audit/PublisherProfileBadge.tsx
@@ -60,10 +60,12 @@ export function PublisherProfileBadge({ profile }: PublisherProfileBadgeProps) {
   const [isOpen, setIsOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement | null>(null);
 
-  // Close on outside click / Escape so the popover behaves like a menu.
+  // Close on outside tap / Escape so the popover behaves like a menu.
+  // `pointerdown` covers mouse, touch, and pen — `mousedown` would miss
+  // outside-tap dismiss on touch devices.
   useEffect(() => {
     if (!isOpen) return;
-    const handleClick = (e: MouseEvent) => {
+    const handlePointerDown = (e: PointerEvent) => {
       if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
         setIsOpen(false);
       }
@@ -71,10 +73,10 @@ export function PublisherProfileBadge({ profile }: PublisherProfileBadgeProps) {
     const handleKey = (e: KeyboardEvent) => {
       if (e.key === 'Escape') setIsOpen(false);
     };
-    document.addEventListener('mousedown', handleClick);
+    document.addEventListener('pointerdown', handlePointerDown);
     document.addEventListener('keydown', handleKey);
     return () => {
-      document.removeEventListener('mousedown', handleClick);
+      document.removeEventListener('pointerdown', handlePointerDown);
       document.removeEventListener('keydown', handleKey);
     };
   }, [isOpen]);

--- a/src/components/audit/PublisherProfileBadge.tsx
+++ b/src/components/audit/PublisherProfileBadge.tsx
@@ -1,0 +1,138 @@
+/**
+ * Surfaces the backend-detected publisher profile (today: PRH UK + imprint)
+ * on the audit-results page so reviewers see at a glance that publisher-
+ * specific validators ran. Click-toggles a popover showing the detection
+ * signals so reviewers can answer "why does this EPUB show as Vintage?".
+ *
+ * Renders nothing when:
+ *   - the field is absent (older audit results), or
+ *   - publisher is null (no profile detected), or
+ *   - confidence is 'low' (the signals are too weak to call out).
+ */
+
+import { useEffect, useRef, useState } from 'react';
+import { Building2 } from 'lucide-react';
+import { Badge } from '../ui/Badge';
+
+export type PublisherProfileImprint =
+  | 'penguin'
+  | 'puffin'
+  | 'vintage'
+  | 'pelican'
+  | 'ladybird'
+  | 'merky'
+  | 'cornerstone-saga'
+  | 'unknown';
+
+export interface PublisherProfileSignal {
+  id: string;
+  description: string;
+  strength: 'strong' | 'moderate' | 'weak';
+}
+
+export interface PublisherProfile {
+  publisher: 'PRH-UK' | null;
+  imprint: PublisherProfileImprint | null;
+  confidence: 'high' | 'medium' | 'low';
+  signals: PublisherProfileSignal[];
+}
+
+interface PublisherProfileBadgeProps {
+  profile: PublisherProfile | null | undefined;
+}
+
+const STRENGTH_STYLES: Record<PublisherProfileSignal['strength'], string> = {
+  strong: 'bg-green-700 text-green-50',
+  moderate: 'bg-amber-600 text-amber-50',
+  weak: 'bg-gray-600 text-gray-100',
+};
+
+function formatImprint(imprint: PublisherProfileImprint | null): string {
+  if (!imprint || imprint === 'unknown') return '';
+  // 'cornerstone-saga' -> 'Cornerstone Saga', 'penguin' -> 'Penguin'
+  return imprint
+    .split('-')
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+}
+
+export function PublisherProfileBadge({ profile }: PublisherProfileBadgeProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  // Close on outside click / Escape so the popover behaves like a menu.
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleClick = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setIsOpen(false);
+    };
+    document.addEventListener('mousedown', handleClick);
+    document.addEventListener('keydown', handleKey);
+    return () => {
+      document.removeEventListener('mousedown', handleClick);
+      document.removeEventListener('keydown', handleKey);
+    };
+  }, [isOpen]);
+
+  if (!profile || profile.publisher !== 'PRH-UK' || profile.confidence === 'low') {
+    return null;
+  }
+
+  const imprintLabel = formatImprint(profile.imprint);
+  const label = imprintLabel ? `PRH UK · ${imprintLabel}` : 'PRH UK';
+
+  return (
+    <div ref={containerRef} className="relative inline-block">
+      <Badge
+        as="button"
+        variant="info"
+        size="md"
+        onClick={() => setIsOpen((v) => !v)}
+        aria-expanded={isOpen}
+        aria-haspopup="dialog"
+        className="gap-1.5"
+      >
+        <Building2 className="w-3.5 h-3.5" aria-hidden="true" />
+        {label}
+      </Badge>
+
+      {isOpen && (
+        <div
+          role="dialog"
+          aria-label="Publisher detection signals"
+          className="absolute z-50 left-0 top-full mt-2 w-80 bg-white border border-gray-200 rounded-lg shadow-xl p-4"
+        >
+          <div className="flex items-baseline justify-between mb-3">
+            <h3 className="text-sm font-semibold text-gray-900">Detection signals</h3>
+            <span className="text-xs text-gray-500">
+              Confidence: <span className="font-medium capitalize">{profile.confidence}</span>
+            </span>
+          </div>
+          {profile.signals.length === 0 ? (
+            <p className="text-xs text-gray-500 italic">No signals reported.</p>
+          ) : (
+            <ul className="space-y-2">
+              {profile.signals.map((signal) => (
+                <li key={signal.id} className="flex items-start gap-2 text-xs">
+                  <span
+                    className={`shrink-0 mt-0.5 px-1.5 py-0.5 rounded uppercase tracking-wide font-semibold ${
+                      STRENGTH_STYLES[signal.strength]
+                    }`}
+                  >
+                    {signal.strength}
+                  </span>
+                  <span className="text-gray-700 leading-snug">{signal.description}</span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/audit/PublisherProfileBadge.tsx
+++ b/src/components/audit/PublisherProfileBadge.tsx
@@ -60,11 +60,23 @@ export function PublisherProfileBadge({ profile }: PublisherProfileBadgeProps) {
   const [isOpen, setIsOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement | null>(null);
 
+  const shouldRender =
+    !!profile && profile.publisher === 'PRH-UK' && profile.confidence !== 'low';
+
+  // If the badge stops rendering (e.g. the audit refetches with a profile that
+  // has dropped below our threshold) while the popover was open, snap state
+  // back to closed so the popover doesn't re-appear "open" if the badge
+  // becomes visible again later.
+  useEffect(() => {
+    if (!shouldRender && isOpen) setIsOpen(false);
+  }, [shouldRender, isOpen]);
+
   // Close on outside tap / Escape so the popover behaves like a menu.
   // `pointerdown` covers mouse, touch, and pen — `mousedown` would miss
-  // outside-tap dismiss on touch devices.
+  // outside-tap dismiss on touch devices. Skip the listeners entirely when
+  // the badge isn't being rendered.
   useEffect(() => {
-    if (!isOpen) return;
+    if (!isOpen || !shouldRender) return;
     const handlePointerDown = (e: PointerEvent) => {
       if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
         setIsOpen(false);
@@ -79,9 +91,9 @@ export function PublisherProfileBadge({ profile }: PublisherProfileBadgeProps) {
       document.removeEventListener('pointerdown', handlePointerDown);
       document.removeEventListener('keydown', handleKey);
     };
-  }, [isOpen]);
+  }, [isOpen, shouldRender]);
 
-  if (!profile || profile.publisher !== 'PRH-UK' || profile.confidence === 'low') {
+  if (!shouldRender || !profile) {
     return null;
   }
 

--- a/src/components/audit/__tests__/PublisherProfileBadge.test.tsx
+++ b/src/components/audit/__tests__/PublisherProfileBadge.test.tsx
@@ -94,4 +94,24 @@ describe('PublisherProfileBadge', () => {
     await userEvent.click(screen.getByRole('button', { name: /PRH UK/i }));
     expect(screen.getByRole('dialog')).toHaveTextContent(/No signals reported/i);
   });
+
+  it('snaps the popover closed if the profile drops below the render threshold while open', async () => {
+    const { rerender } = render(<PublisherProfileBadge profile={makeProfile()} />);
+    await userEvent.click(screen.getByRole('button', { name: /PRH UK/i }));
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+
+    // Audit refetch returns a low-confidence profile — badge should hide.
+    rerender(<PublisherProfileBadge profile={makeProfile({ confidence: 'low' })} />);
+    expect(screen.queryByRole('button', { name: /PRH UK/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+
+    // Refetch returns a high-confidence profile again — badge reappears
+    // closed, not silently still-open from before.
+    rerender(<PublisherProfileBadge profile={makeProfile()} />);
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /PRH UK/i })).toHaveAttribute(
+      'aria-expanded',
+      'false',
+    );
+  });
 });

--- a/src/components/audit/__tests__/PublisherProfileBadge.test.tsx
+++ b/src/components/audit/__tests__/PublisherProfileBadge.test.tsx
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {
+  PublisherProfileBadge,
+  type PublisherProfile,
+} from '../PublisherProfileBadge';
+
+const sampleSignals = [
+  { id: 's1', description: 'dc:publisher contains "Penguin Random House UK"', strength: 'strong' as const },
+  { id: 's2', description: 'spine starts with cover then frontmatter', strength: 'moderate' as const },
+];
+
+function makeProfile(overrides: Partial<PublisherProfile> = {}): PublisherProfile {
+  return {
+    publisher: 'PRH-UK',
+    imprint: 'vintage',
+    confidence: 'high',
+    signals: sampleSignals,
+    ...overrides,
+  };
+}
+
+describe('PublisherProfileBadge', () => {
+  it('renders nothing when the profile is missing', () => {
+    const { container } = render(<PublisherProfileBadge profile={undefined} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders nothing when publisher is null (no profile detected)', () => {
+    const { container } = render(
+      <PublisherProfileBadge
+        profile={{ publisher: null, imprint: null, confidence: 'high', signals: [] }}
+      />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders nothing when confidence is low', () => {
+    const { container } = render(
+      <PublisherProfileBadge profile={makeProfile({ confidence: 'low' })} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('shows "PRH UK · Vintage" when publisher and imprint are detected', () => {
+    render(<PublisherProfileBadge profile={makeProfile()} />);
+    expect(screen.getByRole('button', { name: /PRH UK · Vintage/i })).toBeInTheDocument();
+  });
+
+  it('shows just "PRH UK" when imprint is unknown', () => {
+    render(<PublisherProfileBadge profile={makeProfile({ imprint: 'unknown' })} />);
+    const button = screen.getByRole('button', { name: /^PRH UK$/i });
+    expect(button).toBeInTheDocument();
+  });
+
+  it('formats hyphenated imprint names with title casing', () => {
+    render(
+      <PublisherProfileBadge profile={makeProfile({ imprint: 'cornerstone-saga' })} />,
+    );
+    expect(
+      screen.getByRole('button', { name: /PRH UK · Cornerstone Saga/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('opens the signals popover on click and closes again', async () => {
+    render(<PublisherProfileBadge profile={makeProfile()} />);
+    const button = screen.getByRole('button', { name: /PRH UK/i });
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+
+    await userEvent.click(button);
+    const dialog = screen.getByRole('dialog', { name: /Publisher detection signals/i });
+    expect(dialog).toBeInTheDocument();
+    expect(dialog).toHaveTextContent('dc:publisher contains "Penguin Random House UK"');
+    expect(dialog).toHaveTextContent('spine starts with cover then frontmatter');
+    // Strength chips render with their label
+    expect(dialog).toHaveTextContent(/strong/i);
+    expect(dialog).toHaveTextContent(/moderate/i);
+
+    await userEvent.click(button);
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('reflects open state via aria-expanded for assistive tech', async () => {
+    render(<PublisherProfileBadge profile={makeProfile()} />);
+    const button = screen.getByRole('button', { name: /PRH UK/i });
+    expect(button).toHaveAttribute('aria-expanded', 'false');
+    await userEvent.click(button);
+    expect(button).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('shows a graceful empty state when there are zero signals', async () => {
+    render(<PublisherProfileBadge profile={makeProfile({ signals: [] })} />);
+    await userEvent.click(screen.getByRole('button', { name: /PRH UK/i }));
+    expect(screen.getByRole('dialog')).toHaveTextContent(/No signals reported/i);
+  });
+});

--- a/src/components/audit/index.ts
+++ b/src/components/audit/index.ts
@@ -6,5 +6,11 @@ export { EpubViewer } from './EpubViewer';
 export { ViewInContextButton } from './ViewInContextButton';
 export { RemediationGuidance } from './RemediationGuidance';
 export { ScoreTooltip } from './ScoreTooltip';
+export { PublisherProfileBadge } from './PublisherProfileBadge';
+export type {
+  PublisherProfile,
+  PublisherProfileSignal,
+  PublisherProfileImprint,
+} from './PublisherProfileBadge';
 export { calculateScoreBreakdown } from '@/lib/score-utils';
 export type { ScoreBreakdown } from '@/lib/score-utils';

--- a/src/components/epub/EPUBAuditResults.tsx
+++ b/src/components/epub/EPUBAuditResults.tsx
@@ -13,8 +13,8 @@ import { Button } from '../ui/Button';
 import { Badge } from '../ui/Badge';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '../ui/Tabs';
 import { QuickRating } from '../feedback';
-import { SourceBadge, SummaryBySource, ViewInContextButton, RemediationGuidance, ScoreTooltip, calculateScoreBreakdown } from '../audit';
-import type { SummaryBySourceData } from '../audit';
+import { SourceBadge, SummaryBySource, ViewInContextButton, RemediationGuidance, ScoreTooltip, PublisherProfileBadge, calculateScoreBreakdown } from '../audit';
+import type { SummaryBySourceData, PublisherProfile } from '../audit';
 import { cn } from '@/utils/cn';
 import { getWcagUrl, getWcagTooltip, formatWcagLabel } from '@/utils/wcag';
 
@@ -49,6 +49,7 @@ interface AuditResult {
   };
   issues: AuditIssue[];
   summaryBySource?: SummaryBySourceData;
+  publisherProfile?: PublisherProfile | null;
   stats?: {
     byFixType?: {
       auto: number;
@@ -332,12 +333,15 @@ export const EPUBAuditResults: React.FC<EPUBAuditResultsProps> = ({
 
   return (
     <div className="space-y-6">
+      {result.publisherProfile && (
+        <PublisherProfileBadge profile={result.publisherProfile} />
+      )}
       <Card>
         <CardHeader>
           <CardTitle>Issues by Source</CardTitle>
         </CardHeader>
         <CardContent>
-          <SummaryBySource 
+          <SummaryBySource
             summaryBySource={summaryBySource} 
             onSourceClick={handleSourceClick}
           />

--- a/src/pages/EPUBAccessibility.tsx
+++ b/src/pages/EPUBAccessibility.tsx
@@ -142,6 +142,7 @@ export const EPUBAccessibility: React.FC = () => {
         accessibilityScore: data.accessibilityScore ?? 72,
         issuesSummary: data.issuesSummary || calculatedSummary,
         issues: apiIssues,
+        publisherProfile: data.publisherProfile ?? null,
         stats: fixTypeStats ? { byFixType: fixTypeStats } : undefined,
       };
       setAuditResult(fullResult);
@@ -225,6 +226,7 @@ export const EPUBAccessibility: React.FC = () => {
         accessibilityScore: data.accessibilityScore ?? summary.accessibilityScore ?? 72,
         issuesSummary: data.issuesSummary || calculatedSummary,
         issues: apiIssues.length > 0 ? apiIssues : (isDemoJob ? generateDemoIssues(issuesSummary) : []),
+        publisherProfile: data.publisherProfile ?? null,
         stats: fixTypeStats ? { byFixType: fixTypeStats } : undefined,
       };
       setAuditResult(fullResult);


### PR DESCRIPTION
## Summary
First of five frontend follow-ups to the PRH UK backend work (P1-Frontend-Followups.md, prompt 1). The backend (PRs #356-#361) now returns a `publisherProfile` field on every EPUB audit result. This PR surfaces that field as a small clickable badge at the top of the audit-results page so reviewers can see at a glance that publisher-specific validators ran.

**Behaviour:**
- Renders **"PRH UK · {Imprint}"** when `publisher === 'PRH-UK'` and `confidence !== 'low'` (e.g., "PRH UK · Vintage", "PRH UK · Cornerstone Saga").
- Renders just **"PRH UK"** when the imprint is `'unknown'`.
- Renders **nothing** when the field is absent (older audit results), `publisher` is null, or confidence is low — the signals are too weak to call out.
- Click-toggles a popover listing the detection signals with description + strength chips, so reviewers can answer "why does this EPUB show as Vintage?". Click-outside and Escape both close.

**Out of scope (covered by later prompts):**
- PRH-prefixed issue codes and `'prh-uk'` source filter (Prompt 2).
- `PRH-COVER-ALT-EMPTY` quick-fix dialog wiring (Prompt 3).
- "PRH UK Edition" VPAT dropdown + Certification block (Prompt 4).

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean (max-warnings 0)
- [x] `npx vitest run` — 721 passed, 10 skipped (9 new tests for the badge: conditional rendering for missing/null/low-confidence, imprint name formatting incl. hyphenated `cornerstone-saga`, popover open/close, signals list, empty-state, `aria-expanded`)
- [ ] Manual: upload a PRH EPUB on staging — confirm "PRH UK · Penguin/Vintage/etc." appears at the top of the audit-results card; click the badge → signals list opens; click outside → closes.
- [ ] Manual: upload a non-PRH EPUB → confirm no badge renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a publisher profile badge that surfaces PRH‑UK detection on audit pages.
  * Badge displays confidence and an interactive popover listing detection signals with strength labels; it auto-closes on outside click, Esc, or if the profile becomes ineligible.
  * Audit results and the EPUB accessibility page now surface publisher profile data when available.

* **Tests**
  * Added tests covering rendering, labeling, empty states, popover behavior, and dynamic threshold changes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/s4cindia/ninja-frontend/pull/263)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->