### PR TITLE
feat(audit): display PRH-UK source and issues distinctly

### DIFF
--- a/src/components/audit/SourceBadge.tsx
+++ b/src/components/audit/SourceBadge.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { cn } from '@/utils/cn';
 
-export type IssueSource = 'epubcheck' | 'ace' | 'js-auditor';
+export type IssueSource = 'epubcheck' | 'ace' | 'js-auditor' | 'prh-uk';
 
 interface SourceBadgeProps {
   source: IssueSource | string;
@@ -20,6 +20,12 @@ const SOURCE_CONFIG: Record<string, { label: string; colors: string }> = {
   'js-auditor': {
     label: 'JS Auditor',
     colors: 'bg-green-100 text-green-800',
+  },
+  // Distinct teal so PRH UK issues are recognisable at a glance among the
+  // generic source badges (blue/purple/green).
+  'prh-uk': {
+    label: 'PRH UK',
+    colors: 'bg-teal-100 text-teal-800',
   },
   manual: {
     label: 'Manual',

--- a/src/components/audit/SummaryBySource.tsx
+++ b/src/components/audit/SummaryBySource.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { FileCode, Eye, Wrench } from 'lucide-react';
+import { FileCode, Eye, Wrench, Building2 } from 'lucide-react';
 import { Card, CardContent } from '../ui/Card';
 import { cn } from '@/utils/cn';
 
@@ -14,19 +14,22 @@ export interface SourceSummary {
   fixable?: number; // Combined auto + quickfix count
 }
 
+export type SourceKey = 'epubcheck' | 'ace' | 'js-auditor' | 'prh-uk';
+
 export interface SummaryBySourceData {
   epubcheck?: SourceSummary;
   ace?: SourceSummary;
   'js-auditor'?: SourceSummary;
+  'prh-uk'?: SourceSummary;
 }
 
 interface SummaryBySourceProps {
   summaryBySource: SummaryBySourceData;
-  onSourceClick?: (source: 'epubcheck' | 'ace' | 'js-auditor') => void;
+  onSourceClick?: (source: SourceKey) => void;
 }
 
 interface SourceCardProps {
-  source: 'epubcheck' | 'ace' | 'js-auditor';
+  source: SourceKey;
   title: string;
   subtitle: string;
   data: SourceSummary;
@@ -150,6 +153,17 @@ const SOURCE_CONFIG = {
       border: 'border-green-200',
     },
   },
+  'prh-uk': {
+    title: 'PRH UK',
+    subtitle: 'Publisher-specific Checks',
+    icon: <Building2 className="h-5 w-5" />,
+    theme: {
+      bg: 'bg-teal-50',
+      accent: 'text-teal-600',
+      text: 'text-teal-900',
+      border: 'border-teal-200',
+    },
+  },
 };
 
 const EMPTY_SUMMARY: SourceSummary = {
@@ -164,10 +178,20 @@ export const SummaryBySource: React.FC<SummaryBySourceProps> = ({
   summaryBySource,
   onSourceClick,
 }) => {
-  const sources: Array<'epubcheck' | 'ace' | 'js-auditor'> = ['epubcheck', 'ace', 'js-auditor'];
+  // PRH UK is publisher-specific — only render the card when the backend
+  // actually reported issues for it, so non-PRH audits don't pick up an
+  // empty 4th card cluttering the grid.
+  const hasPrhIssues = (summaryBySource['prh-uk']?.total ?? 0) > 0;
+  const sources: SourceKey[] = hasPrhIssues
+    ? ['epubcheck', 'ace', 'js-auditor', 'prh-uk']
+    : ['epubcheck', 'ace', 'js-auditor'];
+  const gridCols =
+    sources.length === 4
+      ? 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-4'
+      : 'grid-cols-1 sm:grid-cols-3';
 
   return (
-    <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+    <div className={cn('grid gap-4', gridCols)}>
       {sources.map((source) => {
         const config = SOURCE_CONFIG[source];
         const data = summaryBySource[source] || EMPTY_SUMMARY;

--- a/src/components/audit/__tests__/SourceBadge.test.tsx
+++ b/src/components/audit/__tests__/SourceBadge.test.tsx
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { SourceBadge } from '../SourceBadge';
+
+describe('SourceBadge', () => {
+  it.each([
+    ['epubcheck', 'EPUBCheck', /bg-blue-100/],
+    ['ace', 'ACE', /bg-purple-100/],
+    ['js-auditor', 'JS Auditor', /bg-green-100/],
+    ['prh-uk', 'PRH UK', /bg-teal-100/],
+  ] as const)(
+    'renders the %s source with the expected label and theme class',
+    (source, label, classRe) => {
+      render(<SourceBadge source={source} />);
+      const badge = screen.getByText(label);
+      expect(badge).toBeInTheDocument();
+      expect(badge.className).toMatch(classRe);
+    },
+  );
+
+  it('falls back to a neutral style for an unknown source value', () => {
+    render(<SourceBadge source="something-new" />);
+    const badge = screen.getByText('something-new');
+    expect(badge.className).toMatch(/bg-gray-100/);
+  });
+});

--- a/src/components/audit/__tests__/SummaryBySource.test.tsx
+++ b/src/components/audit/__tests__/SummaryBySource.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { SummaryBySource, type SummaryBySourceData } from '../SummaryBySource';
+
+const baseSummary: SummaryBySourceData = {
+  epubcheck: { critical: 1, serious: 0, moderate: 2, minor: 0, total: 3 },
+  ace: { critical: 0, serious: 1, moderate: 0, minor: 1, total: 2 },
+  'js-auditor': { critical: 0, serious: 0, moderate: 0, minor: 0, total: 0 },
+};
+
+describe('SummaryBySource', () => {
+  it('renders the three core source cards even when PRH UK is absent', () => {
+    render(<SummaryBySource summaryBySource={baseSummary} />);
+    expect(screen.getByText('EPUBCheck')).toBeInTheDocument();
+    expect(screen.getByText('ACE')).toBeInTheDocument();
+    expect(screen.getByText('JS Auditor')).toBeInTheDocument();
+    expect(screen.queryByText('PRH UK')).not.toBeInTheDocument();
+  });
+
+  it('does not render the PRH UK card when the bucket has zero total issues', () => {
+    render(
+      <SummaryBySource
+        summaryBySource={{
+          ...baseSummary,
+          'prh-uk': { critical: 0, serious: 0, moderate: 0, minor: 0, total: 0 },
+        }}
+      />,
+    );
+    expect(screen.queryByText('PRH UK')).not.toBeInTheDocument();
+  });
+
+  it('renders the PRH UK card when the backend reports non-zero PRH issues', () => {
+    render(
+      <SummaryBySource
+        summaryBySource={{
+          ...baseSummary,
+          'prh-uk': { critical: 0, serious: 4, moderate: 0, minor: 1, total: 5, autoFixable: 2 },
+        }}
+      />,
+    );
+    expect(screen.getByText('PRH UK')).toBeInTheDocument();
+    expect(screen.getByText('Publisher-specific Checks')).toBeInTheDocument();
+    expect(screen.getByText('5')).toBeInTheDocument();
+    expect(screen.getByText(/2 fixable/)).toBeInTheDocument();
+  });
+
+  it('forwards onSourceClick with "prh-uk" when the PRH card is clicked', async () => {
+    const handleClick = vi.fn();
+    render(
+      <SummaryBySource
+        summaryBySource={{
+          ...baseSummary,
+          'prh-uk': { critical: 0, serious: 1, moderate: 0, minor: 0, total: 1 },
+        }}
+        onSourceClick={handleClick}
+      />,
+    );
+    await userEvent.click(screen.getByText('PRH UK'));
+    expect(handleClick).toHaveBeenCalledWith('prh-uk');
+  });
+});

--- a/src/components/epub/EPUBAuditResults.tsx
+++ b/src/components/epub/EPUBAuditResults.tsx
@@ -19,7 +19,8 @@ import { cn } from '@/utils/cn';
 import { getWcagUrl, getWcagTooltip, formatWcagLabel } from '@/utils/wcag';
 
 type Severity = 'critical' | 'serious' | 'moderate' | 'minor';
-type IssueSource = 'js-auditor' | 'ace' | 'epubcheck' | 'manual';
+type IssueSource = 'js-auditor' | 'ace' | 'epubcheck' | 'manual' | 'prh-uk';
+type FilterableSource = 'js-auditor' | 'ace' | 'epubcheck' | 'prh-uk';
 
 interface AuditIssue {
   id: string;
@@ -278,29 +279,31 @@ export const EPUBAuditResults: React.FC<EPUBAuditResultsProps> = ({
     if (result?.summaryBySource) {
       return result.summaryBySource;
     }
-    const sources: Array<'epubcheck' | 'ace' | 'js-auditor'> = ['epubcheck', 'ace', 'js-auditor'];
+    const sources: FilterableSource[] = ['epubcheck', 'ace', 'js-auditor', 'prh-uk'];
     const summary: SummaryBySourceData = {};
-    
+
     for (const source of sources) {
       const sourceIssues = issues.filter(i => i.source === source);
+      // js-auditor always renders (even when empty) per existing UX; the
+      // others (incl. PRH UK) only render when the source produced issues.
       if (sourceIssues.length > 0 || source === 'js-auditor') {
         // Compute autoFixable per-source (not global stats)
         const autoFixable = sourceIssues.filter(isAutoFixable).length;
-        
+
         summary[source] = {
           critical: sourceIssues.filter(i => i.severity === 'critical').length,
           serious: sourceIssues.filter(i => i.severity === 'serious').length,
           moderate: sourceIssues.filter(i => i.severity === 'moderate').length,
           minor: sourceIssues.filter(i => i.severity === 'minor').length,
           total: sourceIssues.length,
-          ...(source === 'js-auditor' ? { autoFixable } : {}),
+          ...(source === 'js-auditor' || source === 'prh-uk' ? { autoFixable } : {}),
         };
       }
     }
     return summary;
   }, [result?.summaryBySource, issues]);
 
-  const [sourceFilter, setSourceFilter] = useState<'epubcheck' | 'ace' | 'js-auditor' | null>(null);
+  const [sourceFilter, setSourceFilter] = useState<FilterableSource | null>(null);
 
   const filteredIssues = useMemo(() => {
     let filtered = issues;
@@ -321,7 +324,7 @@ export const EPUBAuditResults: React.FC<EPUBAuditResultsProps> = ({
     }
   }, [issues, activeTab, sourceFilter]);
 
-  const handleSourceClick = (source: 'epubcheck' | 'ace' | 'js-auditor') => {
+  const handleSourceClick = (source: FilterableSource) => {
     setSourceFilter(prev => prev === source ? null : source);
   };
 

--- a/src/pages/EPUBAccessibility.tsx
+++ b/src/pages/EPUBAccessibility.tsx
@@ -142,6 +142,7 @@ export const EPUBAccessibility: React.FC = () => {
         accessibilityScore: data.accessibilityScore ?? 72,
         issuesSummary: data.issuesSummary || calculatedSummary,
         issues: apiIssues,
+        summaryBySource: data.summaryBySource,
         publisherProfile: data.publisherProfile ?? null,
         stats: fixTypeStats ? { byFixType: fixTypeStats } : undefined,
       };
@@ -226,6 +227,7 @@ export const EPUBAccessibility: React.FC = () => {
         accessibilityScore: data.accessibilityScore ?? summary.accessibilityScore ?? 72,
         issuesSummary: data.issuesSummary || calculatedSummary,
         issues: apiIssues.length > 0 ? apiIssues : (isDemoJob ? generateDemoIssues(issuesSummary) : []),
+        summaryBySource: data.summaryBySource,
         publisherProfile: data.publisherProfile ?? null,
         stats: fixTypeStats ? { byFixType: fixTypeStats } : undefined,
       };


### PR DESCRIPTION
## Summary
Second of five frontend follow-ups to the PRH UK backend work (P1-Frontend-Followups.md, Prompt 2). The backend emits 18 new `PRH-*` issue codes with `source: 'prh-uk'` and a matching `summaryBySource['prh-uk']` bucket. This PR makes them recognisable across the audit-results UI without taking space on non-PRH audits.

- Widens `IssueSource` (SourceBadge) and `SummaryBySourceData` / `SourceKey` (SummaryBySource) to include `'prh-uk'`.
- Adds a **teal**-themed PRH UK source badge so any issue row with `source: 'prh-uk'` is visually distinct from EPUBCheck/ACE/JS-Auditor.
- Adds a 4th **PRH UK · Publisher-specific Checks** source-summary card that **only renders when the backend reports a non-zero PRH bucket** — non-PRH audits keep the existing 3-card layout. Grid switches to `sm:grid-cols-2 lg:grid-cols-4` when the 4th card appears.
- Adds `'prh-uk'` to `EPUBAuditResults`' per-source click filter so "click card → filter list" picks up the new bucket automatically.
- Auto-fallback path in `EPUBAuditResults` (used when the backend doesn't pre-build `summaryBySource`) now also computes the PRH bucket by filtering issues by source.

The per-row "visual marker" the prompt asked for is the teal SourceBadge — no separate "PRH" chrome, just a recognisable colour where the source badge already lives.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean (max-warnings 0)
- [x] `npx vitest run` — 731 passed, 10 skipped (9 new tests: SourceBadge for `'prh-uk'` + unknown-source fallback; SummaryBySource for 3-card default, hidden when PRH bucket is empty, 4-card render with non-zero PRH, click-through forwards `'prh-uk'`)
- [ ] Manual: audit a PRH EPUB on staging, confirm 4-card layout with PRH UK card showing the bucket count
- [ ] Manual: click the PRH UK card — issue list filters to PRH-prefixed codes; click again clears
- [ ] Manual: confirm non-PRH audits still show 3 cards, no PRH UK card

## Out of scope
- `PRH-COVER-ALT-EMPTY` quick-fix dialog wiring (Prompt 3).
- "PRH UK Edition" VPAT dropdown + Certification section (Prompt 4).
- workflow-contracts enum reconciliation (Prompt 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added PRH UK as a new audit source with badge, summary card and auto-fixable indicator
  * Audit results and filters now include PRH UK so its issues can be displayed and selected
  * Summary cards adapt layout to hide an empty PRH UK card

* **Tests**
  * Added tests for SourceBadge rendering and themes
  * Added tests for SummaryBySource conditional rendering and click behavior

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/s4cindia/ninja-frontend/pull/264)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->