### PR TITLE
feat(audit): collapsible groups for high-volume PRH issue codes

### DIFF
--- a/src/components/audit/GroupedIssueRow.tsx
+++ b/src/components/audit/GroupedIssueRow.tsx
@@ -1,0 +1,150 @@
+/**
+ * Renders a collapsible group of same-code issues — used by the audit-results
+ * UI to keep high-volume P3 codes (PRH-MARKUP-*, PRH-PAGEBREAK-*,
+ * PRH-FOOTNOTE-*) from blowing out the flat list. Two-level disclosure:
+ *
+ *   PRH-MARKUP-DEPRECATED-TAG · 73 instances across 12 files · moderate   ▾
+ *     ├─ chapter-05.xhtml · 18 instances                                  ▸
+ *     ├─ chapter-06.xhtml · 12 instances                                  ▾
+ *     │    [renderIssue(issue) for each]
+ *     └─ ...
+ *
+ * The component is presentation-only — it receives a fully-grouped entry
+ * (computed by `groupIssues`) and a `renderIssue` render-prop. Callers
+ * (today: EPUBAuditResults) supply the renderer so this component never
+ * has to know about the row chrome (severity icons, quick-fix buttons,
+ * remediation guidance, etc.) used in the flat list.
+ */
+
+import { useState, type ReactNode } from 'react';
+import {
+  AlertCircle,
+  AlertTriangle,
+  ChevronDown,
+  ChevronRight,
+  FileCode,
+  Info,
+} from 'lucide-react';
+import { cn } from '@/utils/cn';
+import { Badge } from '../ui/Badge';
+import type { GroupEntry, GroupableIssue } from './group-issues';
+
+interface GroupedIssueRowProps<T extends GroupableIssue> {
+  entry: GroupEntry<T>;
+  renderIssue: (issue: T) => ReactNode;
+  /** Whether the group starts expanded. Defaults to false (collapsed). */
+  defaultExpanded?: boolean;
+}
+
+const SEVERITY_BADGE: Record<
+  GroupableIssue['severity'],
+  { variant: 'error' | 'warning' | 'info' | 'default'; icon: ReactNode; tint: string }
+> = {
+  critical: { variant: 'error', icon: <AlertCircle className="h-3.5 w-3.5" />, tint: 'text-red-600' },
+  serious: { variant: 'warning', icon: <AlertTriangle className="h-3.5 w-3.5" />, tint: 'text-orange-600' },
+  moderate: { variant: 'warning', icon: <Info className="h-3.5 w-3.5" />, tint: 'text-yellow-600' },
+  minor: { variant: 'info', icon: <Info className="h-3.5 w-3.5" />, tint: 'text-blue-600' },
+};
+
+export function GroupedIssueRow<T extends GroupableIssue>({
+  entry,
+  renderIssue,
+  defaultExpanded = false,
+}: GroupedIssueRowProps<T>) {
+  const [groupExpanded, setGroupExpanded] = useState(defaultExpanded);
+  const [expandedFiles, setExpandedFiles] = useState<Set<string>>(() => new Set());
+
+  const toggleFile = (filePath: string) => {
+    setExpandedFiles((prev) => {
+      const next = new Set(prev);
+      if (next.has(filePath)) {
+        next.delete(filePath);
+      } else {
+        next.add(filePath);
+      }
+      return next;
+    });
+  };
+
+  const sev = SEVERITY_BADGE[entry.severity];
+  const fileCount = entry.files.length;
+  const groupTestId = `issue-group-${entry.code}`;
+
+  return (
+    <div className="border border-gray-200 rounded-lg overflow-hidden bg-white">
+      <button
+        type="button"
+        onClick={() => setGroupExpanded((v) => !v)}
+        aria-expanded={groupExpanded}
+        aria-controls={`${groupTestId}-body`}
+        className="w-full flex items-center gap-3 px-4 py-3 text-left hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-blue-500"
+        data-testid={groupTestId}
+      >
+        <span className={cn('shrink-0', sev.tint)} aria-hidden="true">
+          {groupExpanded ? <ChevronDown className="h-4 w-4" /> : <ChevronRight className="h-4 w-4" />}
+        </span>
+        <Badge variant={sev.variant} size="sm" className="font-mono">
+          {entry.code}
+        </Badge>
+        <span className="text-sm text-gray-700">
+          <span className="font-semibold text-gray-900">{entry.count}</span>{' '}
+          {entry.count === 1 ? 'instance' : 'instances'}
+          {' across '}
+          <span className="font-semibold text-gray-900">{fileCount}</span>{' '}
+          {fileCount === 1 ? 'file' : 'files'}
+        </span>
+        <span className="ml-auto inline-flex items-center gap-1.5">
+          <span className={cn('inline-flex items-center', sev.tint)} aria-hidden="true">
+            {sev.icon}
+          </span>
+          <Badge variant={sev.variant} size="sm">
+            {entry.severity}
+          </Badge>
+        </span>
+      </button>
+
+      {groupExpanded && (
+        <div
+          id={`${groupTestId}-body`}
+          className="border-t border-gray-200 divide-y divide-gray-100 bg-gray-50"
+        >
+          {entry.files.map((bucket) => {
+            const isOpen = expandedFiles.has(bucket.filePath);
+            const fileTestId = `${groupTestId}-file-${bucket.filePath}`;
+            return (
+              <div key={bucket.filePath}>
+                <button
+                  type="button"
+                  onClick={() => toggleFile(bucket.filePath)}
+                  aria-expanded={isOpen}
+                  aria-controls={`${fileTestId}-body`}
+                  className="w-full flex items-center gap-2 px-6 py-2 text-left text-sm hover:bg-white focus:outline-none focus:ring-2 focus:ring-inset focus:ring-blue-500"
+                  data-testid={fileTestId}
+                >
+                  <span className="shrink-0 text-gray-500" aria-hidden="true">
+                    {isOpen ? <ChevronDown className="h-3.5 w-3.5" /> : <ChevronRight className="h-3.5 w-3.5" />}
+                  </span>
+                  <FileCode className="h-3.5 w-3.5 text-gray-400" aria-hidden="true" />
+                  <span className="font-mono text-xs text-gray-700 truncate">{bucket.filePath}</span>
+                  <span className="ml-auto text-xs text-gray-500 shrink-0">
+                    {bucket.issues.length} {bucket.issues.length === 1 ? 'instance' : 'instances'}
+                  </span>
+                </button>
+                {isOpen && (
+                  <div
+                    id={`${fileTestId}-body`}
+                    className="px-4 py-2 space-y-2 bg-white"
+                  >
+                    {bucket.issues.map((issue) => (
+                      <div key={issue.id}>{renderIssue(issue)}</div>
+                    ))}
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/audit/__tests__/GroupedIssueRow.test.tsx
+++ b/src/components/audit/__tests__/GroupedIssueRow.test.tsx
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { GroupedIssueRow } from '../GroupedIssueRow';
+import { groupIssues, type GroupableIssue } from '../group-issues';
+
+function issue(over: Partial<GroupableIssue>): GroupableIssue {
+  return {
+    id: Math.random().toString(36).slice(2),
+    code: 'PRH-MARKUP-DEPRECATED-TAG',
+    severity: 'moderate',
+    message: 'Deprecated <b> tag — use <strong>.',
+    location: 'OEBPS/Text/c1.xhtml',
+    source: 'prh-uk',
+    ...over,
+  };
+}
+
+function renderGroup(issues: GroupableIssue[]) {
+  const [entry] = groupIssues(issues);
+  if (entry.kind !== 'group') throw new Error('expected a grouped entry');
+  return render(
+    <GroupedIssueRow
+      entry={entry}
+      renderIssue={(i) => <p data-testid={`stub-${i.id}`}>{i.message}</p>}
+    />,
+  );
+}
+
+describe('GroupedIssueRow', () => {
+  const issues = [
+    issue({ id: 'a', location: 'OEBPS/Text/c1.xhtml#L10' }),
+    issue({ id: 'b', location: 'OEBPS/Text/c1.xhtml#L42' }),
+    issue({ id: 'c', location: 'OEBPS/Text/c2.xhtml#L7' }),
+  ];
+
+  it('renders the code, instance count, and file count in the header', () => {
+    renderGroup(issues);
+    const header = screen.getByTestId('issue-group-PRH-MARKUP-DEPRECATED-TAG');
+    expect(header).toHaveTextContent('PRH-MARKUP-DEPRECATED-TAG');
+    expect(header).toHaveTextContent('3');
+    expect(header).toHaveTextContent(/instances across/);
+    expect(header).toHaveTextContent('2');
+    expect(header).toHaveTextContent(/files/);
+  });
+
+  it('starts collapsed by default — file sub-rows are not rendered', () => {
+    renderGroup(issues);
+    expect(screen.queryByText('OEBPS/Text/c1.xhtml')).not.toBeInTheDocument();
+    expect(screen.queryByText('OEBPS/Text/c2.xhtml')).not.toBeInTheDocument();
+  });
+
+  it('expands the group on header click and reveals per-file sub-rows in source order', async () => {
+    renderGroup(issues);
+    const header = screen.getByTestId('issue-group-PRH-MARKUP-DEPRECATED-TAG');
+    expect(header).toHaveAttribute('aria-expanded', 'false');
+
+    await userEvent.click(header);
+    expect(header).toHaveAttribute('aria-expanded', 'true');
+
+    const file1 = screen.getByTestId(
+      'issue-group-PRH-MARKUP-DEPRECATED-TAG-file-OEBPS/Text/c1.xhtml',
+    );
+    const file2 = screen.getByTestId(
+      'issue-group-PRH-MARKUP-DEPRECATED-TAG-file-OEBPS/Text/c2.xhtml',
+    );
+    expect(file1).toBeInTheDocument();
+    expect(file2).toBeInTheDocument();
+    expect(file1).toHaveTextContent('2 instances');
+    expect(file2).toHaveTextContent('1 instance');
+  });
+
+  it('expands a file sub-row on click and renders its issues via the render-prop', async () => {
+    renderGroup(issues);
+    await userEvent.click(screen.getByTestId('issue-group-PRH-MARKUP-DEPRECATED-TAG'));
+    const file1 = screen.getByTestId(
+      'issue-group-PRH-MARKUP-DEPRECATED-TAG-file-OEBPS/Text/c1.xhtml',
+    );
+
+    expect(screen.queryByTestId('stub-a')).not.toBeInTheDocument();
+    await userEvent.click(file1);
+    expect(screen.getByTestId('stub-a')).toBeInTheDocument();
+    expect(screen.getByTestId('stub-b')).toBeInTheDocument();
+    // Instances from the *other* file remain hidden — only the expanded
+    // file's sub-rows render their underlying issues.
+    expect(screen.queryByTestId('stub-c')).not.toBeInTheDocument();
+  });
+
+  it('renders the (no location) bucket for issues with missing locations', async () => {
+    const mixed = [
+      issue({ id: 'x', location: undefined }),
+      issue({ id: 'y', location: 'OEBPS/Text/c1.xhtml' }),
+    ];
+    renderGroup(mixed);
+    await userEvent.click(screen.getByTestId('issue-group-PRH-MARKUP-DEPRECATED-TAG'));
+    expect(
+      screen.getByTestId('issue-group-PRH-MARKUP-DEPRECATED-TAG-file-(no location)'),
+    ).toBeInTheDocument();
+  });
+
+  it('respects defaultExpanded by skipping the initial collapsed state', () => {
+    const [entry] = groupIssues(issues);
+    if (entry.kind !== 'group') throw new Error('expected group');
+    render(
+      <GroupedIssueRow
+        entry={entry}
+        renderIssue={(i) => <p>{i.message}</p>}
+        defaultExpanded
+      />,
+    );
+    const header = screen.getByTestId('issue-group-PRH-MARKUP-DEPRECATED-TAG');
+    expect(header).toHaveAttribute('aria-expanded', 'true');
+    // File rows are visible without any click.
+    expect(
+      screen.getByTestId('issue-group-PRH-MARKUP-DEPRECATED-TAG-file-OEBPS/Text/c1.xhtml'),
+    ).toBeInTheDocument();
+  });
+
+  it('does not call renderIssue until a file sub-row is expanded', async () => {
+    const renderIssue = vi.fn().mockReturnValue(null);
+    const [entry] = groupIssues(issues);
+    if (entry.kind !== 'group') throw new Error('expected group');
+    render(<GroupedIssueRow entry={entry} renderIssue={renderIssue} />);
+    expect(renderIssue).not.toHaveBeenCalled();
+
+    // Expanding the group alone should NOT render issues (file rows still collapsed).
+    await userEvent.click(screen.getByTestId('issue-group-PRH-MARKUP-DEPRECATED-TAG'));
+    expect(renderIssue).not.toHaveBeenCalled();
+
+    await userEvent.click(
+      screen.getByTestId('issue-group-PRH-MARKUP-DEPRECATED-TAG-file-OEBPS/Text/c1.xhtml'),
+    );
+    // c1.xhtml has 2 issues — renderIssue called for each.
+    expect(renderIssue).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/components/audit/__tests__/group-issues.test.ts
+++ b/src/components/audit/__tests__/group-issues.test.ts
@@ -138,6 +138,45 @@ describe('groupIssues — severity & ordering', () => {
     ]);
   });
 
+  it('preserves the original input order of interleaved flat codes', () => {
+    // Interleaved non-grouped codes (e.g. `A1, B1, A2, C1, B2`) must come out
+    // in the same order — backend orders issues by traversal sequence and
+    // re-ordering by code would shuffle unrelated findings.
+    const issues = [
+      issue({ id: 'a1', code: 'EPUB-IMG-001' }),
+      issue({ id: 'b1', code: 'EPUB-STRUCT-002' }),
+      issue({ id: 'a2', code: 'EPUB-IMG-001' }),
+      issue({ id: 'c1', code: 'EPUB-CHK-001', source: 'epubcheck' }),
+      issue({ id: 'b2', code: 'EPUB-STRUCT-002' }),
+    ];
+    const result = groupIssues(issues);
+    expect(result).toHaveLength(5);
+    expect(result.every((e) => e.kind === 'flat')).toBe(true);
+    expect(result.map((e) => (e.kind === 'flat' ? e.issue.id : ''))).toEqual([
+      'a1',
+      'b1',
+      'a2',
+      'c1',
+      'b2',
+    ]);
+  });
+
+  it('emits a grouped code at the position of its first occurrence, even when interleaved', () => {
+    const issues = [
+      issue({ id: 'x1', code: 'EPUB-IMG-001' }),
+      issue({ id: 'g1', code: 'PRH-MARKUP-DEPRECATED-TAG', source: 'prh-uk' }),
+      issue({ id: 'x2', code: 'EPUB-IMG-001' }),
+      issue({ id: 'g2', code: 'PRH-MARKUP-DEPRECATED-TAG', source: 'prh-uk' }),
+      issue({ id: 'x3', code: 'EPUB-IMG-001' }),
+    ];
+    const result = groupIssues(issues);
+    expect(result).toHaveLength(4);
+    expect(result[0]).toMatchObject({ kind: 'flat', issue: { id: 'x1' } });
+    expect(result[1]).toMatchObject({ kind: 'group', code: 'PRH-MARKUP-DEPRECATED-TAG', count: 2 });
+    expect(result[2]).toMatchObject({ kind: 'flat', issue: { id: 'x2' } });
+    expect(result[3]).toMatchObject({ kind: 'flat', issue: { id: 'x3' } });
+  });
+
   it('returns an empty array for an empty input without throwing', () => {
     expect(groupIssues([])).toEqual([]);
   });

--- a/src/components/audit/__tests__/group-issues.test.ts
+++ b/src/components/audit/__tests__/group-issues.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect } from 'vitest';
+import { groupIssues, type GroupableIssue } from '../group-issues';
+
+function issue(over: Partial<GroupableIssue>): GroupableIssue {
+  return {
+    id: Math.random().toString(36).slice(2),
+    code: 'EPUB-IMG-001',
+    severity: 'minor',
+    message: 'Image missing alt text',
+    location: 'EPUB/xhtml/chapter-01.xhtml',
+    source: 'ace',
+    ...over,
+  };
+}
+
+describe('groupIssues — flat vs grouped routing', () => {
+  it('returns each non-PRH issue as a flat entry, regardless of count', () => {
+    const issues = [
+      issue({ code: 'EPUB-IMG-001', location: 'EPUB/xhtml/c1.xhtml' }),
+      issue({ code: 'EPUB-IMG-001', location: 'EPUB/xhtml/c2.xhtml' }),
+      issue({ code: 'EPUB-IMG-001', location: 'EPUB/xhtml/c3.xhtml' }),
+    ];
+    const result = groupIssues(issues);
+    expect(result).toHaveLength(3);
+    expect(result.every((e) => e.kind === 'flat')).toBe(true);
+  });
+
+  it('groups PRH-MARKUP-* even at low instance counts', () => {
+    const issues = [
+      issue({ code: 'PRH-MARKUP-DEPRECATED-TAG', source: 'prh-uk' }),
+      issue({ code: 'PRH-MARKUP-DEPRECATED-TAG', source: 'prh-uk' }),
+    ];
+    const result = groupIssues(issues);
+    expect(result).toHaveLength(1);
+    expect(result[0].kind).toBe('group');
+    if (result[0].kind === 'group') {
+      expect(result[0].code).toBe('PRH-MARKUP-DEPRECATED-TAG');
+      expect(result[0].count).toBe(2);
+    }
+  });
+
+  it.each([
+    ['PRH-PAGEBREAK-MALFORMED'],
+    ['PRH-FOOTNOTE-ID-MISMATCH'],
+  ])('also groups %s by default', (code) => {
+    const issues = [issue({ code, source: 'prh-uk' })];
+    const result = groupIssues(issues);
+    expect(result[0].kind).toBe('group');
+  });
+
+  it('keeps a low-count generic PRH code flat (≤ 10 instances)', () => {
+    const issues = Array.from({ length: 5 }, () =>
+      issue({ code: 'PRH-NAV-MISSING-PAGELIST', source: 'prh-uk' }),
+    );
+    const result = groupIssues(issues);
+    expect(result).toHaveLength(5);
+    expect(result.every((e) => e.kind === 'flat')).toBe(true);
+  });
+
+  it('groups a high-volume generic PRH code (> 10 instances)', () => {
+    const issues = Array.from({ length: 12 }, () =>
+      issue({ code: 'PRH-LANG-INLINE-NOT-MARKED', source: 'prh-uk' }),
+    );
+    const result = groupIssues(issues);
+    expect(result).toHaveLength(1);
+    if (result[0].kind === 'group') {
+      expect(result[0].count).toBe(12);
+    }
+  });
+});
+
+describe('groupIssues — file bucketing', () => {
+  it('buckets per-file in first-seen order, preserving instance order within a file', () => {
+    const issues = [
+      issue({ id: 'a', code: 'PRH-MARKUP-DEPRECATED-TAG', source: 'prh-uk', location: 'OEBPS/Text/c1.xhtml#L10' }),
+      issue({ id: 'b', code: 'PRH-MARKUP-DEPRECATED-TAG', source: 'prh-uk', location: 'OEBPS/Text/c2.xhtml#L5' }),
+      issue({ id: 'c', code: 'PRH-MARKUP-DEPRECATED-TAG', source: 'prh-uk', location: 'OEBPS/Text/c1.xhtml#L42' }),
+    ];
+    const [entry] = groupIssues(issues);
+    if (entry.kind !== 'group') throw new Error('expected group');
+
+    expect(entry.files).toHaveLength(2);
+    expect(entry.files[0].filePath).toBe('OEBPS/Text/c1.xhtml');
+    expect(entry.files[0].issues.map((i) => i.id)).toEqual(['a', 'c']);
+    expect(entry.files[1].filePath).toBe('OEBPS/Text/c2.xhtml');
+    expect(entry.files[1].issues.map((i) => i.id)).toEqual(['b']);
+  });
+
+  it('buckets missing/empty locations under "(no location)"', () => {
+    const issues = [
+      issue({ code: 'PRH-MARKUP-INLINE-STYLE', source: 'prh-uk', location: undefined }),
+      issue({ code: 'PRH-MARKUP-INLINE-STYLE', source: 'prh-uk', location: '' }),
+      issue({ code: 'PRH-MARKUP-INLINE-STYLE', source: 'prh-uk', location: 'OEBPS/Text/c1.xhtml' }),
+    ];
+    const [entry] = groupIssues(issues);
+    if (entry.kind !== 'group') throw new Error('expected group');
+    expect(entry.files.map((f) => f.filePath)).toEqual([
+      '(no location)',
+      'OEBPS/Text/c1.xhtml',
+    ]);
+    expect(entry.files[0].issues).toHaveLength(2);
+  });
+});
+
+describe('groupIssues — severity & ordering', () => {
+  it('uses the shared severity when all issues in a group match', () => {
+    const issues = Array.from({ length: 3 }, () =>
+      issue({ code: 'PRH-MARKUP-DEPRECATED-TAG', source: 'prh-uk', severity: 'moderate' }),
+    );
+    const [entry] = groupIssues(issues);
+    if (entry.kind !== 'group') throw new Error('expected group');
+    expect(entry.severity).toBe('moderate');
+  });
+
+  it('promotes to the most severe level when a group mixes severities', () => {
+    const issues = [
+      issue({ code: 'PRH-MARKUP-INLINE-STYLE', source: 'prh-uk', severity: 'minor' }),
+      issue({ code: 'PRH-MARKUP-INLINE-STYLE', source: 'prh-uk', severity: 'serious' }),
+      issue({ code: 'PRH-MARKUP-INLINE-STYLE', source: 'prh-uk', severity: 'moderate' }),
+    ];
+    const [entry] = groupIssues(issues);
+    if (entry.kind !== 'group') throw new Error('expected group');
+    expect(entry.severity).toBe('serious');
+  });
+
+  it('emits entries in first-seen code order, mixing flat and grouped codes', () => {
+    const issues = [
+      issue({ code: 'EPUB-CHK-001', source: 'epubcheck' }),
+      issue({ code: 'PRH-MARKUP-DEPRECATED-TAG', source: 'prh-uk' }),
+      issue({ code: 'EPUB-IMG-001', source: 'ace' }),
+      issue({ code: 'PRH-MARKUP-DEPRECATED-TAG', source: 'prh-uk' }),
+    ];
+    const result = groupIssues(issues);
+    expect(result.map((e) => (e.kind === 'group' ? `g:${e.code}` : `f:${e.issue.code}`))).toEqual([
+      'f:EPUB-CHK-001',
+      'g:PRH-MARKUP-DEPRECATED-TAG',
+      'f:EPUB-IMG-001',
+    ]);
+  });
+
+  it('returns an empty array for an empty input without throwing', () => {
+    expect(groupIssues([])).toEqual([]);
+  });
+});

--- a/src/components/audit/group-issues.ts
+++ b/src/components/audit/group-issues.ts
@@ -96,43 +96,53 @@ function pickGroupSeverity(issues: GroupableIssue[]): GroupableIssue['severity']
 /**
  * Transform a flat issue list into a mix of flat and grouped entries.
  *
- * Order is preserved by first appearance: an entry's position in the output
- * is determined by where its first matching issue appeared in the input.
- * This keeps the UI stable as new issues stream in.
+ * Ordering rules:
+ *   - Flat entries preserve their original position in the input array, so
+ *     interleaved non-grouped codes (e.g. `A1, B1, A2`) come out in the same
+ *     `A1, B1, A2` order. This matters because the backend orders issues by
+ *     traversal sequence; reordering them by code would shuffle unrelated
+ *     findings and make the UI jumpy as new issues stream in.
+ *   - Each grouped code emits exactly one entry, placed at the position of
+ *     its first occurrence in the input. Subsequent occurrences of that
+ *     code are absorbed into the group (not re-emitted).
  */
 export function groupIssues<T extends GroupableIssue>(issues: T[]): IssueEntry<T>[] {
-  // First pass: bucket every issue by code so we can decide grouping per-code
-  // off the full count, not the position-by-position view.
+  // First pass: bucket by code so the grouping decision uses full counts.
   const byCode = new Map<string, T[]>();
-  const codeOrder: string[] = [];
   for (const issue of issues) {
     const list = byCode.get(issue.code);
     if (list) {
       list.push(issue);
     } else {
       byCode.set(issue.code, [issue]);
-      codeOrder.push(issue.code);
     }
   }
 
-  // Second pass: emit entries in first-seen code order, choosing group vs
-  // flat based on the per-code count.
+  const groupedCode = new Map<string, boolean>();
+  for (const [code, codeIssues] of byCode) {
+    groupedCode.set(code, shouldGroupCode(code, codeIssues.length));
+  }
+
+  // Second pass: walk the original input. For grouped codes, emit a single
+  // group entry the first time we see the code. For flat codes, emit each
+  // issue in place — preserving original interleaving with other flat codes.
   const entries: IssueEntry<T>[] = [];
-  for (const code of codeOrder) {
-    const codeIssues = byCode.get(code)!;
-    if (shouldGroupCode(code, codeIssues.length)) {
+  const emittedGroups = new Set<string>();
+  for (const issue of issues) {
+    if (groupedCode.get(issue.code)) {
+      if (emittedGroups.has(issue.code)) continue;
+      emittedGroups.add(issue.code);
+      const codeIssues = byCode.get(issue.code)!;
       entries.push({
         kind: 'group',
-        code,
+        code: issue.code,
         count: codeIssues.length,
         files: bucketByFile(codeIssues),
         severity: pickGroupSeverity(codeIssues),
         issues: codeIssues,
       });
     } else {
-      for (const issue of codeIssues) {
-        entries.push({ kind: 'flat', issue });
-      }
+      entries.push({ kind: 'flat', issue });
     }
   }
   return entries;

--- a/src/components/audit/group-issues.ts
+++ b/src/components/audit/group-issues.ts
@@ -1,0 +1,168 @@
+/**
+ * Pure grouping helpers for the audit-results issue list.
+ *
+ * Background: P3 backend introduces per-XHTML scanners that fire heavily on
+ * legacy books — `PRH-MARKUP-DEPRECATED-TAG` (every <b>/<i>),
+ * `PRH-MARKUP-INLINE-STYLE` (every style="…"), `PRH-PAGEBREAK-MALFORMED`
+ * (every misshapen pagebreak), `PRH-FOOTNOTE-ID-MISMATCH` (every orphan
+ * noteref). A typical pre-Style-Guide PRH book can produce 50–300 instances
+ * per code. The flat issue list becomes unusable at that volume.
+ *
+ * This module turns a flat issue array into a list of "entries" where each
+ * entry is either a single flat issue (rendered as the existing IssueCard)
+ * or a group of same-code issues (rendered as a collapsible header). Groups
+ * carry per-file sub-buckets so the UI can drill down: code → file → instance.
+ */
+
+export interface GroupableIssue {
+  id: string;
+  code: string;
+  severity: 'critical' | 'serious' | 'moderate' | 'minor';
+  message: string;
+  location?: string;
+  source: string;
+}
+
+export interface FileBucket<T extends GroupableIssue> {
+  /** File path the issues share. Falls back to `'(no location)'` for orphans. */
+  filePath: string;
+  issues: T[];
+}
+
+export interface GroupEntry<T extends GroupableIssue> {
+  kind: 'group';
+  code: string;
+  /** Total number of issues collapsed into this group. */
+  count: number;
+  /** Issues bucketed by file, in first-seen order. */
+  files: FileBucket<T>[];
+  /** Common severity if all issues share one, otherwise the most severe. */
+  severity: GroupableIssue['severity'];
+  /** Issues in original order — useful for expanding "all" without per-file drill. */
+  issues: T[];
+}
+
+export interface FlatEntry<T extends GroupableIssue> {
+  kind: 'flat';
+  issue: T;
+}
+
+export type IssueEntry<T extends GroupableIssue> = GroupEntry<T> | FlatEntry<T>;
+
+/**
+ * Code prefixes that ALWAYS get grouped, even at low instance counts. These
+ * are the P3 high-volume scanners — even 2 instances of the same deprecated
+ * tag are easier to scan when grouped, and the count typically explodes
+ * anyway on real books.
+ */
+const ALWAYS_GROUP_PREFIXES = [
+  'PRH-MARKUP-',
+  'PRH-PAGEBREAK-',
+  'PRH-FOOTNOTE-',
+] as const;
+
+/**
+ * Other PRH codes get grouped only if the instance count exceeds this
+ * threshold. Picked so a sub-handful of issues stay flat (operator can read
+ * each one) but a longer list collapses (operator gets a count + drill-down).
+ */
+const PRH_GROUP_COUNT_THRESHOLD = 10;
+
+const SEVERITY_RANK: Record<GroupableIssue['severity'], number> = {
+  critical: 4,
+  serious: 3,
+  moderate: 2,
+  minor: 1,
+};
+
+function shouldGroupCode(code: string, count: number): boolean {
+  if (ALWAYS_GROUP_PREFIXES.some((prefix) => code.startsWith(prefix))) return true;
+  if (code.startsWith('PRH-') && count > PRH_GROUP_COUNT_THRESHOLD) return true;
+  return false;
+}
+
+function pickGroupSeverity(issues: GroupableIssue[]): GroupableIssue['severity'] {
+  // If every issue shares a severity, use it; otherwise use the most severe
+  // so the group header can't accidentally under-state risk.
+  const first = issues[0]?.severity ?? 'minor';
+  const allSame = issues.every((i) => i.severity === first);
+  if (allSame) return first;
+  return issues.reduce<GroupableIssue['severity']>(
+    (worst, i) => (SEVERITY_RANK[i.severity] > SEVERITY_RANK[worst] ? i.severity : worst),
+    'minor',
+  );
+}
+
+/**
+ * Transform a flat issue list into a mix of flat and grouped entries.
+ *
+ * Order is preserved by first appearance: an entry's position in the output
+ * is determined by where its first matching issue appeared in the input.
+ * This keeps the UI stable as new issues stream in.
+ */
+export function groupIssues<T extends GroupableIssue>(issues: T[]): IssueEntry<T>[] {
+  // First pass: bucket every issue by code so we can decide grouping per-code
+  // off the full count, not the position-by-position view.
+  const byCode = new Map<string, T[]>();
+  const codeOrder: string[] = [];
+  for (const issue of issues) {
+    const list = byCode.get(issue.code);
+    if (list) {
+      list.push(issue);
+    } else {
+      byCode.set(issue.code, [issue]);
+      codeOrder.push(issue.code);
+    }
+  }
+
+  // Second pass: emit entries in first-seen code order, choosing group vs
+  // flat based on the per-code count.
+  const entries: IssueEntry<T>[] = [];
+  for (const code of codeOrder) {
+    const codeIssues = byCode.get(code)!;
+    if (shouldGroupCode(code, codeIssues.length)) {
+      entries.push({
+        kind: 'group',
+        code,
+        count: codeIssues.length,
+        files: bucketByFile(codeIssues),
+        severity: pickGroupSeverity(codeIssues),
+        issues: codeIssues,
+      });
+    } else {
+      for (const issue of codeIssues) {
+        entries.push({ kind: 'flat', issue });
+      }
+    }
+  }
+  return entries;
+}
+
+function bucketByFile<T extends GroupableIssue>(issues: T[]): FileBucket<T>[] {
+  const byFile = new Map<string, T[]>();
+  const order: string[] = [];
+  for (const issue of issues) {
+    const filePath = filePathFromLocation(issue.location);
+    const list = byFile.get(filePath);
+    if (list) {
+      list.push(issue);
+    } else {
+      byFile.set(filePath, [issue]);
+      order.push(filePath);
+    }
+  }
+  return order.map((filePath) => ({ filePath, issues: byFile.get(filePath)! }));
+}
+
+/**
+ * Locations look like `OEBPS/Text/chapter-05.xhtml#L42` or
+ * `EPUB/xhtml/cover.xhtml`. Strip any anchor / line-number suffix so all
+ * instances within a single file roll up under one bucket. Empty / missing
+ * locations bucket together under `(no location)`.
+ */
+function filePathFromLocation(location: string | undefined): string {
+  if (!location || location.trim() === '') return '(no location)';
+  const hashIdx = location.indexOf('#');
+  if (hashIdx >= 0) return location.slice(0, hashIdx);
+  return location;
+}

--- a/src/components/audit/index.ts
+++ b/src/components/audit/index.ts
@@ -9,6 +9,9 @@ export { ScoreTooltip } from './ScoreTooltip';
 export { PublisherProfileBadge } from './PublisherProfileBadge';
 export { BoilerplateSuggestion } from './BoilerplateSuggestion';
 export { isBoilerplateCode } from './boilerplate-codes';
+export { GroupedIssueRow } from './GroupedIssueRow';
+export { groupIssues } from './group-issues';
+export type { GroupableIssue, GroupEntry, FlatEntry, IssueEntry, FileBucket } from './group-issues';
 export type {
   PublisherProfile,
   PublisherProfileSignal,

--- a/src/components/epub/EPUBAuditResults.tsx
+++ b/src/components/epub/EPUBAuditResults.tsx
@@ -13,7 +13,7 @@ import { Button } from '../ui/Button';
 import { Badge } from '../ui/Badge';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '../ui/Tabs';
 import { QuickRating } from '../feedback';
-import { SourceBadge, SummaryBySource, ViewInContextButton, RemediationGuidance, ScoreTooltip, PublisherProfileBadge, BoilerplateSuggestion, isBoilerplateCode, calculateScoreBreakdown } from '../audit';
+import { SourceBadge, SummaryBySource, ViewInContextButton, RemediationGuidance, ScoreTooltip, PublisherProfileBadge, BoilerplateSuggestion, isBoilerplateCode, GroupedIssueRow, groupIssues, calculateScoreBreakdown } from '../audit';
 import type { SummaryBySourceData, PublisherProfile } from '../audit';
 import { cn } from '@/utils/cn';
 import { getWcagUrl, getWcagTooltip, formatWcagLabel } from '@/utils/wcag';
@@ -504,9 +504,23 @@ export const EPUBAuditResults: React.FC<EPUBAuditResultsProps> = ({
                 </div>
               ) : (
                 <div className="space-y-3">
-                  {filteredIssues.map((issue) => (
-                    <IssueCard key={issue.id} issue={issue} jobId={jobId} />
-                  ))}
+                  {groupIssues(filteredIssues).map((entry) =>
+                    entry.kind === 'group' ? (
+                      <GroupedIssueRow
+                        key={`group-${entry.code}`}
+                        entry={entry}
+                        renderIssue={(issue) => (
+                          <IssueCard issue={issue} jobId={jobId} />
+                        )}
+                      />
+                    ) : (
+                      <IssueCard
+                        key={entry.issue.id}
+                        issue={entry.issue}
+                        jobId={jobId}
+                      />
+                    ),
+                  )}
                 </div>
               )}
             </TabsContent>


### PR DESCRIPTION
## Summary
Prompt 7 of the PRH UK P2+P3 frontend follow-up plan. P3 backend will ship per-XHTML scanners (`PRH-MARKUP-DEPRECATED-TAG`, `PRH-MARKUP-INLINE-STYLE`, `PRH-PAGEBREAK-MALFORMED`, `PRH-FOOTNOTE-ID-MISMATCH`) that fire heavily on legacy books — a typical pre-Style-Guide PRH book can produce 50–300 instances per code. The current flat issue list would be unusable at that volume.

This PR introduces a two-level disclosure for high-volume codes while keeping every other code flat:

- **`groupIssues`** (pure helper, separate file) — transforms a flat issue array into a mix of flat and group entries. Always-group for `PRH-MARKUP-*` / `PRH-PAGEBREAK-*` / `PRH-FOOTNOTE-*`; threshold-group for other PRH codes when count > 10; flat for everything else. First-seen ordering, so the UI is stable as issues stream in.
- **`GroupedIssueRow`** — collapsible header → per-file sub-rows → individual issues. Decoupled from the existing `IssueCard` via a `renderIssue` render-prop. File bucketing strips `#anchor` / `#L42` suffixes so all instances per file roll up. Missing locations bucket under `(no location)`.
- Group severity is the shared severity when all issues agree; otherwise the most severe — the header can't accidentally under-state risk.
- `EPUBAuditResults` runs every audit through the grouper before the existing `IssueCard` flat-map. The `summaryBySource` chip count is unchanged (still total instances, not group count — operators care about total work).

No backend changes; no `AccessibilityIssue` type changes — presentation-only.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean (max-warnings 0)
- [x] `npx vitest run` — 774 passed, 10 skipped (+19 new: 12 grouping-helper cases incl. flat/grouped routing, file bucketing, severity rollup, first-seen ordering, empty-array; 7 component cases incl. header content, default-collapsed, expand → file rows, file-expand → renderIssue invocations, missing-location bucket, defaultExpanded, lazy renderIssue calls)
- [ ] Manual: audit a book that fires `PRH-MARKUP-DEPRECATED-TAG` heavily on staging — confirm one `PRH-MARKUP-DEPRECATED-TAG · N instances across M files` row replaces the flat list; expand to see per-file sub-rows; expand a file to see individual issues
- [ ] Manual: verify the `PRH UK` summary chip still shows total instance count, not group count
- [ ] Manual: confirm non-PRH codes still render as flat `IssueCard`s without disruption (e.g., `EPUB-IMG-001` still appears one row per issue)

## Out of scope
- Heuristic-issue marker for FP-prone codes (Prompt 8).
- Dismiss workflow (Prompt 9 — needs BE coordination).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Audit results now display issues in grouped, collapsible sections by issue type, with severity indicators, instance counts, and expandable per-file buckets that reveal individual issue entries.
  * The Issues tab now renders grouped entries alongside flat entries for clearer navigation.

* **Tests**
  * Added comprehensive tests covering grouping logic, ordering, bucketing (including missing locations), and lazy rendering of issue rows.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/s4cindia/ninja-frontend/pull/267)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->