### PR TITLE
feat(audit): heuristic marker on FP-prone PRH issue rows

### DIFF
--- a/src/components/audit/GroupedIssueRow.tsx
+++ b/src/components/audit/GroupedIssueRow.tsx
@@ -28,6 +28,8 @@ import {
 import { cn } from '@/utils/cn';
 import { Badge } from '../ui/Badge';
 import type { GroupEntry, GroupableIssue } from './group-issues';
+import { isHeuristicCode } from './heuristic-codes';
+import { HeuristicMarker } from './HeuristicMarker';
 
 interface GroupedIssueRowProps<T extends GroupableIssue> {
   entry: GroupEntry<T>;
@@ -100,6 +102,10 @@ export function GroupedIssueRow<T extends GroupableIssue>({
           <Badge variant={sev.variant} size="sm">
             {entry.severity}
           </Badge>
+          {/* Heuristic marker also lives on the group header so the FP cue is
+              visible on grouped high-volume rows — otherwise operators only
+              see it after drilling down to individual issues. */}
+          {isHeuristicCode(entry.code) && <HeuristicMarker />}
         </span>
       </button>
 

--- a/src/components/audit/HeuristicMarker.tsx
+++ b/src/components/audit/HeuristicMarker.tsx
@@ -1,0 +1,32 @@
+/**
+ * Small "this is a heuristic" indicator rendered next to the severity badge
+ * on PRH issue rows whose code is pattern-derived (PRH-LANG-*, PRH-HASHTAG-*,
+ * PRH-ACRONYM-*). Hover/focus reveals a short explanation so operators don't
+ * mistake the finding for a definitive bug.
+ *
+ * Neutral gray styling — not red or yellow — so it reads as informational.
+ * The actual severity badge still carries the urgency cue.
+ */
+
+import { Info } from 'lucide-react';
+import { InfoTooltip } from '../ui/InfoTooltip';
+
+const TOOLTIP_TEXT =
+  'Pattern detector — this finding may be a false positive. Review the highlighted text manually before fixing.';
+
+export function HeuristicMarker() {
+  return (
+    <InfoTooltip
+      content={<span className="block">{TOOLTIP_TEXT}</span>}
+      maxWidth="260px"
+    >
+      <span
+        role="img"
+        aria-label="Heuristic finding"
+        className="inline-flex items-center text-gray-500 hover:text-gray-700 cursor-help"
+      >
+        <Info className="h-3.5 w-3.5" />
+      </span>
+    </InfoTooltip>
+  );
+}

--- a/src/components/audit/HeuristicMarker.tsx
+++ b/src/components/audit/HeuristicMarker.tsx
@@ -6,6 +6,11 @@
  *
  * Neutral gray styling — not red or yellow — so it reads as informational.
  * The actual severity badge still carries the urgency cue.
+ *
+ * Dual disclosure: InfoTooltip handles the styled hover/click case, and a
+ * native `title` attribute mirrors the message so keyboard users get the
+ * same text from the browser's built-in tooltip when they Tab to the icon
+ * (the shared InfoTooltip primitive isn't focus-aware on its own).
  */
 
 import { Info } from 'lucide-react';
@@ -23,7 +28,9 @@ export function HeuristicMarker() {
       <span
         role="img"
         aria-label="Heuristic finding"
-        className="inline-flex items-center text-gray-500 hover:text-gray-700 cursor-help"
+        title={TOOLTIP_TEXT}
+        tabIndex={0}
+        className="inline-flex items-center text-gray-500 hover:text-gray-700 focus:text-gray-700 focus:outline-none focus:ring-2 focus:ring-gray-400 focus:ring-offset-1 rounded-full cursor-help"
       >
         <Info className="h-3.5 w-3.5" />
       </span>

--- a/src/components/audit/__tests__/GroupedIssueRow.test.tsx
+++ b/src/components/audit/__tests__/GroupedIssueRow.test.tsx
@@ -116,6 +116,29 @@ describe('GroupedIssueRow', () => {
     ).toBeInTheDocument();
   });
 
+  it('renders the heuristic marker on the group header for FP-prone PRH codes', () => {
+    const heuristicIssues = Array.from({ length: 12 }, (_, i) =>
+      issue({
+        id: `h${i}`,
+        code: 'PRH-HASHTAG-NOT-CAMEL-CASE',
+        severity: 'minor',
+        location: `OEBPS/Text/c${(i % 3) + 1}.xhtml`,
+      }),
+    );
+    renderGroup(heuristicIssues);
+    // The marker is inside the header (still collapsed) — high-volume
+    // heuristic groups must show the FP cue without making the operator
+    // drill in.
+    expect(screen.getByLabelText(/Heuristic finding/i)).toBeInTheDocument();
+  });
+
+  it('does NOT render the heuristic marker on definitive (non-heuristic) group headers', () => {
+    // PRH-MARKUP-DEPRECATED-TAG is grouped by default but not a heuristic —
+    // it must not pick up the FP cue.
+    renderGroup(issues);
+    expect(screen.queryByLabelText(/Heuristic finding/i)).not.toBeInTheDocument();
+  });
+
   it('does not call renderIssue until a file sub-row is expanded', async () => {
     const renderIssue = vi.fn().mockReturnValue(null);
     const [entry] = groupIssues(issues);

--- a/src/components/audit/__tests__/HeuristicMarker.test.tsx
+++ b/src/components/audit/__tests__/HeuristicMarker.test.tsx
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { HeuristicMarker } from '../HeuristicMarker';
+
+describe('HeuristicMarker', () => {
+  it('renders an accessible icon trigger labelled "Heuristic finding"', () => {
+    render(<HeuristicMarker />);
+    expect(screen.getByLabelText(/Heuristic finding/i)).toBeInTheDocument();
+  });
+
+  it('reveals the false-positive tooltip on hover', async () => {
+    render(<HeuristicMarker />);
+    const trigger = screen.getByLabelText(/Heuristic finding/i);
+    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+
+    await userEvent.hover(trigger);
+    const tooltip = await screen.findByRole('tooltip');
+    expect(tooltip).toHaveTextContent(/Pattern detector/);
+    expect(tooltip).toHaveTextContent(/may be a false positive/);
+    expect(tooltip).toHaveTextContent(/Review the highlighted text manually/);
+  });
+
+  it('uses neutral (not red/yellow) styling so it reads as informational', () => {
+    render(<HeuristicMarker />);
+    const trigger = screen.getByLabelText(/Heuristic finding/i);
+    // Marker uses a neutral gray palette — confirm no warning colours leak in.
+    expect(trigger.className).toMatch(/text-gray-/);
+    expect(trigger.className).not.toMatch(/text-(red|orange|yellow)/);
+  });
+});

--- a/src/components/audit/__tests__/heuristic-codes.test.ts
+++ b/src/components/audit/__tests__/heuristic-codes.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { isHeuristicCode } from '../heuristic-codes';
+
+describe('isHeuristicCode', () => {
+  it.each([
+    'PRH-LANG-INLINE-NOT-MARKED',
+    'PRH-HASHTAG-NOT-CAMEL-CASE',
+    'PRH-ACRONYM-INSERTED-SEPARATORS',
+    // New family members inherit the marker via the prefix match — no FE
+    // change required when the backend adds another heuristic in the same
+    // family.
+    'PRH-LANG-RTL-NOT-DETECTED',
+    'PRH-HASHTAG-DUPLICATE-CASING',
+    'PRH-ACRONYM-LOWERCASE-CHUNK',
+  ])('returns true for known-heuristic code %s', (code) => {
+    expect(isHeuristicCode(code)).toBe(true);
+  });
+
+  it.each([
+    'PRH-MARKUP-DEPRECATED-TAG',
+    'PRH-MARKUP-INLINE-STYLE',
+    'PRH-PAGEBREAK-MALFORMED',
+    'PRH-FOOTNOTE-ID-MISMATCH',
+    'PRH-COPY-TDM-PARAGRAPH-MISSING',
+    'PRH-SOCIALS-STRAPLINE-MISSING',
+    'PRH-NAV-MISSING-PAGELIST',
+    'PRH-COVER-ALT-EMPTY',
+    'EPUB-IMG-001',
+    'EPUB-CHK-001',
+    'something-totally-different',
+  ])('returns false for non-heuristic code %s', (code) => {
+    expect(isHeuristicCode(code)).toBe(false);
+  });
+});

--- a/src/components/audit/heuristic-codes.ts
+++ b/src/components/audit/heuristic-codes.ts
@@ -1,0 +1,22 @@
+/**
+ * Identifies PRH issue codes that are pattern-detection heuristics — they fire
+ * on text patterns where the validator can't be certain the finding is a real
+ * issue. Operators need a visual cue that these are heuristics rather than
+ * definitive findings, otherwise they treat them as bugs and waste cycles.
+ *
+ * Known heuristics (P3 backend):
+ *   - PRH-LANG-INLINE-NOT-MARKED   non-Latin runs not wrapped in <span lang=…>
+ *   - PRH-HASHTAG-NOT-CAMEL-CASE   hashtag tokens not in PascalCase
+ *   - PRH-ACRONYM-INSERTED-SEPARATORS   ALL-CAPS sequences with separators
+ *
+ * Recognised by code-prefix rather than a backend tag so adding a new
+ * heuristic in the same family (e.g. PRH-LANG-RTL-NOT-DETECTED) automatically
+ * picks up the marker without an FE change. Add a new prefix here only when
+ * an entirely new heuristic family appears.
+ */
+
+const HEURISTIC_PREFIXES = ['PRH-LANG-', 'PRH-HASHTAG-', 'PRH-ACRONYM-'] as const;
+
+export function isHeuristicCode(code: string): boolean {
+  return HEURISTIC_PREFIXES.some((prefix) => code.startsWith(prefix));
+}

--- a/src/components/audit/index.ts
+++ b/src/components/audit/index.ts
@@ -12,6 +12,8 @@ export { isBoilerplateCode } from './boilerplate-codes';
 export { GroupedIssueRow } from './GroupedIssueRow';
 export { groupIssues } from './group-issues';
 export type { GroupableIssue, GroupEntry, FlatEntry, IssueEntry, FileBucket } from './group-issues';
+export { HeuristicMarker } from './HeuristicMarker';
+export { isHeuristicCode } from './heuristic-codes';
 export type {
   PublisherProfile,
   PublisherProfileSignal,

--- a/src/components/epub/EPUBAuditResults.tsx
+++ b/src/components/epub/EPUBAuditResults.tsx
@@ -13,7 +13,7 @@ import { Button } from '../ui/Button';
 import { Badge } from '../ui/Badge';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '../ui/Tabs';
 import { QuickRating } from '../feedback';
-import { SourceBadge, SummaryBySource, ViewInContextButton, RemediationGuidance, ScoreTooltip, PublisherProfileBadge, BoilerplateSuggestion, isBoilerplateCode, GroupedIssueRow, groupIssues, calculateScoreBreakdown } from '../audit';
+import { SourceBadge, SummaryBySource, ViewInContextButton, RemediationGuidance, ScoreTooltip, PublisherProfileBadge, BoilerplateSuggestion, isBoilerplateCode, GroupedIssueRow, groupIssues, HeuristicMarker, isHeuristicCode, calculateScoreBreakdown } from '../audit';
 import type { SummaryBySourceData, PublisherProfile } from '../audit';
 import { cn } from '@/utils/cn';
 import { getWcagUrl, getWcagTooltip, formatWcagLabel } from '@/utils/wcag';
@@ -584,6 +584,7 @@ const IssueCard: React.FC<{ issue: AuditIssue; jobId: string }> = ({ issue, jobI
             <Badge variant={config.variant} size="sm">
               {issue.severity}
             </Badge>
+            {isHeuristicCode(issue.code) && <HeuristicMarker />}
             <SourceBadge source={issue.source} />
             {autoFix ? (
               <Badge variant="success" size="sm">


### PR DESCRIPTION
## Summary
Prompt 8 of the PRH UK P2+P3 frontend follow-up plan. P3 backend ships three pattern-detection rules with a known higher false-positive rate than the rest of the PRH ruleset:

| Code | Detects | Known FPs |
|---|---|---|
| `PRH-LANG-INLINE-NOT-MARKED` | non-Latin script text not wrapped in `<span lang="…">` | proper nouns, single-emoji runs |
| `PRH-HASHTAG-NOT-CAMEL-CASE` | hashtag tokens not in PascalCase | imprint-convention hashtags |
| `PRH-ACRONYM-INSERTED-SEPARATORS` | ALL-CAPS sequences with separators | legitimate formal abbreviations |

Without a visual cue these read as definitive bugs and operators waste cycles "fixing" findings that were intentional content.

- New `isHeuristicCode` helper (in a separate `.ts` file so `react-refresh/only-export-components` doesn't trip on mixed exports) matches by prefix — `PRH-LANG-`, `PRH-HASHTAG-`, `PRH-ACRONYM-`. New family members (e.g. `PRH-LANG-RTL-NOT-DETECTED`) inherit the marker automatically.
- New `HeuristicMarker` component renders a neutral-gray Info icon next to the severity badge with an `InfoTooltip` (the existing rich-content tooltip primitive) reading: *"Pattern detector — this finding may be a false positive. Review the highlighted text manually before fixing."* Neutral palette (not red/yellow) so it reads as informational; the severity badge still owns the urgency cue.
- `EPUBAuditResults`' `IssueCard` renders the marker conditionally when `isHeuristicCode(issue.code)`. Definitive findings get no marker.

No backend coordination needed. No type changes.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean (max-warnings 0)
- [x] `npx vitest run` — 796 passed, 10 skipped (+20 new: 17 helper-allowlist cases including known heuristics, hypothetical same-family additions, and a wide negative sweep; 3 component cases covering accessible label, tooltip reveal on hover with the full message, and the neutral-styling assertion)
- [ ] Manual: audit a PRH EPUB on staging with a `PRH-HASHTAG-NOT-CAMEL-CASE` issue — confirm the row shows an Info icon next to the "minor" severity badge; hover reveals the tooltip text
- [ ] Manual: a `PRH-MARKUP-DEPRECATED-TAG` issue (definitive) shows NO Info icon on the same page

## Out of scope
- Dismiss workflow (Prompt 9 — needs BE coordination).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Audit results now show a neutral-info marker on heuristic findings with an accessible tooltip explaining these may be false positives and advising manual review.

* **Tests**
  * Added tests covering the heuristic marker UI, tooltip content, styling, and the detection logic for heuristic issue codes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/s4cindia/ninja-frontend/pull/268)

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/s4cindia/ninja-frontend/pull/268)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->