### PR TITLE
feat(audit): quick-fix dialog for PRH-COVER-ALT-EMPTY

### DIFF
--- a/src/components/quickfix/QuickFixPanel.tsx
+++ b/src/components/quickfix/QuickFixPanel.tsx
@@ -16,6 +16,37 @@ import { QuickFixRadioGroup } from './QuickFixRadioGroup';
 import { QuickFixTextInput } from './QuickFixTextInput';
 import { QuickFixColorPicker } from './QuickFixColorPicker';
 import { ImageAltTemplate } from './templates/ImageAltTemplate';
+import { PrhCoverAltTemplate } from './templates/PrhCoverAltTemplate';
+
+const PRH_COVER_ALT_CODE = 'PRH-COVER-ALT-EMPTY';
+
+/**
+ * Pulls the human-readable error message out of an axios-style error so the
+ * caller can surface it directly in the dialog. Falls back to `null` when the
+ * error doesn't carry a recognisable shape, letting the caller emit its own
+ * fallback copy.
+ */
+function extractApiErrorMessage(err: unknown): string | null {
+  if (!err || typeof err !== 'object') return null;
+  const e = err as {
+    response?: {
+      data?: { error?: { message?: string } | string; message?: string };
+    };
+    message?: string;
+  };
+  const data = e.response?.data;
+  if (data && typeof data === 'object') {
+    const errField = (data as { error?: { message?: string } | string }).error;
+    if (errField && typeof errField === 'object' && typeof errField.message === 'string') {
+      return errField.message;
+    }
+    if (typeof errField === 'string') return errField;
+    const topMessage = (data as { message?: string }).message;
+    if (typeof topMessage === 'string') return topMessage;
+  }
+  if (typeof e.message === 'string' && e.message) return e.message;
+  return null;
+}
 
 const IMAGE_ALT_ISSUE_CODES = [
   'EPUB-IMG-001', 'IMG-001', 'IMG-ALT', 'IMG-ALT-MISSING', 'IMG-ALT-EMPTY',
@@ -35,8 +66,15 @@ interface QuickFixPanelProps {
     context?: string;
     snippet?: string;
     lineNumber?: number;
+    imagePath?: string;
   };
   jobId?: string;
+  /**
+   * EPUB title used to pre-fill alt-text for PRH-COVER-ALT-EMPTY as
+   * "Cover for {bookTitle}". Optional — when absent the operator types
+   * the alt text from scratch.
+   */
+  bookTitle?: string;
   onApplyFix: (fix: QuickFix) => Promise<void>;
   onFixApplied?: () => void;
   onMarkFixed?: (taskId: string, notes?: string) => Promise<void>;
@@ -53,6 +91,7 @@ type ToastState = {
 export function QuickFixPanel({
   issue,
   jobId,
+  bookTitle,
   onApplyFix,
   onFixApplied,
   onMarkFixed,
@@ -75,7 +114,15 @@ export function QuickFixPanel({
   const [toast, setToast] = useState<ToastState>(null);
   const [errors, setErrors] = useState<Record<string, string>>({});
   const [imageAltValid, setImageAltValid] = useState(false);
-  
+
+  // PRH-COVER-ALT-EMPTY state — kept separate from the generic template path
+  // because the backend takes a fixed `imageAlts` payload rather than the
+  // FileChange[] format other quick fixes use.
+  const isPrhCoverIssue = issue.code === PRH_COVER_ALT_CODE;
+  const [coverAltText, setCoverAltText] = useState('');
+  const [coverImageSrc, setCoverImageSrc] = useState('');
+  const [coverApiError, setCoverApiError] = useState<string | null>(null);
+
   const isImageAltIssue = IMAGE_ALT_ISSUE_CODES.some(
     code => issue.code.toUpperCase().replace(/_/g, '-') === code
   );
@@ -183,6 +230,59 @@ export function QuickFixPanel({
       return null;
     }
   }, [template, inputValues, context, showPreview]);
+
+  const handleApplyPrhCover = async () => {
+    if (!jobId) {
+      setCoverApiError('Missing job ID — cannot submit fix.');
+      return;
+    }
+    // Surface client-side validation immediately so the operator doesn't burn
+    // a round-trip for an obvious empty-field case. The BE validates the same
+    // rules but its 400 message is still authoritative when it fires.
+    const altTrimmed = coverAltText.trim();
+    const srcTrimmed = coverImageSrc.trim();
+    if (!srcTrimmed) {
+      setCoverApiError('Cover image path is required.');
+      return;
+    }
+    if (!altTrimmed) {
+      setCoverApiError('Alt text is required.');
+      return;
+    }
+
+    setIsApplying(true);
+    setCoverApiError(null);
+    setToast(null);
+
+    try {
+      // Calling api.post directly (rather than the applyQuickFix service
+      // wrapper) so the axios error survives — the BE returns a 400 with a
+      // per-field message that the operator needs to see in-dialog.
+      await api.post(`/epub/job/${jobId}/apply-fix`, {
+        fixCode: PRH_COVER_ALT_CODE,
+        options: {
+          imageAlts: [{ imageSrc: srcTrimmed, altText: altTrimmed }],
+        },
+      });
+      setToast({ type: 'success', message: 'Cover alt text applied — re-audit to verify.' });
+      try {
+        await api.post(`/epub/job/${jobId}/task/${issue.id}/mark-fixed`, {
+          notes: `Cover alt text added: "${altTrimmed.slice(0, 80)}${altTrimmed.length > 80 ? '…' : ''}"`,
+        });
+      } catch (markErr) {
+        console.warn('mark-fixed failed (may auto-complete on BE):', markErr);
+      }
+      onFixApplied?.();
+      closeTimeoutRef.current = setTimeout(() => onClose?.(), 1500);
+    } catch (err) {
+      // Backend returns 400 with a field-specific message — pull it out so
+      // the operator can correct in place. Falls back to a generic message.
+      const apiMsg = extractApiErrorMessage(err);
+      setCoverApiError(apiMsg ?? 'Failed to apply cover alt-text fix.');
+    } finally {
+      setIsApplying(false);
+    }
+  };
 
   const handleInputChange = useCallback((inputId: string, value: unknown) => {
     setInputValues(prev => ({ ...prev, [inputId]: value }));
@@ -321,6 +421,102 @@ export function QuickFixPanel({
         return null;
     }
   };
+
+  // Dedicated render branch for PRH-COVER-ALT-EMPTY. Short-circuits the
+  // template / backend-fix / manual branches below because the BE accepts a
+  // specific `imageAlts` payload that doesn't map to the generic template
+  // input system.
+  if (isPrhCoverIssue) {
+    return (
+      <div className="bg-white rounded-lg border border-gray-200 shadow-sm">
+        <div className="flex items-center gap-3 p-4 border-b border-gray-200">
+          <div className="p-2 bg-teal-100 rounded-lg">
+            <Wrench className="h-5 w-5 text-teal-600" />
+          </div>
+          <div className="flex-1 min-w-0">
+            <h3 className="font-semibold text-gray-900">Add cover image alt text</h3>
+            <p className="text-sm text-gray-500 truncate">
+              PRH UK requires descriptive alt on the cover image.
+            </p>
+          </div>
+          {onClose && (
+            <button
+              onClick={onClose}
+              className="p-1 text-gray-400 hover:text-gray-600 rounded"
+              aria-label="Close panel"
+            >
+              <X className="h-5 w-5" />
+            </button>
+          )}
+        </div>
+
+        <div className="p-4 space-y-4">
+          <div className="p-3 bg-gray-50 rounded-lg">
+            <p className="text-sm text-gray-700">
+              <span className="font-medium">Issue:</span> {issue.message}
+            </p>
+          </div>
+
+          <PrhCoverAltTemplate
+            issue={issue}
+            bookTitle={bookTitle}
+            altText={coverAltText}
+            onAltTextChange={(v) => {
+              setCoverAltText(v);
+              if (coverApiError) setCoverApiError(null);
+            }}
+            imageSrc={coverImageSrc}
+            onImageSrcChange={(v) => {
+              setCoverImageSrc(v);
+              if (coverApiError) setCoverApiError(null);
+            }}
+            apiError={coverApiError}
+            isApplying={isApplying}
+          />
+
+          {toast?.type === 'success' && (
+            <div
+              className="flex items-center gap-2 p-3 rounded-lg bg-green-50 text-green-700"
+              role="alert"
+            >
+              <CheckCircle className="h-5 w-5 flex-shrink-0" />
+              <span className="text-sm">{toast.message}</span>
+            </div>
+          )}
+        </div>
+
+        <div className="flex items-center gap-2 p-4 border-t border-gray-200 bg-gray-50">
+          <button
+            onClick={handleApplyPrhCover}
+            disabled={isApplying || !jobId}
+            className={cn(
+              'flex items-center gap-2 px-4 py-2 rounded-lg font-medium transition-colors',
+              'bg-primary-600 text-white hover:bg-primary-700',
+              'disabled:opacity-50 disabled:cursor-not-allowed'
+            )}
+          >
+            {isApplying ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <Play className="h-4 w-4" />
+            )}
+            {isApplying ? 'Applying...' : 'Apply Cover Alt Text'}
+          </button>
+
+          {onSkip && (
+            <button
+              onClick={onSkip}
+              disabled={isApplying}
+              className="flex items-center gap-2 px-4 py-2 text-gray-600 hover:text-gray-800 transition-colors disabled:opacity-50"
+            >
+              <SkipForward className="h-4 w-4" />
+              Skip
+            </button>
+          )}
+        </div>
+      </div>
+    );
+  }
 
   if (isLoadingData) {
     return (

--- a/src/components/quickfix/QuickFixPanel.tsx
+++ b/src/components/quickfix/QuickFixPanel.tsx
@@ -123,6 +123,26 @@ export function QuickFixPanel({
   const [coverImageSrc, setCoverImageSrc] = useState('');
   const [coverApiError, setCoverApiError] = useState<string | null>(null);
 
+  // Reset PRH form state when the panel is reused for a different issue.
+  // Done during render rather than in an effect so the reset lands before
+  // the re-keyed PrhCoverAltTemplate mounts — running it as a useEffect
+  // would mean the template's own mount-time pre-fill effect (which reads
+  // `altText` from props) sees the stale value from the previous issue and
+  // skips the pre-fill.
+  //
+  // React supports this pattern explicitly: setState during render is
+  // bailed out of when the previous state matches, and otherwise triggers
+  // a single additional render synchronously in the same commit.
+  // https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes
+  const prhLastIssueIdRef = useRef(issue.id);
+  if (isPrhCoverIssue && prhLastIssueIdRef.current !== issue.id) {
+    prhLastIssueIdRef.current = issue.id;
+    setCoverAltText('');
+    setCoverImageSrc('');
+    setCoverApiError(null);
+    setToast(null);
+  }
+
   const isImageAltIssue = IMAGE_ALT_ISSUE_CODES.some(
     code => issue.code.toUpperCase().replace(/_/g, '-') === code
   );
@@ -265,12 +285,24 @@ export function QuickFixPanel({
         },
       });
       setToast({ type: 'success', message: 'Cover alt text applied — re-audit to verify.' });
-      try {
-        await api.post(`/epub/job/${jobId}/task/${issue.id}/mark-fixed`, {
-          notes: `Cover alt text added: "${altTrimmed.slice(0, 80)}${altTrimmed.length > 80 ? '…' : ''}"`,
-        });
-      } catch (markErr) {
-        console.warn('mark-fixed failed (may auto-complete on BE):', markErr);
+      const markNote = `Cover alt text added: "${altTrimmed.slice(0, 80)}${altTrimmed.length > 80 ? '…' : ''}"`;
+      // Honor the onMarkFixed contract when the caller supplied one — keeps
+      // this branch consistent with the other apply flows (handleApplyFix,
+      // handleApplyBackendFix) and lets parents override the bookkeeping.
+      if (onMarkFixed) {
+        try {
+          await onMarkFixed(issue.id, markNote);
+        } catch (markErr) {
+          console.warn('onMarkFixed callback failed:', markErr);
+        }
+      } else {
+        try {
+          await api.post(`/epub/job/${jobId}/task/${issue.id}/mark-fixed`, {
+            notes: markNote,
+          });
+        } catch (markErr) {
+          console.warn('mark-fixed failed (may auto-complete on BE):', markErr);
+        }
       }
       onFixApplied?.();
       closeTimeoutRef.current = setTimeout(() => onClose?.(), 1500);
@@ -458,6 +490,10 @@ export function QuickFixPanel({
           </div>
 
           <PrhCoverAltTemplate
+            // Force a fresh template instance when the panel is re-used for
+            // a new issue so the template's own once-on-mount pre-fill effect
+            // runs against the new issue's bookTitle / extracted image src.
+            key={issue.id}
             issue={issue}
             bookTitle={bookTitle}
             altText={coverAltText}

--- a/src/components/quickfix/__tests__/QuickFixPanel.prhCover.test.tsx
+++ b/src/components/quickfix/__tests__/QuickFixPanel.prhCover.test.tsx
@@ -122,6 +122,75 @@ describe('QuickFixPanel — PRH-COVER-ALT-EMPTY branch', () => {
     expect(alert).toHaveTextContent(/Alt text is required/i);
   });
 
+  it('resets the cover form state when the panel is reused for a different PRH issue', async () => {
+    postMock.mockResolvedValue({ data: { data: { results: [] } } });
+    const { rerender } = render(
+      <QuickFixPanel
+        issue={{ ...issue, id: 'iss-cover-a' }}
+        jobId="job-1"
+        bookTitle="Book A"
+        onApplyFix={vi.fn()}
+      />,
+    );
+    const altInputA = screen.getByLabelText(/Alt text/i) as HTMLTextAreaElement;
+    expect(altInputA.value).toBe('Cover for Book A');
+
+    // Pretend the operator edited it before swapping issues — the new issue
+    // must NOT inherit the previous text.
+    await userEvent.clear(altInputA);
+    await userEvent.type(altInputA, 'leftover');
+    expect((screen.getByLabelText(/Alt text/i) as HTMLTextAreaElement).value).toBe(
+      'leftover',
+    );
+
+    rerender(
+      <QuickFixPanel
+        issue={{ ...issue, id: 'iss-cover-b', imagePath: 'EPUB/images/cover-b.jpg' }}
+        jobId="job-1"
+        bookTitle="Book B"
+        onApplyFix={vi.fn()}
+      />,
+    );
+
+    await waitFor(() =>
+      expect((screen.getByLabelText(/Alt text/i) as HTMLTextAreaElement).value).toBe(
+        'Cover for Book B',
+      ),
+    );
+    expect((screen.getByLabelText(/Cover image path/i) as HTMLInputElement).value).toBe(
+      'EPUB/images/cover-b.jpg',
+    );
+  });
+
+  it('invokes the onMarkFixed callback (instead of POSTing mark-fixed directly) when provided', async () => {
+    postMock.mockResolvedValue({ data: { data: { results: [] } } });
+    const onMarkFixed = vi.fn().mockResolvedValue(undefined);
+    render(
+      <QuickFixPanel
+        issue={issue}
+        jobId="job-1"
+        bookTitle="Test Book"
+        onApplyFix={vi.fn()}
+        onMarkFixed={onMarkFixed}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: /Apply Cover Alt Text/i }));
+    await waitFor(() => expect(onMarkFixed).toHaveBeenCalled());
+    expect(onMarkFixed).toHaveBeenCalledWith(
+      'iss-cover-1',
+      expect.stringContaining('Cover alt text added'),
+    );
+
+    // The apply-fix call still goes through, but the direct mark-fixed POST
+    // must NOT fire when the caller supplied a callback — duplicating the
+    // bookkeeping would invite race conditions.
+    const markFixedCalls = postMock.mock.calls.filter(
+      ([url]) => typeof url === 'string' && url.includes('/mark-fixed'),
+    );
+    expect(markFixedCalls).toHaveLength(0);
+  });
+
   it('clears the apiError state when the operator edits the alt-text field', async () => {
     postMock.mockRejectedValueOnce({
       response: { data: { error: { message: 'whatever' } } },

--- a/src/components/quickfix/__tests__/QuickFixPanel.prhCover.test.tsx
+++ b/src/components/quickfix/__tests__/QuickFixPanel.prhCover.test.tsx
@@ -1,0 +1,144 @@
+/**
+ * Scoped integration tests for the `PRH-COVER-ALT-EMPTY` branch of
+ * QuickFixPanel. The broader panel has many other branches (template-driven
+ * inputs, backend-fix-only, manual remediation) that are covered elsewhere
+ * or implicitly — this file only exercises the new cover-alt path so the
+ * apply-handler wiring stays correct as the panel evolves.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+// vi.mock factories hoist to the top of the file, so the mock function must
+// be created inside vi.hoisted() to avoid the TDZ "Cannot access before
+// initialization" error when the mock body references it.
+const { postMock } = vi.hoisted(() => ({ postMock: vi.fn() }));
+vi.mock('@/services/api', () => ({
+  api: { post: postMock },
+}));
+
+import { QuickFixPanel } from '../QuickFixPanel';
+
+const issue = {
+  id: 'iss-cover-1',
+  code: 'PRH-COVER-ALT-EMPTY',
+  message: 'Cover image is missing alt text.',
+  location: 'EPUB/xhtml/cover.xhtml',
+  imagePath: 'EPUB/images/cover.jpg',
+};
+
+describe('QuickFixPanel — PRH-COVER-ALT-EMPTY branch', () => {
+  beforeEach(() => {
+    postMock.mockReset();
+  });
+
+  it('renders the cover-alt template (not the generic image-alt template)', () => {
+    render(
+      <QuickFixPanel
+        issue={issue}
+        jobId="job-1"
+        bookTitle="The Midnight Library"
+        onApplyFix={vi.fn()}
+      />,
+    );
+    expect(
+      screen.getByRole('heading', { name: /Add cover image alt text/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText(/Alt text/i)).toHaveValue(
+      'Cover for The Midnight Library',
+    );
+    expect(screen.getByLabelText(/Cover image path/i)).toHaveValue(
+      'EPUB/images/cover.jpg',
+    );
+  });
+
+  it('POSTs the imageAlts payload to /epub/job/:id/apply-fix on submit', async () => {
+    postMock.mockResolvedValue({ data: { data: { results: [] } } });
+    render(
+      <QuickFixPanel
+        issue={issue}
+        jobId="job-1"
+        bookTitle="Test Book"
+        onApplyFix={vi.fn()}
+      />,
+    );
+    await userEvent.click(screen.getByRole('button', { name: /Apply Cover Alt Text/i }));
+
+    await waitFor(() => expect(postMock).toHaveBeenCalled());
+    const applyCall = postMock.mock.calls.find(
+      ([url]) => typeof url === 'string' && url.endsWith('/apply-fix'),
+    );
+    expect(applyCall).toBeDefined();
+    expect(applyCall![0]).toBe('/epub/job/job-1/apply-fix');
+    expect(applyCall![1]).toEqual({
+      fixCode: 'PRH-COVER-ALT-EMPTY',
+      options: {
+        imageAlts: [
+          { imageSrc: 'EPUB/images/cover.jpg', altText: 'Cover for Test Book' },
+        ],
+      },
+    });
+  });
+
+  it('surfaces a backend 400 message directly in the dialog (no generic toast)', async () => {
+    postMock.mockRejectedValueOnce({
+      response: {
+        data: { error: { message: '`imageSrc` is required for cover image' } },
+      },
+    });
+    render(
+      <QuickFixPanel
+        issue={issue}
+        jobId="job-1"
+        bookTitle="Test"
+        onApplyFix={vi.fn()}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: /Apply Cover Alt Text/i }));
+
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveTextContent('Server rejected the fix');
+    expect(alert).toHaveTextContent('`imageSrc` is required for cover image');
+  });
+
+  it('blocks submit and shows an in-dialog error when alt text is empty', async () => {
+    render(
+      <QuickFixPanel
+        issue={{ ...issue, imagePath: 'EPUB/images/cover.jpg' }}
+        jobId="job-1"
+        // bookTitle absent → no pre-fill → alt-text starts empty.
+        onApplyFix={vi.fn()}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: /Apply Cover Alt Text/i }));
+
+    // Network call never fires — client-side validation short-circuits so
+    // the operator gets immediate feedback rather than a round-trip.
+    expect(postMock).not.toHaveBeenCalled();
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveTextContent(/Alt text is required/i);
+  });
+
+  it('clears the apiError state when the operator edits the alt-text field', async () => {
+    postMock.mockRejectedValueOnce({
+      response: { data: { error: { message: 'whatever' } } },
+    });
+    render(
+      <QuickFixPanel
+        issue={issue}
+        jobId="job-1"
+        bookTitle="Test Book"
+        onApplyFix={vi.fn()}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: /Apply Cover Alt Text/i }));
+    await waitFor(() => expect(screen.queryByRole('alert')).toBeInTheDocument());
+
+    await userEvent.type(screen.getByLabelText(/Alt text/i), '!');
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/quickfix/templates/PrhCoverAltTemplate.tsx
+++ b/src/components/quickfix/templates/PrhCoverAltTemplate.tsx
@@ -1,0 +1,150 @@
+/**
+ * Quick-fix dialog body for `PRH-COVER-ALT-EMPTY`.
+ *
+ * The PRH UK audit fires this code on EPUBs whose cover image has an empty
+ * or missing `alt`. The backend (ninja-backend PR #377) routes the fix
+ * through the same `POST /epub/job/:jobId/apply-fix` endpoint as
+ * `EPUB-IMG-001`, but with a stricter validator: `imageAlts` must be
+ * non-empty, `imageSrc` must be non-whitespace, `altText` must be
+ * non-whitespace. 400 responses carry a human-readable message naming
+ * the offending field — surface it in the dialog so the operator can
+ * fix in place rather than re-opening the panel.
+ *
+ * Cover image src is extracted from whatever issue field carries the
+ * surrounding HTML; if extraction fails we expose the src as a manual
+ * input so the operator can paste it.
+ */
+
+import { useState, useEffect, useId } from 'react';
+import { AlertCircle, BookOpen, Loader2 } from 'lucide-react';
+import { extractCoverImageSrc, type CoverIssue } from './prh-cover-extract';
+
+interface PrhCoverAltTemplateProps {
+  issue: CoverIssue;
+  /** Used to pre-fill the alt-text input as "Cover for {bookTitle}". */
+  bookTitle?: string;
+  altText: string;
+  onAltTextChange: (value: string) => void;
+  imageSrc: string;
+  onImageSrcChange: (value: string) => void;
+  /** Backend validation message, if any (rendered in-dialog). */
+  apiError: string | null;
+  isApplying: boolean;
+}
+
+export function PrhCoverAltTemplate({
+  issue,
+  bookTitle,
+  altText,
+  onAltTextChange,
+  imageSrc,
+  onImageSrcChange,
+  apiError,
+  isApplying,
+}: PrhCoverAltTemplateProps) {
+  const altInputId = useId();
+  const srcInputId = useId();
+
+  // Pre-fill on mount only — never overwrite something the operator has
+  // already typed (re-renders from parent prop changes shouldn't clobber).
+  const [hasInitialised, setHasInitialised] = useState(false);
+  useEffect(() => {
+    if (hasInitialised) return;
+    if (!altText) {
+      if (bookTitle && bookTitle.trim()) {
+        onAltTextChange(`Cover for ${bookTitle.trim()}`);
+      }
+    }
+    if (!imageSrc) {
+      const extracted = extractCoverImageSrc(issue);
+      if (extracted) onImageSrcChange(extracted);
+    }
+    setHasInitialised(true);
+    // Run once when the component mounts for a given issue. Re-running on
+    // every render would race with the user typing.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const extractedSrcMissing = imageSrc.trim() === '';
+
+  return (
+    <div className="space-y-4">
+      <div className="p-3 bg-teal-50 border border-teal-200 rounded-lg flex gap-2">
+        <BookOpen className="h-4 w-4 text-teal-600 shrink-0 mt-0.5" aria-hidden="true" />
+        <p className="text-xs text-teal-900 leading-relaxed">
+          PRH UK requires descriptive alt text on the cover image so screen-reader
+          users can identify the book. Keep it short and specific — for example,
+          <em> "Cover for The Midnight Library by Matt Haig"</em>.
+        </p>
+      </div>
+
+      <div>
+        <label htmlFor={srcInputId} className="block text-sm font-medium text-gray-700 mb-1">
+          Cover image path
+          {extractedSrcMissing && <span className="ml-1 text-red-600">*</span>}
+        </label>
+        <input
+          id={srcInputId}
+          type="text"
+          value={imageSrc}
+          onChange={(e) => onImageSrcChange(e.target.value)}
+          placeholder="e.g., EPUB/images/cover.jpg"
+          disabled={isApplying}
+          className="w-full px-3 py-2 text-sm border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary-500 disabled:bg-gray-50 disabled:text-gray-500"
+        />
+        <p className="mt-1 text-xs text-gray-500">
+          {extractedSrcMissing
+            ? 'Could not detect the cover image src — paste the path from the EPUB.'
+            : 'Auto-detected from the audit issue. Edit if it points to the wrong image.'}
+        </p>
+      </div>
+
+      <div>
+        <label htmlFor={altInputId} className="block text-sm font-medium text-gray-700 mb-1">
+          Alt text <span className="text-red-600">*</span>
+        </label>
+        <textarea
+          id={altInputId}
+          value={altText}
+          onChange={(e) => onAltTextChange(e.target.value)}
+          rows={2}
+          placeholder={
+            bookTitle ? `Cover for ${bookTitle}` : 'e.g., Cover for [Book Title]'
+          }
+          maxLength={250}
+          disabled={isApplying}
+          className="w-full px-3 py-2 text-sm border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary-500 disabled:bg-gray-50 disabled:text-gray-500"
+        />
+        <div className="mt-1 flex items-center justify-between text-xs text-gray-500">
+          <span>Describe what the cover shows; max 250 chars.</span>
+          <span>{altText.length}/250</span>
+        </div>
+      </div>
+
+      {apiError && (
+        <div
+          role="alert"
+          aria-live="polite"
+          className="flex items-start gap-2 p-3 bg-red-50 border border-red-200 rounded-md"
+        >
+          <AlertCircle className="h-4 w-4 text-red-600 shrink-0 mt-0.5" aria-hidden="true" />
+          <div className="text-sm text-red-700">
+            <p className="font-medium">Server rejected the fix</p>
+            <p className="mt-0.5">{apiError}</p>
+          </div>
+        </div>
+      )}
+
+      {isApplying && (
+        <div className="flex items-center gap-2 text-sm text-gray-500">
+          <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+          Applying cover alt-text fix…
+        </div>
+      )}
+
+      <p className="text-xs text-gray-400" data-testid="prh-cover-issue-location">
+        Issue location: <span className="font-mono">{issue.location ?? '(unknown)'}</span>
+      </p>
+    </div>
+  );
+}

--- a/src/components/quickfix/templates/__tests__/PrhCoverAltTemplate.test.tsx
+++ b/src/components/quickfix/templates/__tests__/PrhCoverAltTemplate.test.tsx
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { PrhCoverAltTemplate } from '../PrhCoverAltTemplate';
+import { extractCoverImageSrc } from '../prh-cover-extract';
+
+const baseIssue = {
+  id: 'iss-1',
+  code: 'PRH-COVER-ALT-EMPTY',
+  message: 'Cover image is missing alt text.',
+  location: 'EPUB/xhtml/cover.xhtml',
+};
+
+describe('extractCoverImageSrc', () => {
+  it('returns the imagePath field when set', () => {
+    expect(
+      extractCoverImageSrc({ ...baseIssue, imagePath: 'EPUB/images/cover.jpg' }),
+    ).toBe('EPUB/images/cover.jpg');
+  });
+
+  it('falls back to context.images[0].fullPath when context parses as JSON', () => {
+    const context = JSON.stringify({
+      images: [{ fullPath: 'OEBPS/images/cover.png', html: '<img …/>' }],
+    });
+    expect(extractCoverImageSrc({ ...baseIssue, context })).toBe(
+      'OEBPS/images/cover.png',
+    );
+  });
+
+  it('falls through to the html regex when context is not JSON', () => {
+    expect(
+      extractCoverImageSrc({
+        ...baseIssue,
+        html: '<img src="EPUB/images/cover-front.jpg" alt=""/>',
+      }),
+    ).toBe('EPUB/images/cover-front.jpg');
+  });
+
+  it('returns "" when nothing in the issue carries a src', () => {
+    expect(extractCoverImageSrc(baseIssue)).toBe('');
+  });
+});
+
+describe('PrhCoverAltTemplate', () => {
+  function setup(over: Partial<React.ComponentProps<typeof PrhCoverAltTemplate>> = {}) {
+    // Pull the change handlers out of `over` first so we can fall back to a
+    // fresh mock when the caller didn't supply one — and so spreading `over`
+    // later doesn't re-introduce undefined values from missing keys.
+    const onAltTextChange = over.onAltTextChange ?? vi.fn();
+    const onImageSrcChange = over.onImageSrcChange ?? vi.fn();
+    const { onAltTextChange: _omitA, onImageSrcChange: _omitB, ...rest } = over;
+    void _omitA;
+    void _omitB;
+    const props: React.ComponentProps<typeof PrhCoverAltTemplate> = {
+      issue: baseIssue,
+      bookTitle: undefined,
+      altText: '',
+      imageSrc: '',
+      apiError: null,
+      isApplying: false,
+      ...rest,
+      onAltTextChange,
+      onImageSrcChange,
+    };
+    return { ...render(<PrhCoverAltTemplate {...props} />), onAltTextChange, onImageSrcChange };
+  }
+
+  it('pre-fills the alt-text input with "Cover for {bookTitle}" on mount when title is supplied', () => {
+    const onAltTextChange = vi.fn();
+    setup({ bookTitle: 'The Midnight Library', onAltTextChange });
+    expect(onAltTextChange).toHaveBeenCalledWith('Cover for The Midnight Library');
+  });
+
+  it('does not pre-fill alt text when bookTitle is missing', () => {
+    const onAltTextChange = vi.fn();
+    setup({ onAltTextChange });
+    expect(onAltTextChange).not.toHaveBeenCalled();
+  });
+
+  it('does not overwrite an alt-text value the operator already typed', () => {
+    const onAltTextChange = vi.fn();
+    setup({ bookTitle: 'Book', altText: 'Operator typed this', onAltTextChange });
+    expect(onAltTextChange).not.toHaveBeenCalled();
+  });
+
+  it('pre-fills the image src on mount when the issue carries one', () => {
+    const onImageSrcChange = vi.fn();
+    setup({
+      issue: { ...baseIssue, imagePath: 'EPUB/images/cover.jpg' },
+      onImageSrcChange,
+    });
+    expect(onImageSrcChange).toHaveBeenCalledWith('EPUB/images/cover.jpg');
+  });
+
+  it('exposes a manual image-src input and flags when extraction failed', () => {
+    setup();
+    expect(
+      screen.getByText(/Could not detect the cover image src/i),
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText(/Cover image path/i)).toBeInTheDocument();
+  });
+
+  it('renders the backend validation error verbatim when apiError is set', () => {
+    setup({ apiError: '`altText` cannot be empty for cover image' });
+    const alert = screen.getByRole('alert');
+    expect(alert).toHaveTextContent('Server rejected the fix');
+    expect(alert).toHaveTextContent('`altText` cannot be empty for cover image');
+  });
+
+  it('disables both inputs while a submit is in flight', () => {
+    setup({ isApplying: true });
+    expect(screen.getByLabelText(/Cover image path/i)).toBeDisabled();
+    expect(screen.getByLabelText(/Alt text/i)).toBeDisabled();
+    expect(screen.getByText(/Applying cover alt-text fix/i)).toBeInTheDocument();
+  });
+
+  it('forwards subsequent edits via onAltTextChange', async () => {
+    const onAltTextChange = vi.fn();
+    setup({ onAltTextChange });
+    const input = screen.getByLabelText(/Alt text/i);
+    await userEvent.type(input, 'A');
+    // Type fires per-character changes; check the latest call carries the
+    // partial value the parent should commit.
+    expect(onAltTextChange).toHaveBeenCalled();
+    expect(onAltTextChange).toHaveBeenLastCalledWith('A');
+  });
+});

--- a/src/components/quickfix/templates/prh-cover-extract.ts
+++ b/src/components/quickfix/templates/prh-cover-extract.ts
@@ -1,0 +1,48 @@
+/**
+ * Helpers for the PRH-COVER-ALT-EMPTY quick-fix flow that don't render UI.
+ *
+ * Kept in a non-component file so the react-refresh/only-export-components
+ * lint rule stays satisfied — importing a helper from a component file
+ * breaks fast-refresh for everything that depends on that component.
+ */
+
+export interface CoverIssue {
+  id: string;
+  code: string;
+  message: string;
+  location?: string;
+  html?: string;
+  element?: string;
+  context?: string;
+  snippet?: string;
+  imagePath?: string;
+}
+
+/**
+ * Single-cover-image extraction. Returns the first `src` we can find or the
+ * empty string. The operator can override via the manual input in the
+ * template if extraction misses — the cover img tag is usually carried on
+ * the issue payload but legacy issues may omit context fields.
+ */
+export function extractCoverImageSrc(issue: CoverIssue): string {
+  if (issue.imagePath) return issue.imagePath.trim();
+
+  if (issue.context) {
+    try {
+      const parsed = JSON.parse(issue.context) as {
+        images?: Array<{ fullPath?: string; src?: string }>;
+      };
+      const first = parsed.images?.[0];
+      if (first?.fullPath) return first.fullPath.trim();
+      if (first?.src) return first.src.trim();
+    } catch {
+      // Context wasn't JSON — fall through to the regex extraction.
+    }
+  }
+
+  const haystack = [issue.html, issue.element, issue.snippet, issue.message]
+    .filter((s): s is string => typeof s === 'string')
+    .join('\n');
+  const match = haystack.match(/src=["']([^"']+)["']/);
+  return match ? match[1].trim() : '';
+}

--- a/src/components/quickfix/templates/prh-cover-extract.ts
+++ b/src/components/quickfix/templates/prh-cover-extract.ts
@@ -25,7 +25,11 @@ export interface CoverIssue {
  * the issue payload but legacy issues may omit context fields.
  */
 export function extractCoverImageSrc(issue: CoverIssue): string {
-  if (issue.imagePath) return issue.imagePath.trim();
+  // Trim first, then check — a whitespace-only field is no better than
+  // an absent one, and short-circuiting on it would skip the later
+  // fallback sources.
+  const imagePath = issue.imagePath?.trim();
+  if (imagePath) return imagePath;
 
   if (issue.context) {
     try {
@@ -33,8 +37,10 @@ export function extractCoverImageSrc(issue: CoverIssue): string {
         images?: Array<{ fullPath?: string; src?: string }>;
       };
       const first = parsed.images?.[0];
-      if (first?.fullPath) return first.fullPath.trim();
-      if (first?.src) return first.src.trim();
+      const fullPath = first?.fullPath?.trim();
+      if (fullPath) return fullPath;
+      const src = first?.src?.trim();
+      if (src) return src;
     } catch {
       // Context wasn't JSON — fall through to the regex extraction.
     }
@@ -44,5 +50,6 @@ export function extractCoverImageSrc(issue: CoverIssue): string {
     .filter((s): s is string => typeof s === 'string')
     .join('\n');
   const match = haystack.match(/src=["']([^"']+)["']/);
-  return match ? match[1].trim() : '';
+  const matched = match?.[1]?.trim();
+  return matched ?? '';
 }

--- a/src/data/quickFixTemplates.ts
+++ b/src/data/quickFixTemplates.ts
@@ -1435,12 +1435,21 @@ export function getBackendFixInfo(issueCode: string): BackendFixInfo | undefined
   return BACKEND_HANDLED_FIX_CODES[normalized];
 }
 
+// PRH-COVER-ALT-EMPTY is handled by a dedicated branch in QuickFixPanel —
+// it has no FE template (the backend does the actual EPUB edit) and isn't
+// in BACKEND_HANDLED_FIX_CODES (those render a no-input "click apply" UI,
+// whereas PRH-COVER-ALT-EMPTY needs the operator to supply alt text).
+// Register it here so RemediationTaskCard treats the code as quick-fixable
+// and renders QuickFixPanel; the panel's own dispatch then takes over.
+const PANEL_HANDLED_FIX_CODES = new Set<string>(['PRH-COVER-ALT-EMPTY']);
+
 export function hasQuickFixTemplate(issueCode: string): boolean {
   if (!issueCode) return false;
   if (getQuickFixTemplate(issueCode) !== undefined) {
     return true;
   }
-  return isBackendHandledFixCode(issueCode);
+  if (isBackendHandledFixCode(issueCode)) return true;
+  return PANEL_HANDLED_FIX_CODES.has(normalizeBackendFixCode(issueCode));
 }
 
 export function registerQuickFixTemplate(template: QuickFixTemplate): void {


### PR DESCRIPTION
## Summary
Prompt 3 of the PRH UK P1 frontend follow-up plan. Backend PR #377 landed the controller switch cases (both `applyQuickFix` and `applyBatchQuickFix`), so the FE can now wire `PRH-COVER-ALT-EMPTY` through the existing quick-fix endpoint.

- **`PrhCoverAltTemplate`** — small dedicated dialog body (intentionally not `ImageAltTemplate` — that one drives the FE-side HTML-replacement path with FileChange payloads; this one collects fields for the BE to consume).
- **`prh-cover-extract`** — non-component helper file (keeps `react-refresh/only-export-components` happy) for cover-image-src extraction: `imagePath` → parsed `context.images[0].fullPath` → regex on html/element/snippet/message. Falls back to a manual input if all three miss.
- **`QuickFixPanel` early-return branch** for `issue.code === 'PRH-COVER-ALT-EMPTY'`. Posts the BE's required shape `{ fixCode, options: { imageAlts: [{ imageSrc, altText }] } }` directly to `/epub/job/:jobId/apply-fix` — bypassing the `applyQuickFix` service wrapper so the axios error survives (the BE returns a 400 with a per-field message the operator needs to see).
- **`extractApiErrorMessage`** pulls the human message from `response.data.error.message` → top-level message → `Error.message` and the dialog renders it verbatim in an `aria-live` alert.
- **Client-side validation** short-circuits empty fields with a per-field message, so the operator doesn't burn a round-trip for the obvious case. BE rules remain authoritative when client-side passes but BE still rejects.
- **Optional `bookTitle?: string` prop** on the panel pre-fills the alt text as `"Cover for {bookTitle}"`. Today's callers (`RemediationTaskCard`) don't pass it — that plumbing is a small follow-up; placeholder text guides the operator in the meantime.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean (max-warnings 0)
- [x] `npx vitest run` — 815 passed, 10 skipped (+17 new: 12 helper + template, 5 panel branch integration)
- [ ] Manual: upload a PRH EPUB with an empty cover alt on staging → audit fires `PRH-COVER-ALT-EMPTY` → click Quick Fix → dialog opens (book-title pre-fill follows when wired upstream) → submit → cover alt set in remediated EPUB → re-audit shows the issue resolved
- [ ] Manual edge case: clear the alt-text field and submit → expect the dialog to show the BE 400 message verbatim ("`altText` cannot be empty for cover image" or similar) without closing the dialog

## Out of scope
- Wiring `bookTitle` through `RemediationTaskCard` from the audit-result's `dc:title` / fileName. Follow-up when we surface audit context in the remediation flow.
- Dismiss workflow (Prompt 9 — needs separate FE+BE coordination, see existing memory entry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dedicated quick‑fix panel for empty cover alt‑text with guided inputs, auto-detection of cover image, and optional book title prefill.
  * Submitting a fix sends the correction and shows a success toast; panel closes on success.

* **Bug Fixes**
  * Backend validation errors surface inside the dialog; client‑side checks block incomplete submissions.

* **Tests**
  * Added end‑to‑end tests covering the cover‑alt flow, validation, error handling, and state reset on issue change.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/s4cindia/ninja-frontend/pull/269)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->