### PR TITLE
fix(bootstrap): MAPAccuracyPanel shows best-of-last-14 run, not latest

### DIFF
--- a/src/components/bootstrap/MAPAccuracyPanel.tsx
+++ b/src/components/bootstrap/MAPAccuracyPanel.tsx
@@ -1,5 +1,6 @@
 import { useMAPHistory } from '../../hooks/useMetrics';
 import type { ClassAPResult } from '../../services/metrics.service';
+import { pickBestInWindow, RECENT_RUN_WINDOW } from './mapAccuracySelection';
 
 const ZONE_TYPE_LABELS: Record<string, string> = {
   paragraph: 'Body Text',
@@ -49,7 +50,8 @@ function StatusPill({ row }: { row: ClassAPResult }) {
 
 export default function MAPAccuracyPanel() {
   const { data: history, isLoading, isError } = useMAPHistory();
-  const latest = history?.[history.length - 1];
+  const best = pickBestInWindow(history);
+  const windowSlice = history ? history.slice(-RECENT_RUN_WINDOW) : [];
 
   if (isLoading) {
     return (
@@ -80,16 +82,20 @@ export default function MAPAccuracyPanel() {
     );
   }
 
-  const overallPct = latest ? (latest.overallMAP * 100).toFixed(1) : null;
-  const headlineColour = latest
-    ? latest.overallMAP >= 0.75
+  const overallPct = best ? (best.overallMAP * 100).toFixed(1) : null;
+  const headlineColour = best
+    ? best.overallMAP >= 0.75
       ? 'text-green-600'
-      : latest.overallMAP >= 0.6
+      : best.overallMAP >= 0.6
         ? 'text-amber-600'
         : 'text-red-600'
     : '';
 
-  const hasInsufficientData = latest?.perClass.some((c) => c.insufficientData);
+  const hasInsufficientData = best?.perClass.some((c) => c.insufficientData);
+  const subtitle =
+    windowSlice.length > 1
+      ? `mAP@0.5 — best of last ${windowSlice.length} runs`
+      : 'mAP@0.5 — mean Average Precision';
 
   return (
     <div>
@@ -99,9 +105,7 @@ export default function MAPAccuracyPanel() {
           <h3 className="text-base font-semibold text-gray-800">
             Zone Detection Accuracy
           </h3>
-          <p className="text-xs text-gray-500 mt-0.5">
-            mAP@0.5 — mean Average Precision
-          </p>
+          <p className="text-xs text-gray-500 mt-0.5">{subtitle}</p>
         </div>
         <span className={`text-3xl font-bold ${headlineColour}`} data-testid="overall-map">
           {overallPct ? `${overallPct}%` : '—'}
@@ -120,7 +124,7 @@ export default function MAPAccuracyPanel() {
           </tr>
         </thead>
         <tbody>
-          {latest?.perClass.map((row) => (
+          {best?.perClass.map((row) => (
             <tr key={row.zoneType} className="border-b border-gray-100">
               <td className="py-2 text-gray-700">
                 {ZONE_TYPE_LABELS[row.zoneType] ?? row.zoneType}

--- a/src/components/bootstrap/__tests__/MAPAccuracyPanel.test.tsx
+++ b/src/components/bootstrap/__tests__/MAPAccuracyPanel.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import MAPAccuracyPanel from '../MAPAccuracyPanel';
+import { pickBestInWindow } from '../mapAccuracySelection';
 import type { MAPSnapshot } from '@/services/metrics.service';
 
 function makeSnapshot(overrides: Partial<MAPSnapshot> = {}): MAPSnapshot {
@@ -101,5 +102,85 @@ describe('MAPAccuracyPanel', () => {
     });
     render(<MAPAccuracyPanel />);
     expect(screen.getByText('Heading')).toBeInTheDocument();
+  });
+
+  describe('best-of-window selection', () => {
+    it('picks the BEST run within the window, not the latest', () => {
+      // History ordered completedAt-asc; latest run has worse mAP than a
+      // recent prior one. C1 phase-gate logic picks the best — panel must
+      // mirror that.
+      mockUseMAPHistory.mockReturnValue({
+        data: [
+          makeSnapshot({ runId: 'oldest', overallMAP: 0.50 }),
+          makeSnapshot({ runId: 'best',   overallMAP: 0.80 }),
+          makeSnapshot({ runId: 'latest', overallMAP: 0.36 }),
+        ],
+        isLoading: false,
+      });
+      render(<MAPAccuracyPanel />);
+      expect(screen.getByTestId('overall-map').textContent).toBe('80.0%');
+    });
+
+    it('subtitle shows window size when history has multiple runs', () => {
+      mockUseMAPHistory.mockReturnValue({
+        data: [
+          makeSnapshot({ overallMAP: 0.50 }),
+          makeSnapshot({ overallMAP: 0.80 }),
+        ],
+        isLoading: false,
+      });
+      render(<MAPAccuracyPanel />);
+      expect(screen.getByText(/best of last 2 runs/)).toBeInTheDocument();
+    });
+  });
+});
+
+describe('pickBestInWindow', () => {
+  function snap(runId: string, overallMAP: number): MAPSnapshot {
+    return {
+      runId,
+      runDate: '2026-03-01T00:00:00Z',
+      overallMAP,
+      perClass: [],
+    };
+  }
+
+  it('returns undefined for empty/undefined history', () => {
+    expect(pickBestInWindow(undefined)).toBeUndefined();
+    expect(pickBestInWindow([])).toBeUndefined();
+  });
+
+  it('returns the single snapshot when only one exists', () => {
+    const only = snap('only', 0.42);
+    expect(pickBestInWindow([only])).toBe(only);
+  });
+
+  it('returns the snapshot with the highest overallMAP', () => {
+    const best = snap('b', 0.80);
+    const result = pickBestInWindow([
+      snap('a', 0.50),
+      best,
+      snap('c', 0.65),
+    ]);
+    expect(result?.runId).toBe('b');
+  });
+
+  it('restricts to the last N entries when history exceeds the window', () => {
+    // The very first run is the best in absolute terms, but it's outside
+    // the window — pickBestInWindow should ignore it.
+    const history: MAPSnapshot[] = [
+      snap('ancient', 0.95), // outside window
+      ...Array.from({ length: 14 }, (_, i) => snap(`recent-${i}`, 0.40 + i * 0.01)),
+    ];
+    const result = pickBestInWindow(history, 14);
+    expect(result?.runId).toBe('recent-13'); // last entry, mAP=0.53 — best within the window
+    expect(result?.runId).not.toBe('ancient');
+  });
+
+  it('uses the default window of 14', () => {
+    const ancient = snap('ancient', 0.99);
+    const window = Array.from({ length: 14 }, (_, i) => snap(`r${i}`, 0.30));
+    const result = pickBestInWindow([ancient, ...window]);
+    expect(result?.overallMAP).toBe(0.30); // ancient is outside default window
   });
 });

--- a/src/components/bootstrap/mapAccuracySelection.ts
+++ b/src/components/bootstrap/mapAccuracySelection.ts
@@ -1,0 +1,25 @@
+import type { MAPSnapshot } from '../../services/metrics.service';
+
+// Must match C1_RECENT_RUN_WINDOW in
+// ninja-backend src/services/metrics/phase-gate.service.ts. Keeping this
+// constant aligned with the backend ensures the Zone Detection Accuracy
+// panel selects the same run that drives the C1 phase-gate criterion,
+// so the gauge above and the breakdown below tell a coherent story.
+export const RECENT_RUN_WINDOW = 14;
+
+/**
+ * Pick the run with the highest overallMAP among the N most-recent
+ * snapshots (matching the backend's C1 logic). Returns undefined when
+ * history is empty. Assumes input is ordered completedAt-asc as
+ * returned by GET /ml-metrics/map-history.
+ */
+export function pickBestInWindow(
+  history: readonly MAPSnapshot[] | undefined,
+  windowSize: number = RECENT_RUN_WINDOW,
+): MAPSnapshot | undefined {
+  if (!history || history.length === 0) return undefined;
+  const recent = history.slice(-windowSize);
+  return recent.reduce((best, snap) =>
+    snap.overallMAP > best.overallMAP ? snap : best,
+  );
+}


### PR DESCRIPTION
## Summary

The Analytics tab told two stories at once: the C1 gauge said e.g. \`75.8% (best of last 14) — GREEN\` while the Zone Detection Accuracy panel beneath it showed e.g. \`52.6% — Below target\` (latest run, Farraye). Same page, opposite signals.

Switch the panel to match the C1 selection logic.

## Changes

- New \`pickBestInWindow(history, windowSize=14)\` helper, exported for tests
- Component picks \`best\` instead of \`latest\` for the headline number and the per-class table
- Subtitle updates to "mAP@0.5 — best of last N runs" when >1 run exists; falls back to the original phrasing for the single-run case
- Window constant \`RECENT_RUN_WINDOW = 14\` matches \`C1_RECENT_RUN_WINDOW\` in backend \`src/services/metrics/phase-gate.service.ts\` — comment cross-references it

## Test plan

- [x] tsc --noEmit clean
- [x] vitest — 15/15 pass (3 new cases: best-not-latest, subtitle, pickBestInWindow unit tests covering window clamping)
- [ ] After merge + deploy: refresh Analytics tab; verify headline number matches the C1 gauge value above, and the per-class breakdown corresponds to the run named in the C1 tooltip

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * MAP accuracy panel now shows the best-performing snapshot from the recent run window (not just the latest), and updates headline, subtitle, and per-class rows accordingly.
* **Tests**
  * Added tests to ensure best-of-window selection, subtitle messaging when multiple runs exist, handling of empty/undefined histories, window bounds, and default window size.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/s4cindia/ninja-frontend/pull/270)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->