### PR TITLE
feat(audit): export raw + human-reviewed AI alt text as CSV

### DIFF
--- a/src/components/epub/EPUBAuditResults.tsx
+++ b/src/components/epub/EPUBAuditResults.tsx
@@ -4,10 +4,15 @@ import { useQuery } from '@tanstack/react-query';
 import {
   AlertCircle, AlertTriangle, Info, CheckCircle,
   Wrench, Hand, FileDown, ClipboardList, ExternalLink, FileCheck, FileSpreadsheet,
-  HelpCircle, ChevronDown, ChevronUp, Zap, User
+  HelpCircle, ChevronDown, ChevronUp, Zap, User, Image as ImageIcon, Loader2
 } from 'lucide-react';
 import { api } from '@/services/api';
 import { generateCSV, downloadCSV, formatDate } from '@/utils/csvExport';
+import {
+  buildAiAltTextExportCsv,
+  buildAiAltTextExportFilename,
+} from '@/lib/ai-alt-text-export';
+import { altTextService } from '@/services/alt-text.service';
 import { Card, CardContent, CardHeader, CardTitle } from '../ui/Card';
 import { Button } from '../ui/Button';
 import { Badge } from '../ui/Badge';
@@ -133,16 +138,58 @@ interface ActionButtonsProps {
   isDownloading?: boolean;
 }
 
-function ActionButtons({ 
-  jobId, 
+function ActionButtons({
+  jobId,
   issues,
   fileName,
-  onCreateRemediationPlan, 
-  onDownloadReport, 
-  isCreatingPlan = false, 
-  isDownloading = false 
+  onCreateRemediationPlan,
+  onDownloadReport,
+  isCreatingPlan = false,
+  isDownloading = false
 }: ActionButtonsProps) {
   const navigate = useNavigate();
+  const [isExportingAi, setIsExportingAi] = useState(false);
+  const [aiExportMessage, setAiExportMessage] = useState<
+    { kind: 'success' | 'error' | 'empty'; text: string } | null
+  >(null);
+
+  const handleExportAiAltText = async () => {
+    if (!jobId) return;
+    setIsExportingAi(true);
+    setAiExportMessage(null);
+    try {
+      // The review queue already carries the raw AI output (shortAlt /
+      // extendedAlt — never mutated) AND the operator-final approvedAlt
+      // on each record, so we don't need a new BE endpoint. We just need
+      // to repackage the data into the CSV format PRH will read.
+      const queue = await altTextService.getReviewQueue(jobId);
+      if (queue.items.length === 0) {
+        setAiExportMessage({
+          kind: 'empty',
+          text: 'No AI alt-text records found for this job — nothing to export.',
+        });
+        return;
+      }
+      const csv = buildAiAltTextExportCsv(queue.items);
+      const filename = buildAiAltTextExportFilename(fileName);
+      downloadCSV(csv, filename);
+      setAiExportMessage({
+        kind: 'success',
+        text: `Exported ${queue.items.length} AI alt-text record${queue.items.length === 1 ? '' : 's'} to ${filename}.`,
+      });
+    } catch (err) {
+      console.error('AI alt-text export failed:', err);
+      setAiExportMessage({
+        kind: 'error',
+        text:
+          err instanceof Error
+            ? `Failed to export AI alt-text: ${err.message}`
+            : 'Failed to export AI alt-text.',
+      });
+    } finally {
+      setIsExportingAi(false);
+    }
+  };
 
   const handleDownloadIssuesCSV = () => {
     const columns = [
@@ -222,13 +269,40 @@ function ActionButtons({
           </>
         )}
       </Button>
-      <Button 
-        variant="outline" 
+      <Button
+        variant="outline"
         onClick={handleDownloadIssuesCSV}
       >
         <FileSpreadsheet className="h-4 w-4 mr-2" />
         Download Issues CSV
       </Button>
+      <Button
+        variant="outline"
+        onClick={handleExportAiAltText}
+        disabled={isExportingAi || !jobId}
+        title="Download a CSV of raw AI image alt text alongside any human-reviewed versions — required as a separate deliverable by the PRH UK trial."
+      >
+        {isExportingAi ? (
+          <Loader2 className="h-4 w-4 mr-2 animate-spin" aria-hidden="true" />
+        ) : (
+          <ImageIcon className="h-4 w-4 mr-2" aria-hidden="true" />
+        )}
+        {isExportingAi ? 'Exporting…' : 'Export AI Alt-Text'}
+      </Button>
+      {aiExportMessage && (
+        <p
+          role={aiExportMessage.kind === 'error' ? 'alert' : 'status'}
+          aria-live="polite"
+          className={cn(
+            'basis-full text-xs mt-1',
+            aiExportMessage.kind === 'success' && 'text-green-700',
+            aiExportMessage.kind === 'empty' && 'text-gray-600',
+            aiExportMessage.kind === 'error' && 'text-red-700',
+          )}
+        >
+          {aiExportMessage.text}
+        </p>
+      )}
     </div>
   );
 }

--- a/src/lib/__tests__/ai-alt-text-export.test.ts
+++ b/src/lib/__tests__/ai-alt-text-export.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildAiAltTextExportCsv,
+  buildAiAltTextExportFilename,
+} from '../ai-alt-text-export';
+import type { GeneratedAltText } from '@/types/alt-text.types';
+
+function item(over: Partial<GeneratedAltText> = {}): GeneratedAltText {
+  return {
+    id: 'gen-1',
+    imageId: 'img-1',
+    jobId: 'job-1',
+    shortAlt: 'A grey cat sitting by a window.',
+    extendedAlt: 'A medium-haired grey cat sits on a wooden windowsill in afternoon light.',
+    confidence: 87,
+    flags: ['NEEDS_MANUAL_REVIEW'],
+    aiModel: 'gemini-2.0-flash',
+    status: 'pending',
+    createdAt: '2026-05-10T09:00:00Z',
+    updatedAt: '2026-05-10T09:00:00Z',
+    ...over,
+  };
+}
+
+describe('buildAiAltTextExportCsv', () => {
+  it('emits the expected header row in the documented order', () => {
+    const csv = buildAiAltTextExportCsv([item()]);
+    const header = csv.split('\r\n')[0];
+    expect(header).toBe(
+      'image_id,raw_ai_short_alt,raw_ai_extended_alt,ai_confidence,ai_flags,ai_model,review_status,human_reviewed,approved_alt,approved_by,approved_at,generated_at,last_updated',
+    );
+  });
+
+  it('writes the raw AI fields verbatim (never replaced by approvedAlt) so PRH can compare', () => {
+    const csv = buildAiAltTextExportCsv([
+      item({
+        shortAlt: 'Raw AI text.',
+        approvedAlt: 'Operator-edited text.',
+        approvedBy: 'reviewer@example.com',
+        approvedAt: '2026-05-10T10:00:00Z',
+        status: 'approved',
+      }),
+    ]);
+    expect(csv).toContain('Raw AI text.');
+    expect(csv).toContain('Operator-edited text.');
+  });
+
+  it('marks human_reviewed = "yes" only when approvedAt is set', () => {
+    const csv = buildAiAltTextExportCsv([
+      item({ approvedAt: undefined }),
+      item({ imageId: 'img-2', approvedAt: '2026-05-10T11:00:00Z', approvedAlt: 'OK' }),
+    ]);
+    const rows = csv.trim().split('\r\n').slice(1);
+    expect(rows[0]).toMatch(/,no,/);
+    expect(rows[1]).toMatch(/,yes,/);
+  });
+
+  it('joins multiple flags into a single semicolon-separated cell', () => {
+    const csv = buildAiAltTextExportCsv([
+      item({ flags: ['FACE_DETECTED', 'TEXT_IN_IMAGE', 'NEEDS_MANUAL_REVIEW'] }),
+    ]);
+    expect(csv).toContain('FACE_DETECTED; TEXT_IN_IMAGE; NEEDS_MANUAL_REVIEW');
+  });
+
+  it('quotes fields containing commas so Excel does not split them', () => {
+    const csv = buildAiAltTextExportCsv([
+      item({ shortAlt: 'A man, a plan, a canal.' }),
+    ]);
+    expect(csv).toContain('"A man, a plan, a canal."');
+  });
+
+  it('escapes embedded double quotes per RFC-4180', () => {
+    const csv = buildAiAltTextExportCsv([item({ shortAlt: 'She said "hello".' })]);
+    expect(csv).toContain('"She said ""hello""."');
+  });
+
+  it('neutralises a formula-trigger AI alt so Excel/Sheets does not auto-execute', () => {
+    // The csv-export helper prefixes leading =/+/-/@/\t/\r with a single quote.
+    // Without that, an AI suggestion starting with "=" (which the model has
+    // been observed to do for alt text like "=Reaction shot=") would be
+    // interpreted as a formula by spreadsheet apps.
+    const csv = buildAiAltTextExportCsv([item({ shortAlt: '=cmd|/c calc' })]);
+    expect(csv).toContain("'=cmd|/c calc");
+  });
+
+  it('emits no data rows for an empty input but still writes the header', () => {
+    const csv = buildAiAltTextExportCsv([]);
+    const lines = csv.split('\r\n').filter((l) => l.length > 0);
+    expect(lines).toHaveLength(1); // header only
+    expect(lines[0]).toMatch(/^image_id,/);
+  });
+
+  it('renders missing extendedAlt / approvedAlt as empty cells, not "undefined"', () => {
+    const csv = buildAiAltTextExportCsv([
+      item({ extendedAlt: undefined, approvedAlt: undefined, approvedBy: undefined, approvedAt: undefined }),
+    ]);
+    expect(csv).not.toContain('undefined');
+  });
+});
+
+describe('buildAiAltTextExportFilename', () => {
+  it('strips a trailing .epub from the base name and appends today\'s date', () => {
+    const name = buildAiAltTextExportFilename(
+      'The-Midnight-Library.epub',
+      new Date('2026-05-13T00:00:00Z'),
+    );
+    expect(name).toBe('ai-alt-text-The-Midnight-Library-2026-05-13.csv');
+  });
+
+  it('sanitises spaces and other shell-unfriendly characters in the base name', () => {
+    const name = buildAiAltTextExportFilename(
+      'Billy and the Giant Adventure.epub',
+      new Date('2026-05-13T00:00:00Z'),
+    );
+    expect(name).toBe('ai-alt-text-Billy_and_the_Giant_Adventure-2026-05-13.csv');
+  });
+
+  it('uses a generic "epub" stem when the base name is missing', () => {
+    const name = buildAiAltTextExportFilename(undefined, new Date('2026-05-13T00:00:00Z'));
+    expect(name).toBe('ai-alt-text-epub-2026-05-13.csv');
+  });
+});

--- a/src/lib/ai-alt-text-export.ts
+++ b/src/lib/ai-alt-text-export.ts
@@ -1,0 +1,70 @@
+/**
+ * CSV export of AI-generated image alt text for a job — built to satisfy the
+ * PRH UK trial requirement that the *raw, unedited AI output* be delivered
+ * **separately** from the human-reviewed alt text in the EPUB.
+ *
+ * The data already lives end-to-end in the alt-text review queue:
+ *   - `shortAlt` / `extendedAlt` are the raw AI output (never mutated after
+ *     generation).
+ *   - `approvedAlt` is the operator-final version (set only when the
+ *     reviewer accepted/edited the suggestion).
+ *   - `status`, `approvedBy`, `approvedAt` form the audit trail.
+ *
+ * No new backend endpoint is needed — `altTextService.getReviewQueue(jobId)`
+ * returns everything. This file is the operator-side packaging into a
+ * spreadsheet-friendly CSV.
+ */
+
+import type { GeneratedAltText } from '@/types/alt-text.types';
+import { buildCsv } from './csv-export';
+
+export interface AiAltTextExportOptions {
+  /**
+   * Filename slug — typically the EPUB base name without extension.
+   * Falls back to a generic name if omitted.
+   */
+  baseName?: string;
+}
+
+/**
+ * Build the CSV body for the export. Pure function so the CSV shape is
+ * easily testable without mocking the alt-text service.
+ *
+ * Column order is chosen to put raw-AI fields and human-reviewed fields
+ * on opposite sides of the row, so PRH's spreadsheet reviewer can
+ * visually scan "is the AI suggestion close to the final alt?" without
+ * jumping back and forth.
+ */
+export function buildAiAltTextExportCsv(items: ReadonlyArray<GeneratedAltText>): string {
+  return buildCsv<GeneratedAltText>({
+    columns: [
+      { label: 'image_id', value: (r) => r.imageId },
+      // Raw AI output — these fields are set at generation time and never
+      // mutated, even when an operator approves or edits the suggestion.
+      { label: 'raw_ai_short_alt', value: (r) => r.shortAlt },
+      { label: 'raw_ai_extended_alt', value: (r) => r.extendedAlt ?? '' },
+      { label: 'ai_confidence', value: (r) => r.confidence },
+      { label: 'ai_flags', value: (r) => r.flags.join('; ') },
+      { label: 'ai_model', value: (r) => r.aiModel },
+      // Audit trail / human-review side.
+      { label: 'review_status', value: (r) => r.status },
+      { label: 'human_reviewed', value: (r) => (r.approvedAt ? 'yes' : 'no') },
+      { label: 'approved_alt', value: (r) => r.approvedAlt ?? '' },
+      { label: 'approved_by', value: (r) => r.approvedBy ?? '' },
+      { label: 'approved_at', value: (r) => r.approvedAt ?? '' },
+      { label: 'generated_at', value: (r) => r.createdAt },
+      { label: 'last_updated', value: (r) => r.updatedAt },
+    ],
+    rows: items,
+  });
+}
+
+/**
+ * Build the export filename. Includes the EPUB base name when supplied so
+ * reviewers can keep one file per title in their working folder.
+ */
+export function buildAiAltTextExportFilename(baseName: string | undefined, today: Date = new Date()): string {
+  const slug = baseName?.replace(/\.epub$/i, '').replace(/[^A-Za-z0-9._-]+/g, '_') || 'epub';
+  const date = today.toISOString().slice(0, 10);
+  return `ai-alt-text-${slug}-${date}.csv`;
+}


### PR DESCRIPTION
## Summary
Addresses the **raw AI alt-text export gap** flagged in the PRH UK trial readiness doc. PRH explicitly requires the raw, unedited AI image-alt output to be delivered **separately** from any human-reviewed alt text in the EPUB.

After investigation: **no new backend endpoint is needed.** `altTextService.getReviewQueue(jobId)` already returns `shortAlt` / `extendedAlt` (raw AI, never mutated) AND `approvedAlt` / `approvedBy` / `approvedAt` (operator-final + audit trail) on each record. The gap was operator-facing packaging.

### What shipped
- **`src/lib/ai-alt-text-export.ts`** — pure `buildAiAltTextExportCsv` emitting a 13-column CSV. Raw-AI columns and approved/reviewed columns sit on opposite halves of the row so PRH's spreadsheet reviewer can scan "is the AI close to the final?" without bouncing back and forth.
- Uses the existing `buildCsv` helper → inherits the **formula-injection guard**. An AI suggestion that happens to start with `=` / `+` / `-` / `@` / `\t` / `\r` is prefixed with `'` so Excel/Sheets doesn't auto-execute it. Important for an export of arbitrary generated text.
- `buildAiAltTextExportFilename` sanitises spaces + appends today's ISO date so operators can keep one file per title.
- **"Export AI Alt-Text" button** in `EPUBAuditResults` ActionButtons. Loading + empty-queue + error states surface inline below the button row (basis-full + `aria-live`), not as a global toast — the operator stays on the audit page.

### Backend coordination
**None required.** This is intentionally pure FE because the data already exists end-to-end. See the "Backend prompt (not needed)" section below if you want the rationale documented for future reference.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean (max-warnings 0)
- [x] `npx vitest run` — 829 passed, 10 skipped (+12 new unit tests covering header order, raw-vs-approved verbatim, human_reviewed yes/no logic, flag joining, RFC-4180 quoting + escape, formula-injection neutralisation, empty input, undefined → empty rendering, filename .epub strip + date stamp, special-character sanitisation, generic-stem fallback)
- [ ] Manual: on staging, audit a PRH EPUB → click "Export AI Alt-Text" → CSV downloads → open in Excel/Sheets, confirm rows present + formula-trigger cells are pre-quoted + reading order keeps raw-AI columns first
- [ ] Manual: on a job with no AI alt-text records, click the button → inline message reads "No AI alt-text records found for this job — nothing to export"
- [ ] Manual: simulate API failure (e.g. block `/alt-text/job/:id/review-queue` in devtools) → confirm inline error message renders, not a hard crash

## CSV columns (in order)
| # | Column | Source |
|---|---|---|
| 1 | image_id | `GeneratedAltText.imageId` |
| 2 | raw_ai_short_alt | `shortAlt` — raw AI, never mutated |
| 3 | raw_ai_extended_alt | `extendedAlt` — raw AI long version |
| 4 | ai_confidence | `confidence` |
| 5 | ai_flags | `flags` joined with `; ` |
| 6 | ai_model | `aiModel` |
| 7 | review_status | `status` (pending / needs_review / approved / edited / rejected) |
| 8 | human_reviewed | `yes` if `approvedAt` is set, else `no` |
| 9 | approved_alt | `approvedAlt` — operator-final |
| 10 | approved_by | `approvedBy` |
| 11 | approved_at | `approvedAt` |
| 12 | generated_at | `createdAt` |
| 13 | last_updated | `updatedAt` |

## Out of scope
- Long-description / chart-description export (separate `/alt-text/generate-chart` flow, not in the PRH brief).
- Per-job export from outside the audit-results page (e.g. from the Files list).
- JSON-format variant (CSV is sufficient for PRH's reviewer; revisit if they ask for structured data later).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CSV export functionality for AI-reviewed image alt text, including a dedicated export button with loading indicator and status notifications for success, errors, and empty results.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/s4cindia/ninja-frontend/pull/272)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->