### PR TITLE
feat(calibration): flip timesheet copy now backend #400 is live

### DIFF
--- a/src/components/calibration/CorpusTimesheetTab.tsx
+++ b/src/components/calibration/CorpusTimesheetTab.tsx
@@ -108,7 +108,7 @@ function PerTitleTable({ rows }: { rows: PerTitleEntry[] }) {
             <th className="px-3 py-2 text-right font-medium text-gray-700">Zones/hr</th>
             <th className="px-3 py-2 text-right font-medium text-gray-700">Cost</th>
             <th className="px-3 py-2 text-right font-medium text-gray-700">Issues</th>
-            <th className="px-3 py-2 text-left font-medium text-gray-700">Completed</th>
+            <th className="px-3 py-2 text-left font-medium text-gray-700">Run status</th>
           </tr>
         </thead>
         <tbody>
@@ -235,12 +235,18 @@ export function CorpusTimesheetTab({ range }: Props) {
 
   return (
     <div className="space-y-4">
-      <div className="flex items-center justify-between">
+      <div className="flex items-start justify-between">
         <div className="text-sm text-gray-600">
           {data ? (
             <>
-              <span className="font-medium text-gray-900">{data.runsIncluded}</span> runs included
-              for {range.from} &rarr; {range.to}
+              <div>
+                <span className="font-medium text-gray-900">{data.runsIncluded}</span>{' '}
+                {`${data.runsIncluded === 1 ? 'run' : 'runs'} with annotation activity in ${range.from} → ${range.to}`}
+              </div>
+              <div className="mt-0.5 text-xs text-gray-400">
+                Filtered by session activity date — hours worked in this range, including runs not
+                yet marked complete.
+              </div>
             </>
           ) : (
             <>&nbsp;</>
@@ -298,7 +304,7 @@ export function CorpusTimesheetTab({ range }: Props) {
 
       {data && data.runsIncluded === 0 && (
         <div className="rounded-md border border-gray-200 bg-gray-50 px-4 py-8 text-center text-sm text-gray-600">
-          No completed runs in this date range.
+          No annotation activity in this date range.
         </div>
       )}
 

--- a/src/components/calibration/__tests__/CorpusTimesheetTab.test.tsx
+++ b/src/components/calibration/__tests__/CorpusTimesheetTab.test.tsx
@@ -61,36 +61,39 @@ function response(over: Partial<TimesheetSummaryResponse> = {}): TimesheetSummar
   };
 }
 
-describe('CorpusTimesheetTab — nullable completedAt (forward-compat for Option A backend)', () => {
+describe('CorpusTimesheetTab — activity-date filter semantics (BE #400 shipped)', () => {
   beforeEach(() => {
     useTimesheetSummary.mockReset();
   });
 
-  it('renders the run count + date range in the header', () => {
+  it('renders the activity-based count line and semantic caption', () => {
     useTimesheetSummary.mockReturnValue({ data: response(), isLoading: false, error: null });
     render(<CorpusTimesheetTab range={RANGE} />);
-    // The count line uses the original wording until the backend ships
-    // the activity-date-filter change (Option A).
-    expect(screen.getByText(/runs included/i)).toBeInTheDocument();
-    expect(screen.getByText(/2026-05-04/)).toBeInTheDocument();
+    expect(
+      screen.getByText(/runs? with annotation activity in 2026-05-04 . 2026-05-10/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Filtered by session activity date/i)).toBeInTheDocument();
   });
 
-  it('renders the completion date when completedAt is a string', () => {
+  it('singularises "run" for exactly 1, pluralises for N>1', () => {
     useTimesheetSummary.mockReturnValue({
-      data: response({ perTitle: [perTitle({ completedAt: '2026-05-09T10:00:00Z' })] }),
+      data: response({ runsIncluded: 1 }),
       isLoading: false,
       error: null,
     });
-    render(<CorpusTimesheetTab range={RANGE} />);
-    // The cell renders the locale date string; just confirm it's not "In progress"
-    expect(screen.queryByText('In progress')).not.toBeInTheDocument();
+    const { rerender } = render(<CorpusTimesheetTab range={RANGE} />);
+    expect(screen.getByText(/^run with annotation activity in/i)).toBeInTheDocument();
+
+    useTimesheetSummary.mockReturnValue({
+      data: response({ runsIncluded: 3 }),
+      isLoading: false,
+      error: null,
+    });
+    rerender(<CorpusTimesheetTab range={RANGE} />);
+    expect(screen.getByText(/^runs with annotation activity in/i)).toBeInTheDocument();
   });
 
-  it('renders "In progress" for a run whose completedAt is null (BE Option A forward-compat)', () => {
-    // Before the backend ships the activity-date filter, completedAt is
-    // always non-null, so this branch is dead code with the current API.
-    // The type is string | null so the FE is ready for when the backend
-    // starts returning in-progress runs.
+  it('shows "In progress" for a run whose completedAt is null', () => {
     useTimesheetSummary.mockReturnValue({
       data: response({
         perTitle: [perTitle({ runId: 'run-wip', completedAt: null })],
@@ -100,9 +103,10 @@ describe('CorpusTimesheetTab — nullable completedAt (forward-compat for Option
     });
     render(<CorpusTimesheetTab range={RANGE} />);
     expect(screen.getByText('In progress')).toBeInTheDocument();
+    expect(screen.getByText('Run status')).toBeInTheDocument();
   });
 
-  it('shows the empty-state message when no runs are in the range', () => {
+  it('shows activity-based empty-state wording', () => {
     useTimesheetSummary.mockReturnValue({
       data: response({ runsIncluded: 0, perTitle: [] }),
       isLoading: false,
@@ -110,13 +114,17 @@ describe('CorpusTimesheetTab — nullable completedAt (forward-compat for Option
     });
     render(<CorpusTimesheetTab range={RANGE} />);
     expect(
-      screen.getByText('No completed runs in this date range.'),
+      screen.getByText('No annotation activity in this date range.'),
     ).toBeInTheDocument();
   });
 
-  it('renders the "Completed" column header', () => {
-    useTimesheetSummary.mockReturnValue({ data: response(), isLoading: false, error: null });
+  it('renders a completion date when completedAt is present', () => {
+    useTimesheetSummary.mockReturnValue({
+      data: response({ perTitle: [perTitle({ completedAt: '2026-05-09T10:00:00Z' })] }),
+      isLoading: false,
+      error: null,
+    });
     render(<CorpusTimesheetTab range={RANGE} />);
-    expect(screen.getByText('Completed')).toBeInTheDocument();
+    expect(screen.queryByText('In progress')).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
Follow-up to:
- **FE PR #273** — added `completedAt: string | null`, the "In progress" cell render, and the forward-compat type; copy held at the old wording until the backend shipped.
- **BE PR #400** — `timesheet-summary` now filters on `AnnotationSession` activity date, not `CalibrationRun.completedAt`. In-progress runs with sessions in the window appear; `completedAt` can now be null on some rows.

With both halves live, this PR flips the UI copy to reflect the real semantics:

| Element | Before | After |
|---|---|---|
| Count line | "N runs included for {range}" | "N run(s) with annotation activity in {range}" |
| Caption | *(none)* | "Filtered by session activity date — hours worked in this range, including runs not yet marked complete." |
| Empty state | "No completed runs in this date range." | "No annotation activity in this date range." |
| Column header | "Completed" | "Run status" |

The "Run status" header and "In progress" cell render were already live since PR #273; only the count-line / caption / empty-state copy was gated on the backend change.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean (max-warnings 0)
- [x] `npx vitest run` (timesheet tests) — 5 passed; tests now assert the live wording (activity-based count, caption, empty state, "Run status" header, "In progress" for null completedAt)
- [ ] Manual: set the Timesheet date range to a week with in-progress runs on staging — confirm the caption appears, "Run status" column shows dates for completed runs and "In progress" for in-progress runs, empty range shows the new empty-state text

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated corpus timesheet interface terminology to reflect "annotation activity" instead of "completed runs" for improved clarity.
  * Refined table column header to "Run status" and adjusted summary messaging and empty-state text for consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/s4cindia/ninja-frontend/pull/274)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->