### PR TITLE
feat(audit): dismiss / 'not an issue' workflow (Prompt 9 FE)

### DIFF
--- a/src/components/audit/DismissIssueDialog.tsx
+++ b/src/components/audit/DismissIssueDialog.tsx
@@ -1,0 +1,121 @@
+/**
+ * Small modal that collects an optional reason before an operator marks
+ * an audit-issue instance as "not an issue". The reason field is optional
+ * (max 280 chars, mirroring the backend validation) and defaults to empty.
+ */
+
+import { useRef, useState, useEffect } from 'react';
+import { X } from 'lucide-react';
+import { Button } from '../ui/Button';
+
+interface DismissIssueDialogProps {
+  /** Human-readable issue code — shown in the dialog title. */
+  issueCode: string;
+  isOpen: boolean;
+  isSubmitting: boolean;
+  onClose: () => void;
+  onSubmit: (reason: string) => void;
+}
+
+const MAX_REASON = 280;
+
+export function DismissIssueDialog({
+  issueCode,
+  isOpen,
+  isSubmitting,
+  onClose,
+  onSubmit,
+}: DismissIssueDialogProps) {
+  const [reason, setReason] = useState('');
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  // Reset on each open + focus the textarea.
+  useEffect(() => {
+    if (isOpen) {
+      setReason('');
+      const id = window.setTimeout(() => textareaRef.current?.focus(), 50);
+      return () => window.clearTimeout(id);
+    }
+  }, [isOpen]);
+
+  // Close on Escape.
+  useEffect(() => {
+    if (!isOpen) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && !isSubmitting) onClose();
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [isOpen, isSubmitting, onClose]);
+
+  if (!isOpen) return null;
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    onSubmit(reason.trim());
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+      onClick={(e) => { if (e.target === e.currentTarget && !isSubmitting) onClose(); }}
+    >
+      <form
+        onSubmit={handleSubmit}
+        className="w-full max-w-md rounded-lg bg-white shadow-xl"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Mark as not an issue"
+      >
+        <div className="flex items-start justify-between border-b border-gray-200 px-5 py-4">
+          <div>
+            <h3 className="text-sm font-semibold text-gray-900">Mark as not an issue</h3>
+            <p className="mt-0.5 text-xs text-gray-500 font-mono">{issueCode}</p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={isSubmitting}
+            className="text-gray-400 hover:text-gray-600 disabled:opacity-50"
+            aria-label="Close"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        <div className="px-5 py-4 space-y-3">
+          <p className="text-xs text-gray-600">
+            This instance will be visually deprioritised. It still counts in the total but won't
+            block re-audits. Dismissals persist until you remove them.
+          </p>
+          <div>
+            <label className="block text-xs font-medium text-gray-700 mb-1">
+              Reason <span className="text-gray-400 font-normal">(optional)</span>
+            </label>
+            <textarea
+              ref={textareaRef}
+              value={reason}
+              onChange={(e) => setReason(e.target.value.slice(0, MAX_REASON))}
+              rows={3}
+              disabled={isSubmitting}
+              placeholder="e.g. Intentional language — proper noun in Latin script"
+              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 disabled:bg-gray-50 disabled:text-gray-500"
+            />
+            <div className="mt-0.5 text-right text-xs text-gray-400">
+              {reason.length}/{MAX_REASON}
+            </div>
+          </div>
+        </div>
+
+        <div className="flex justify-end gap-2 border-t border-gray-200 px-5 py-3">
+          <Button type="button" variant="outline" onClick={onClose} disabled={isSubmitting}>
+            Cancel
+          </Button>
+          <Button type="submit" isLoading={isSubmitting}>
+            Mark as not an issue
+          </Button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/src/components/audit/DismissIssueDialog.tsx
+++ b/src/components/audit/DismissIssueDialog.tsx
@@ -89,10 +89,11 @@ export function DismissIssueDialog({
             block re-audits. Dismissals persist until you remove them.
           </p>
           <div>
-            <label className="block text-xs font-medium text-gray-700 mb-1">
+            <label htmlFor="dismiss-reason" className="block text-xs font-medium text-gray-700 mb-1">
               Reason <span className="text-gray-400 font-normal">(optional)</span>
             </label>
             <textarea
+              id="dismiss-reason"
               ref={textareaRef}
               value={reason}
               onChange={(e) => setReason(e.target.value.slice(0, MAX_REASON))}

--- a/src/components/audit/index.ts
+++ b/src/components/audit/index.ts
@@ -14,6 +14,7 @@ export { groupIssues } from './group-issues';
 export type { GroupableIssue, GroupEntry, FlatEntry, IssueEntry, FileBucket } from './group-issues';
 export { HeuristicMarker } from './HeuristicMarker';
 export { isHeuristicCode } from './heuristic-codes';
+export { DismissIssueDialog } from './DismissIssueDialog';
 export type {
   PublisherProfile,
   PublisherProfileSignal,

--- a/src/components/epub/EPUBAuditResults.tsx
+++ b/src/components/epub/EPUBAuditResults.tsx
@@ -4,8 +4,11 @@ import { useQuery } from '@tanstack/react-query';
 import {
   AlertCircle, AlertTriangle, Info, CheckCircle,
   Wrench, Hand, FileDown, ClipboardList, ExternalLink, FileCheck, FileSpreadsheet,
-  HelpCircle, ChevronDown, ChevronUp, Zap, User, Image as ImageIcon, Loader2
+  HelpCircle, ChevronDown, ChevronUp, Zap, User, Image as ImageIcon, Loader2, Ban, RotateCcw
 } from 'lucide-react';
+import { useIssueDismissals, useCreateDismissal, useDeleteDismissal } from '@/hooks/useIssueDismissals';
+import { DismissIssueDialog } from '../audit';
+import type { IssueDismissal } from '@/services/issue-dismissal.service';
 import { api } from '@/services/api';
 import { generateCSV, downloadCSV, formatDate } from '@/utils/csvExport';
 import {
@@ -379,6 +382,28 @@ export const EPUBAuditResults: React.FC<EPUBAuditResultsProps> = ({
 
   const [sourceFilter, setSourceFilter] = useState<FilterableSource | null>(null);
 
+  // ── Dismiss workflow ─────────────────────────────────────────────────
+  const [showDismissed, setShowDismissed] = useState(true);
+  const { data: dismissalsData } = useIssueDismissals(jobId);
+  const createDismissal = useCreateDismissal(jobId ?? '');
+  const deleteDismissal = useDeleteDismissal(jobId ?? '');
+  // Build a lookup: `${code}::${location}` → dismissal (V1 match by
+  // code+location; sufficient because the same rule rarely fires at
+  // exactly the same location with different message text).
+  const dismissalsByKey = useMemo(() => {
+    const map = new Map<string, IssueDismissal>();
+    if (!dismissalsData) return map;
+    for (const d of dismissalsData) {
+      map.set(`${d.code}::${d.location}`, d);
+    }
+    return map;
+  }, [dismissalsData]);
+  const [dismissDialogIssue, setDismissDialogIssue] = useState<{
+    code: string;
+    location: string;
+    message: string;
+  } | null>(null);
+
   const filteredIssues = useMemo(() => {
     let filtered = issues;
     
@@ -543,10 +568,44 @@ export const EPUBAuditResults: React.FC<EPUBAuditResultsProps> = ({
         </Card>
       </div>
 
+      {/* Dismiss dialog — mounted at the audit-results level so it floats
+          above everything regardless of which IssueCard triggered it. */}
+      <DismissIssueDialog
+        issueCode={dismissDialogIssue?.code ?? ''}
+        isOpen={dismissDialogIssue !== null}
+        isSubmitting={createDismissal.isPending}
+        onClose={() => setDismissDialogIssue(null)}
+        onSubmit={(reason) => {
+          if (!dismissDialogIssue || !jobId) return;
+          createDismissal.mutate(
+            {
+              code: dismissDialogIssue.code,
+              location: dismissDialogIssue.location,
+              message: dismissDialogIssue.message,
+              reason: reason || undefined,
+            },
+            { onSuccess: () => setDismissDialogIssue(null) },
+          );
+        }}
+      />
+
       <Card>
         <CardHeader>
           <div className="flex items-center justify-between">
-            <CardTitle>Issues ({filteredIssues.length})</CardTitle>
+            <div className="flex items-center gap-3">
+              <CardTitle>Issues ({filteredIssues.length})</CardTitle>
+              {dismissalsData && dismissalsData.length > 0 && (
+                <button
+                  type="button"
+                  onClick={() => setShowDismissed((v) => !v)}
+                  className="text-xs text-gray-500 hover:text-gray-700 underline underline-offset-2"
+                >
+                  {showDismissed
+                    ? `Hide ${dismissalsData.length} dismissed`
+                    : `Show ${dismissalsData.length} dismissed`}
+                </button>
+              )}
+            </div>
             <Badge variant="success" size="sm">
               <Wrench className="h-3 w-3 mr-1" />
               {autoFixableCount} Auto-fixable
@@ -583,17 +642,37 @@ export const EPUBAuditResults: React.FC<EPUBAuditResultsProps> = ({
                       <GroupedIssueRow
                         key={`group-${entry.code}`}
                         entry={entry}
-                        renderIssue={(issue) => (
-                          <IssueCard issue={issue} jobId={jobId} />
-                        )}
+                        renderIssue={(issue) => {
+                          const dk = `${issue.code}::${issue.location ?? ''}`;
+                          const dismissal = dismissalsByKey.get(dk);
+                          if (!showDismissed && dismissal) return null;
+                          return (
+                            <IssueCard
+                              issue={issue}
+                              jobId={jobId}
+                              dismissal={dismissal}
+                              onDismiss={() => setDismissDialogIssue({ code: issue.code, location: issue.location ?? '', message: issue.message })}
+                              onReenable={() => deleteDismissal.mutate(dismissal!.id)}
+                            />
+                          );
+                        }}
                       />
-                    ) : (
-                      <IssueCard
-                        key={entry.issue.id}
-                        issue={entry.issue}
-                        jobId={jobId}
-                      />
-                    ),
+                    ) : (() => {
+                        const issue = entry.issue;
+                        const dk = `${issue.code}::${issue.location ?? ''}`;
+                        const dismissal = dismissalsByKey.get(dk);
+                        if (!showDismissed && dismissal) return null;
+                        return (
+                          <IssueCard
+                            key={issue.id}
+                            issue={issue}
+                            jobId={jobId}
+                            dismissal={dismissal}
+                            onDismiss={() => setDismissDialogIssue({ code: issue.code, location: issue.location ?? '', message: issue.message })}
+                            onReenable={() => deleteDismissal.mutate(dismissal!.id)}
+                          />
+                        );
+                      })(),
                   )}
                 </div>
               )}
@@ -626,10 +705,17 @@ interface IssueExplanation {
   estimatedTime: string | null;
 }
 
-const IssueCard: React.FC<{ issue: AuditIssue; jobId: string }> = ({ issue, jobId }) => {
+const IssueCard: React.FC<{
+  issue: AuditIssue;
+  jobId: string;
+  dismissal?: IssueDismissal;
+  onDismiss?: () => void;
+  onReenable?: () => void;
+}> = ({ issue, jobId, dismissal, onDismiss, onReenable }) => {
   const config = SEVERITY_CONFIG[issue.severity];
   const autoFix = isAutoFixable(issue);
   const isQuickFix = QUICK_FIX_CODES.has(issue.code);
+  const isDismissed = !!dismissal;
   const [explanationOpen, setExplanationOpen] = useState(false);
 
   const { data: explanation, isLoading: explanationLoading, isError: explanationError } = useQuery<IssueExplanation>({
@@ -645,7 +731,7 @@ const IssueCard: React.FC<{ issue: AuditIssue; jobId: string }> = ({ issue, jobI
   });
 
   return (
-    <div className={cn('border rounded-lg p-4', config.bgColor, 'border-gray-200')}>
+    <div className={cn('border rounded-lg p-4', config.bgColor, 'border-gray-200', isDismissed && 'opacity-50')}>
       <div className="flex items-start gap-3">
         <div className={cn('mt-0.5', config.color)}>
           {config.icon}
@@ -776,6 +862,36 @@ const IssueCard: React.FC<{ issue: AuditIssue; jobId: string }> = ({ issue, jobI
                   </>
                 ) : null}
               </div>
+            )}
+          </div>
+
+          {/* Dismissed caption */}
+          {isDismissed && (
+            <p className="mt-2 text-xs text-gray-500 italic">
+              Dismissed{dismissal.reason ? `: ${dismissal.reason}` : ''}
+            </p>
+          )}
+
+          {/* Dismiss / re-enable action */}
+          <div className="mt-2 pt-2 border-t border-gray-200 flex items-center gap-2">
+            {isDismissed ? (
+              <button
+                type="button"
+                onClick={(e) => { e.stopPropagation(); onReenable?.(); }}
+                className="inline-flex items-center gap-1 text-xs text-gray-500 hover:text-gray-700"
+              >
+                <RotateCcw className="h-3 w-3" />
+                Re-enable issue
+              </button>
+            ) : (
+              <button
+                type="button"
+                onClick={(e) => { e.stopPropagation(); onDismiss?.(); }}
+                className="inline-flex items-center gap-1 text-xs text-gray-400 hover:text-gray-600"
+              >
+                <Ban className="h-3 w-3" />
+                Mark as not an issue
+              </button>
             )}
           </div>
 

--- a/src/components/epub/EPUBAuditResults.tsx
+++ b/src/components/epub/EPUBAuditResults.tsx
@@ -427,6 +427,16 @@ export const EPUBAuditResults: React.FC<EPUBAuditResultsProps> = ({
     setSourceFilter(prev => prev === source ? null : source);
   };
 
+  // Remove dismissed issues from the render list when the operator hides
+  // them — doing it here keeps counts and the empty-state check accurate.
+  const visibleIssues = useMemo(() => {
+    if (showDismissed) return filteredIssues;
+    return filteredIssues.filter((issue) => {
+      const dk = `${issue.code}::${issue.location ?? ''}`;
+      return !dismissalsByKey.has(dk);
+    });
+  }, [filteredIssues, showDismissed, dismissalsByKey]);
+
   const scoreBreakdown = useMemo(() => calculateScoreBreakdown(issuesSummary), [issuesSummary]);
   
   const displayScore = scoreBreakdown.finalScore;
@@ -593,7 +603,7 @@ export const EPUBAuditResults: React.FC<EPUBAuditResultsProps> = ({
         <CardHeader>
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-3">
-              <CardTitle>Issues ({filteredIssues.length})</CardTitle>
+              <CardTitle>Issues ({visibleIssues.length})</CardTitle>
               {dismissalsData && dismissalsData.length > 0 && (
                 <button
                   type="button"
@@ -630,14 +640,14 @@ export const EPUBAuditResults: React.FC<EPUBAuditResultsProps> = ({
             </TabsList>
 
             <TabsContent value={activeTab}>
-              {filteredIssues.length === 0 ? (
+              {visibleIssues.length === 0 ? (
                 <div className="text-center py-8 text-gray-500">
                   <CheckCircle className="h-12 w-12 mx-auto text-green-500 mb-2" />
-                  <p>No issues found in this category</p>
+                  <p>{filteredIssues.length > 0 ? 'All issues in this category are dismissed.' : 'No issues found in this category'}</p>
                 </div>
               ) : (
                 <div className="space-y-3">
-                  {groupIssues(filteredIssues).map((entry) =>
+                  {groupIssues(visibleIssues).map((entry) =>
                     entry.kind === 'group' ? (
                       <GroupedIssueRow
                         key={`group-${entry.code}`}
@@ -645,14 +655,13 @@ export const EPUBAuditResults: React.FC<EPUBAuditResultsProps> = ({
                         renderIssue={(issue) => {
                           const dk = `${issue.code}::${issue.location ?? ''}`;
                           const dismissal = dismissalsByKey.get(dk);
-                          if (!showDismissed && dismissal) return null;
                           return (
                             <IssueCard
                               issue={issue}
                               jobId={jobId}
                               dismissal={dismissal}
                               onDismiss={() => setDismissDialogIssue({ code: issue.code, location: issue.location ?? '', message: issue.message })}
-                              onReenable={() => deleteDismissal.mutate(dismissal!.id)}
+                              onReenable={dismissal ? () => deleteDismissal.mutate(dismissal.id) : undefined}
                             />
                           );
                         }}
@@ -661,7 +670,6 @@ export const EPUBAuditResults: React.FC<EPUBAuditResultsProps> = ({
                         const issue = entry.issue;
                         const dk = `${issue.code}::${issue.location ?? ''}`;
                         const dismissal = dismissalsByKey.get(dk);
-                        if (!showDismissed && dismissal) return null;
                         return (
                           <IssueCard
                             key={issue.id}
@@ -669,7 +677,7 @@ export const EPUBAuditResults: React.FC<EPUBAuditResultsProps> = ({
                             jobId={jobId}
                             dismissal={dismissal}
                             onDismiss={() => setDismissDialogIssue({ code: issue.code, location: issue.location ?? '', message: issue.message })}
-                            onReenable={() => deleteDismissal.mutate(dismissal!.id)}
+                            onReenable={dismissal ? () => deleteDismissal.mutate(dismissal.id) : undefined}
                           />
                         );
                       })(),

--- a/src/hooks/useIssueDismissals.ts
+++ b/src/hooks/useIssueDismissals.ts
@@ -1,0 +1,39 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { issueDismissalService, type CreateDismissalPayload } from '@/services/issue-dismissal.service';
+
+function queryKey(jobId: string) {
+  return ['issue-dismissals', jobId] as const;
+}
+
+/** Load all dismissals for a job. */
+export function useIssueDismissals(jobId: string | undefined) {
+  return useQuery({
+    queryKey: queryKey(jobId ?? ''),
+    queryFn: () => issueDismissalService.list(jobId!),
+    enabled: !!jobId,
+    staleTime: 30_000,
+  });
+}
+
+/** Dismiss one issue instance. */
+export function useCreateDismissal(jobId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (payload: CreateDismissalPayload) =>
+      issueDismissalService.create(jobId, payload),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: queryKey(jobId) });
+    },
+  });
+}
+
+/** Remove a dismissal. */
+export function useDeleteDismissal(jobId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (dismissalId: string) => issueDismissalService.remove(jobId, dismissalId),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: queryKey(jobId) });
+    },
+  });
+}

--- a/src/services/__tests__/issue-dismissal.service.test.ts
+++ b/src/services/__tests__/issue-dismissal.service.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import { api } from '../api';
+import { issueDismissalService } from '../issue-dismissal.service';
+
+vi.mock('../api', () => ({
+  api: { get: vi.fn(), post: vi.fn(), delete: vi.fn() },
+}));
+
+const DISMISSAL = {
+  id: 'd-1',
+  jobId: 'job-1',
+  code: 'PRH-HASHTAG-NOT-CAMEL-CASE',
+  location: 'OEBPS/Text/c1.xhtml',
+  instanceKey: 'abc123',
+  dismissedBy: 'user-1',
+  dismissedAt: '2026-05-15T09:00:00Z',
+  reason: 'Intentional brand hashtag',
+};
+
+describe('issueDismissalService', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('list() calls GET and returns the dismissals array', async () => {
+    (api.get as Mock).mockResolvedValueOnce({ data: { data: { dismissals: [DISMISSAL] } } });
+    const result = await issueDismissalService.list('job-1');
+    expect(api.get).toHaveBeenCalledWith('/jobs/job-1/issues/dismissals');
+    expect(result).toEqual([DISMISSAL]);
+  });
+
+  it('create() POSTs the payload and returns the new dismissal', async () => {
+    (api.post as Mock).mockResolvedValueOnce({ data: { data: { dismissal: DISMISSAL } } });
+    const result = await issueDismissalService.create('job-1', {
+      code: 'PRH-HASHTAG-NOT-CAMEL-CASE',
+      location: 'OEBPS/Text/c1.xhtml',
+      message: '#nytbestseller not in PascalCase',
+      reason: 'Intentional brand hashtag',
+    });
+    expect(api.post).toHaveBeenCalledWith('/jobs/job-1/issues/dismissals', expect.objectContaining({ code: 'PRH-HASHTAG-NOT-CAMEL-CASE' }));
+    expect(result.id).toBe('d-1');
+  });
+
+  it('remove() DELETEs by id with an encoded path', async () => {
+    (api.delete as Mock).mockResolvedValueOnce({});
+    await issueDismissalService.remove('job-1', 'd-1');
+    expect(api.delete).toHaveBeenCalledWith('/jobs/job-1/issues/dismissals/d-1');
+  });
+});

--- a/src/services/issue-dismissal.service.ts
+++ b/src/services/issue-dismissal.service.ts
@@ -22,21 +22,24 @@ export interface CreateDismissalPayload {
 
 export const issueDismissalService = {
   list: async (jobId: string): Promise<IssueDismissal[]> => {
+    const eid = encodeURIComponent(jobId);
     const res = await api.get<{ success: boolean; data: { dismissals: IssueDismissal[] } }>(
-      `/jobs/${jobId}/issues/dismissals`,
+      `/jobs/${eid}/issues/dismissals`,
     );
     return res.data.data.dismissals;
   },
 
   create: async (jobId: string, payload: CreateDismissalPayload): Promise<IssueDismissal> => {
+    const eid = encodeURIComponent(jobId);
     const res = await api.post<{ success: boolean; data: { dismissal: IssueDismissal } }>(
-      `/jobs/${jobId}/issues/dismissals`,
+      `/jobs/${eid}/issues/dismissals`,
       payload,
     );
     return res.data.data.dismissal;
   },
 
   remove: async (jobId: string, dismissalId: string): Promise<void> => {
-    await api.delete(`/jobs/${jobId}/issues/dismissals/${encodeURIComponent(dismissalId)}`);
+    const eid = encodeURIComponent(jobId);
+    await api.delete(`/jobs/${eid}/issues/dismissals/${encodeURIComponent(dismissalId)}`);
   },
 };

--- a/src/services/issue-dismissal.service.ts
+++ b/src/services/issue-dismissal.service.ts
@@ -1,0 +1,42 @@
+import { api } from './api';
+
+export interface IssueDismissal {
+  id: string;
+  jobId: string;
+  code: string;
+  /** Empty string for location-less issues — mirrors the backend default. */
+  location: string;
+  instanceKey: string;
+  dismissedBy: string;
+  dismissedAt: string;
+  reason?: string;
+}
+
+export interface CreateDismissalPayload {
+  code: string;
+  location: string;
+  message: string;
+  /** Optional operator note; max 280 chars. */
+  reason?: string;
+}
+
+export const issueDismissalService = {
+  list: async (jobId: string): Promise<IssueDismissal[]> => {
+    const res = await api.get<{ success: boolean; data: { dismissals: IssueDismissal[] } }>(
+      `/jobs/${jobId}/issues/dismissals`,
+    );
+    return res.data.data.dismissals;
+  },
+
+  create: async (jobId: string, payload: CreateDismissalPayload): Promise<IssueDismissal> => {
+    const res = await api.post<{ success: boolean; data: { dismissal: IssueDismissal } }>(
+      `/jobs/${jobId}/issues/dismissals`,
+      payload,
+    );
+    return res.data.data.dismissal;
+  },
+
+  remove: async (jobId: string, dismissalId: string): Promise<void> => {
+    await api.delete(`/jobs/${jobId}/issues/dismissals/${encodeURIComponent(dismissalId)}`);
+  },
+};


### PR DESCRIPTION
## Summary
Frontend half of Prompt 9 — the per-instance issue-dismissal feature. Pairs with **backend PR #398** which landed the `IssueDismissal` model, `POST / DELETE / GET /jobs/:jobId/issues/dismissals` endpoints, and the audit-pipeline integration (dismissed instances carry `dismissedAt` on re-audit).

### What ships

- **`issue-dismissal.service.ts`** — wraps the three dismissal endpoints with typed request/response shapes.
- **`useIssueDismissals.ts`** — React Query hooks: `useIssueDismissals` (list), `useCreateDismissal` (mutation), `useDeleteDismissal` (mutation). All keyed on `['issue-dismissals', jobId]`.
- **`DismissIssueDialog.tsx`** — small modal for the optional reason (≤ 280 chars; mirrors backend validation). Resets on each open, Escape dismisses, backdrop click closes.
- **`EPUBAuditResults.tsx` integration:**
  - Loads dismissals on mount; builds a `Map<"code::location", IssueDismissal>` for O(1) lookup.
  - `IssueCard` gets `dismissal?` / `onDismiss?` / `onReenable?` props — when dismissed: `opacity-50`, italic "Dismissed: {reason}" caption, "Re-enable issue" button replaces "Mark as not an issue".
  - Dialog mounted once at the audit-results level (floats correctly).
  - **"Hide / Show N dismissed"** toggle in the Issues section header; only renders when at least one dismissal exists.
  - Grouped rows (`GroupedIssueRow` via `renderIssue`) also receive dismiss props per inner card.

### Scope / known V1 limitation

Code+location matching is used for the dismissal lookup (not the full content-derived SHA-256 `instanceKey`). This works for the overwhelming majority of real-world cases; the edge case (same rule firing at the exact same location with different message text) is low-probability and can be upgraded to proper instanceKey matching in a follow-up without a UX change.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean (max-warnings 0)
- [x] `npx vitest run` — 858 passed, 10 skipped (3 new: service list/create/remove round-trips)
- [ ] Manual: audit a PRH EPUB on staging → click "Mark as not an issue" on a heuristic row → enter reason → confirm → row dims to 50% + shows "Dismissed: {reason}" caption + button changes to "Re-enable issue"
- [ ] Manual: click "Re-enable issue" → row returns to full opacity + dismiss button reappears
- [ ] Manual: "Hide N dismissed" toggle collapses all dismissed rows; "Show N dismissed" brings them back
- [ ] Manual: re-audit after dismissal → check that dismissed instances still carry the dismissed state from the BE pipeline integration

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dismiss audit issues ("Mark as not an issue") with an optional reason (max 280 chars) via a confirmation dialog
  * Toggle visibility of dismissed issues in audit results; dismissed items show dimmed with a "Dismissed" caption
  * Re-enable previously dismissed issues; dismissal history is tracked per audit job

* **Tests**
  * Added tests covering dismissal create/list/remove behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/s4cindia/ninja-frontend/pull/275)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->