### PR TITLE
feat(calibration): reopen completed corpus docs for re-annotation

### DIFF
--- a/src/components/bootstrap/DocumentQueueView.tsx
+++ b/src/components/bootstrap/DocumentQueueView.tsx
@@ -1,7 +1,7 @@
 import { useState, useMemo, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Loader2 } from 'lucide-react';
-import { useCorpusDocumentsWithPolling, useUploadTaggedPdf, useTriggerCorpusCalibrationRun } from '@/hooks/useCalibration';
+import { useCorpusDocumentsWithPolling, useUploadTaggedPdf, useTriggerCorpusCalibrationRun, useReopenAnnotation } from '@/hooks/useCalibration';
 import { DocumentStatusBadge } from './DocumentStatusBadge';
 import { EmptyPagesModal } from './EmptyPagesModal';
 import { getCorpusDocumentStatus, resetCorpus } from '@/services/calibration.service';
@@ -163,6 +163,7 @@ export default function DocumentQueueView() {
   const { data, isLoading, isError, error } = useCorpusDocumentsWithPolling();
   const uploadMutation = useUploadTaggedPdf();
   const triggerMutation = useTriggerCorpusCalibrationRun();
+  const reopen = useReopenAnnotation();
 
   const documents = useMemo(() => data?.documents ?? [], [data]);
 
@@ -264,8 +265,28 @@ export default function DocumentQueueView() {
             Review
           </button>
         );
-      case 'COMPLETE':
-        return <span className="text-xs font-medium text-green-700">Done</span>;
+      case 'COMPLETE': {
+        const runId = doc.calibrationRuns?.[0]?.id;
+        return (
+          <div className="flex items-center gap-2">
+            <span className="text-xs font-medium text-green-700">Done</span>
+            {runId && (
+              <button
+                onClick={() =>
+                  reopen.mutate(runId, {
+                    onSuccess: () => navigate(`/bootstrap/review/${doc.id}`),
+                  })
+                }
+                disabled={reopen.isPending}
+                aria-label={`Reopen ${doc.filename} for re-annotation`}
+                className="px-3 py-1.5 text-xs font-medium rounded border border-amber-400 text-amber-700 hover:bg-amber-50 disabled:opacity-50 transition-colors"
+              >
+                {reopen.isPending ? 'Reopening...' : 'Reopen'}
+              </button>
+            )}
+          </div>
+        );
+      }
       default:
         return null;
     }

--- a/src/components/bootstrap/__tests__/DocumentQueueView.test.tsx
+++ b/src/components/bootstrap/__tests__/DocumentQueueView.test.tsx
@@ -5,6 +5,8 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import DocumentQueueView from '../DocumentQueueView';
 import type { CorpusDocument } from '@/services/calibration.service';
 
+const { reopenMutate } = vi.hoisted(() => ({ reopenMutate: vi.fn() }));
+
 vi.mock('@/hooks/useCalibration', () => ({
   useCorpusDocumentsWithPolling: vi.fn(),
   useUploadTaggedPdf: () => ({
@@ -13,6 +15,10 @@ vi.mock('@/hooks/useCalibration', () => ({
   }),
   useTriggerCorpusCalibrationRun: () => ({
     mutate: vi.fn(),
+    isPending: false,
+  }),
+  useReopenAnnotation: () => ({
+    mutate: reopenMutate,
     isPending: false,
   }),
   CALIBRATION_KEYS: {
@@ -121,6 +127,40 @@ describe('DocumentQueueView', () => {
 
     renderWithRouter();
     expect(screen.getByText('Done')).toBeInTheDocument();
+  });
+
+  it('shows "Reopen" button for COMPLETE document with a run and calls reopen on click', () => {
+    mockUseCorpus.mockReturnValue({
+      data: {
+        documents: [
+          makeDoc({
+            status: 'COMPLETE',
+            calibrationRuns: [
+              {
+                id: 'run-1',
+                runDate: '2026-01-01T00:00:00Z',
+                completedAt: '2026-01-02T00:00:00Z',
+              },
+            ],
+          }),
+        ],
+      },
+      isLoading: false,
+      isError: false,
+      error: null,
+    } as unknown as ReturnType<typeof mockUseCorpus>);
+
+    renderWithRouter();
+    const reopenBtn = screen.getByRole('button', {
+      name: /reopen test\.pdf for re-annotation/i,
+    });
+    expect(reopenBtn).toBeInTheDocument();
+
+    fireEvent.click(reopenBtn);
+    expect(reopenMutate).toHaveBeenCalledWith(
+      'run-1',
+      expect.objectContaining({ onSuccess: expect.any(Function) }),
+    );
   });
 
   it('filters documents by publisher', () => {

--- a/src/hooks/useCalibration.ts
+++ b/src/hooks/useCalibration.ts
@@ -9,6 +9,7 @@ import {
   triggerCorpusCalibrationRun,
 } from '../services/calibration.service';
 import type { CorpusDocument } from '../services/calibration.service';
+import { annotationReportService } from '../services/annotation-report.service';
 
 export const CALIBRATION_KEYS = {
   documents: (params?: object) => ['calibration', 'documents', params] as const,
@@ -80,6 +81,19 @@ export function useTriggerCorpusCalibrationRun() {
   return useMutation({
     mutationFn: (documentId: string) => triggerCorpusCalibrationRun(documentId),
     onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['calibration', 'documents'] });
+      qc.invalidateQueries({ queryKey: ['calibration', 'runs'] });
+    },
+  });
+}
+
+export function useReopenAnnotation() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (runId: string) => annotationReportService.reopenAnnotation(runId),
+    onSuccess: () => {
+      // Reopen flips the doc out of COMPLETE and clears the run's completion
+      // signals, so refresh both the document queue and the runs lists.
       qc.invalidateQueries({ queryKey: ['calibration', 'documents'] });
       qc.invalidateQueries({ queryKey: ['calibration', 'runs'] });
     },

--- a/src/services/annotation-report.service.ts
+++ b/src/services/annotation-report.service.ts
@@ -69,6 +69,11 @@ export const annotationReportService = {
   ) =>
     api.post(`/calibration/runs/${runId}/complete`, payload).then(r => r.data.data),
 
+  reopenAnnotation: (
+    runId: string,
+  ): Promise<{ runId: string; documentId: string; status: string }> =>
+    api.post(`/calibration/runs/${runId}/reopen`).then(r => r.data.data),
+
   getAnalysis: (runId: string) =>
     api.get(`/calibration/runs/${runId}/analysis`).then(r => r.data.data),
 


### PR DESCRIPTION
## What & why

Completed corpus documents had no path back into the editor from the **Calibration Document Queue** — the `COMPLETE` action rendered a static "Done" label. This adds a **Reopen** action so an operator can re-annotate a completed doc (needed to fix inconsistent `table` labels on the affected docs).

Consumes the already-deployed backend endpoint (branch `feat/calibration-reopen`):

```
POST /api/v1/calibration/runs/:runId/reopen
→ 200 { success: true, data: { runId, documentId, status: "IN_PROGRESS" } }
```

It clears the run's completion signals and sets `statusOverride = "IN_PROGRESS"`. **Operator zones are preserved**; extraction is not re-run.

## Changes

- **`services/annotation-report.service.ts`** — add `reopenAnnotation(runId)` → `POST .../reopen`.
- **`hooks/useCalibration.ts`** — add `useReopenAnnotation()`; on success invalidate `['calibration','documents']` and `['calibration','runs']` so the row drops out of COMPLETE.
- **`components/bootstrap/DocumentQueueView.tsx`** — render **Reopen** alongside **Done** in the `COMPLETE` case; on click it calls the endpoint and then navigates to `/bootstrap/review/:docId` (the workspace has no completion lock, guaranteeing an editable view).
- **`__tests__/DocumentQueueView.test.tsx`** — add `useReopenAnnotation` to the hook mock and a test asserting the Reopen button renders for a completed doc with a run and calls `mutate`.

## Verification

- `npx tsc --noEmit` — pass
- `npx eslint` (changed files) — pass
- `DocumentQueueView.test.tsx` — 7/7 pass

## Notes

- Optional Status Tracker affordance (spec §4) intentionally **not** included — marked not required.
- `reopen.isPending` disables the button globally while a reopen is in flight (single shared mutation, per spec); fine for sequential admin use.

## Manual test plan (against running app)

1. Pick a corpus doc showing **Complete** in the Document Queue.
2. Click **Reopen** → calls endpoint, navigates to the review workspace.
3. Confirm zones are editable (reject / correct / draw new).
4. Back in the queue → doc shows **Needs Review / In Progress** with the normal **Review** button.
5. Re-run **Mark Complete** → doc returns to Complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to reopen completed annotations in the document queue. When a document is marked as complete with an associated calibration run, a "Reopen" button is now available. Clicking the button reopens the annotation and refreshes the relevant data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->