### PR TITLE
fix(calibration): show Reopen on completed docs (correct status branch)

### DIFF
--- a/src/components/bootstrap/DocumentQueueView.tsx
+++ b/src/components/bootstrap/DocumentQueueView.tsx
@@ -265,28 +265,8 @@ export default function DocumentQueueView() {
             Review
           </button>
         );
-      case 'COMPLETE': {
-        const runId = doc.calibrationRuns?.[0]?.id;
-        return (
-          <div className="flex items-center gap-2">
-            <span className="text-xs font-medium text-green-700">Done</span>
-            {runId && (
-              <button
-                onClick={() =>
-                  reopen.mutate(runId, {
-                    onSuccess: () => navigate(`/bootstrap/review/${doc.id}`),
-                  })
-                }
-                disabled={reopen.isPending}
-                aria-label={`Reopen ${doc.filename} for re-annotation`}
-                className="px-3 py-1.5 text-xs font-medium rounded border border-amber-400 text-amber-700 hover:bg-amber-50 disabled:opacity-50 transition-colors"
-              >
-                {reopen.isPending ? 'Reopening...' : 'Reopen'}
-              </button>
-            )}
-          </div>
-        );
-      }
+      case 'COMPLETE':
+        return <span className="text-xs font-medium text-green-700">Done</span>;
       default:
         return null;
     }
@@ -536,6 +516,18 @@ export default function DocumentQueueView() {
                                     className="border border-purple-300 text-purple-600 text-xs px-3 py-1 rounded hover:bg-purple-50 transition-colors"
                                   >
                                     Analysis
+                                  </button>
+                                  <button
+                                    onClick={() =>
+                                      reopen.mutate(doc.calibrationRuns![0].id, {
+                                        onSuccess: () => navigate(`/bootstrap/review/${doc.id}`),
+                                      })
+                                    }
+                                    disabled={reopen.isPending}
+                                    aria-label={`Reopen ${doc.filename} for re-annotation`}
+                                    className="border border-amber-400 text-amber-700 text-xs px-3 py-1 rounded hover:bg-amber-50 disabled:opacity-50 transition-colors"
+                                  >
+                                    {reopen.isPending ? 'Reopening...' : 'Reopen'}
                                   </button>
                                 </>
                               )}

--- a/src/components/bootstrap/__tests__/DocumentQueueView.test.tsx
+++ b/src/components/bootstrap/__tests__/DocumentQueueView.test.tsx
@@ -129,12 +129,15 @@ describe('DocumentQueueView', () => {
     expect(screen.getByText('Done')).toBeInTheDocument();
   });
 
-  it('shows "Reopen" button for COMPLETE document with a run and calls reopen on click', () => {
+  // A "completed" doc in the queue is one whose latest calibration run has
+  // completedAt set (getCorpusDocumentStatus -> 'COMPLETED'); the backend never
+  // populates doc.status, so Reopen lives in that block, not the renderActions
+  // 'COMPLETE' branch.
+  it('shows "Reopen" button for a completed doc and calls reopen on click', () => {
     mockUseCorpus.mockReturnValue({
       data: {
         documents: [
           makeDoc({
-            status: 'COMPLETE',
             calibrationRuns: [
               {
                 id: 'run-1',


### PR DESCRIPTION
## Problem

The **Reopen** button shipped in #278 never appeared on completed documents in the Calibration Document Queue.

**Root cause:** #278 put the button in `renderActions`' `case 'COMPLETE'`, which switches on `doc.status`. But the `/calibration/corpus-docs` endpoint **never sets `doc.status`** — the `CorpusDocument` model has no such column (only `statusOverride`, used by the separate Status Tracker). So `doc.status` is always `undefined`, `renderActions` always falls through to `'PENDING'` → `null`, and the `COMPLETE` branch is dead code.

Completed docs actually surface through the `getCorpusDocumentStatus(doc) === 'COMPLETED'` block — the one rendering **Review Zones / Lineage / Timesheet / Analysis**.

## Fix

- Move **Reopen** into the `COMPLETED` block, beside Review Zones (uses `doc.calibrationRuns![0].id`, which that block already guards on). Behaviour is unchanged: calls `POST /calibration/runs/:runId/reopen`, then navigates to `/bootstrap/review/:docId` on success.
- Revert the `renderActions` `COMPLETE` case to its original `Done` label.
- Update the test to drive off `calibrationRuns` + `completedAt` (the real completion signal) instead of the non-existent `doc.status`.

The service (`reopenAnnotation`) and hook (`useReopenAnnotation`) from #278 are unchanged.

## Verification

- `npx tsc --noEmit` — pass
- `npx eslint` (changed files) — pass
- `DocumentQueueView.test.tsx` — 7/7 pass (Reopen test now exercises the real path)

## Manual test (post-deploy)

1. Calibration Document Queue → a doc showing **Complete** (Review Zones visible).
2. **Reopen** now appears next to Analysis → click → navigates to the editable review workspace.
3. Confirm zones are editable; doc drops out of Complete after the queue refetches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Repositioned the "Reopen" action to the completed operations section of the document queue, improving accessibility when users need to reopen finished documents. The action now properly navigates to the review page upon successful completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->