### PR TITLE
feat(pdf): Matterhorn Step 2/5 + audit UX (revive of #166)

### DIFF
--- a/docs/pdf-preview-cross-reference-design.md
+++ b/docs/pdf-preview-cross-reference-design.md
@@ -1,0 +1,130 @@
+# PDF Preview ↔ Issues Panel Cross-Reference Design
+
+**Decision:** Option A + C
+**Status:** Approved for implementation
+
+---
+
+## Problem
+
+The PDF preview panel displays numbered circles (1, 2, 3… per page) over issue bounding boxes.
+The issues panel (right column) displays a separate filtered list with its own ordering.
+There is no visual or interactive link between the two — a user who sees circle `3` on the PDF has
+no way to find that issue in the right panel without clicking through it.
+
+---
+
+## Options Considered
+
+### Option A — Global Sequential Numbers (Fixed Order)
+
+Each issue gets a single global number (1–N) assigned once at load time by severity → page order.
+Both the circle on the PDF and the issue card in the right panel display that same number always.
+
+```
+Right panel:          PDF overlay:
+[#1] Critical — ...   ┌─────────────┐
+[#2] Serious  — ...   │  ①  ③       │
+[#3] Serious  — ...   │       ②     │
+                      └─────────────┘
+```
+
+**Pros:** Simple, stable — numbers never change when you filter. "Circle 7 = Issue 7" is always true.
+**Cons:** Numbers can be large (circle showing "47" is hard to read). If the right panel is filtered,
+issue #47 may be off-screen and hard to find.
+
+---
+
+### Option B — Filter-Aware Numbers (Dynamic)
+
+Numbers match only the currently-visible issues in the right panel. Filter to "Tables" → only table
+issues get circles (1, 2, 3). Other circles disappear or are grayed out.
+
+**Pros:** "Circle 2 = issue 2 in the list" is always true for what you can currently see.
+**Cons:** Numbers shift every time the filter changes, which feels unstable.
+
+---
+
+### Option C — Bidirectional Selection (No Numbering)
+
+Remove numbers from circles entirely. Wire selection bidirectionally:
+- Click a circle → right panel **scrolls to and pulses** that issue card
+- Click an issue card → PDF navigates to that page and **animates** that circle
+
+**Pros:** No number-matching confusion. Cleanest UX. The selection IS the correlation.
+**Cons:** No "which numbered item is this?" without an extra click.
+
+---
+
+### Option D — Page-Local Numbers + "On This Page" Highlight in Right Panel
+
+Keep circles as 1, 2, 3… per page but add a visual marker in the right panel showing which
+issues are on the currently viewed page.
+
+**Pros:** Circles stay stable, right panel shows page context.
+**Cons:** Two numbering systems exist simultaneously.
+
+---
+
+## Decision: Option A + C Combined
+
+**Global sequential numbers** (Option A) for stable identity, plus **bidirectional selection**
+(Option C) for interaction wiring. Numbers never shift with filters; selection state links both panels.
+
+---
+
+## Implementation Spec
+
+### 1. Global Issue Numbering
+
+Assign `globalIndex` (1-based) to every issue once, at the point where issues are loaded from the
+audit result. Ordering: **page number ascending → severity weight descending → original array order**.
+
+Severity weight: `critical=4`, `serious=3`, `moderate=2`, `minor=1`.
+
+`globalIndex` is passed as a stable prop — it does not recompute when filters change.
+
+### 2. PDF Preview Panel — Circle Shows Global Number
+
+`PdfPreviewPanel` receives a `issueNumberMap: Map<string, number>` (issueId → globalIndex).
+The overlay circle renders `issueNumberMap.get(issue.id) ?? '?'` instead of the per-page `index + 1`.
+
+### 3. Issues Panel — Number Badge on Each Card
+
+Each issue card in the right panel shows a small `#N` badge (gray, monospace) alongside the severity
+chip. The badge always shows the global number — visible even when filtered.
+
+### 4. Bidirectional Selection Wiring
+
+**Circle → Right panel (existing + enhanced):**
+- Clicking a circle already sets `selectedIssueId`
+- New: after setting selection, call `scrollToIssueCard(issueId)` which calls
+  `document.getElementById(`issue-card-${issueId}`)?.scrollIntoView({ behavior: 'smooth', block: 'nearest' })`
+
+**Right panel → PDF preview (new):**
+- Each issue card already has a click handler that sets `selectedIssueId`
+- New: after setting selection, if the issue is on a different page, call `onPageChange(issue.page)`
+  so the PDF navigates to that page and the circle becomes visible
+
+### 5. Issue Card DOM IDs
+
+Add `id={`issue-card-${issue.id}`}` to each issue card wrapper so `scrollIntoView` can target it.
+
+---
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `src/pages/PdfAuditResultsPage.tsx` | Compute `issueNumberMap`, wire `onIssueSelect` to scroll right panel, wire issue card click to `onPageChange` |
+| `src/components/pdf/PdfPreviewPanel.tsx` | Accept `issueNumberMap` prop, use global number in overlay circle |
+| `src/components/remediation/IssueCard.tsx` | Add `#N` badge, add `id` attribute to card wrapper |
+
+---
+
+## What Does NOT Change
+
+- Filter state — numbers stay the same regardless of active filter
+- Sort order of the right panel — independent of global numbering
+- Existing `selectedIssueId` state management
+- Any backend code

--- a/docs/pdf-preview-cross-reference-design.md
+++ b/docs/pdf-preview-cross-reference-design.md
@@ -21,7 +21,7 @@ no way to find that issue in the right panel without clicking through it.
 Each issue gets a single global number (1–N) assigned once at load time by severity → page order.
 Both the circle on the PDF and the issue card in the right panel display that same number always.
 
-```
+```text
 Right panel:          PDF overlay:
 [#1] Critical — ...   ┌─────────────┐
 [#2] Serious  — ...   │  ①  ③       │

--- a/src/components/epub/EPUBUploader.tsx
+++ b/src/components/epub/EPUBUploader.tsx
@@ -165,6 +165,7 @@ const DocumentUploader: React.FC<DocumentUploaderProps> = ({
       try {
         const res = await api.get(`/pdf/${completedResult.jobId}/ai-analysis`);
         const d = res.data.data;
+        // 'pending' = job done but AI not started yet; keep polling
         if (d.status === 'complete') {
           setAiStatus('complete');
           setAiSuggestionCount(d.analyzed ?? 0);
@@ -174,6 +175,7 @@ const DocumentUploader: React.FC<DocumentUploaderProps> = ({
           setAiStatus('error');
           if (aiPollRef.current) { clearInterval(aiPollRef.current); aiPollRef.current = null; }
         }
+        // 'pending' and 'processing' → leave interval running
       } catch { /* ignore transient errors */ }
     };
 

--- a/src/components/epub/EPUBUploader.tsx
+++ b/src/components/epub/EPUBUploader.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useCallback, useRef, useEffect } from 'react';
-import { Upload, FileText, CheckCircle, AlertCircle, Loader2, X, Circle } from 'lucide-react';
+import { Upload, FileText, CheckCircle, AlertCircle, Loader2, X, Circle, ArrowRight, Sparkles } from 'lucide-react';
 import { Button } from '../ui/Button';
 import { Progress } from '../ui/Progress';
 import { Alert } from '../ui/Alert';
@@ -65,12 +65,23 @@ const DocumentUploader: React.FC<DocumentUploaderProps> = ({
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
   const [isDragging, setIsDragging] = useState(false);
   const [workflowEnabled, setWorkflowEnabled] = useState<boolean>(false);
+  const [completedResult, setCompletedResult] = useState<AuditSummary | null>(null);
+  const [completedJobData, setCompletedJobData] = useState<JobData | null>(null);
+  const [aiStatus, setAiStatus] = useState<'running' | 'complete' | 'error' | null>(null);
+  const [aiSuggestionCount, setAiSuggestionCount] = useState(0);
+  const [aiTokenStats, setAiTokenStats] = useState<{
+    gemini: { totalTokens: number; estimatedCostUsd: number };
+    claude: { totalTokens: number; estimatedCostUsd: number };
+    totalTokens: number;
+    totalCostUsd: number;
+  } | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const fileNameRef = useRef<string>('');
   const fileTypeRef = useRef<DocumentFileType>('epub');
   const workflowIdRef = useRef<string | undefined>(undefined);
   const uploadStartRef = useRef<Date | null>(null);
   const uploadEndRef = useRef<Date | null>(null);
+  const aiPollRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   const handleJobComplete = useCallback((jobData: JobData) => {
     setState('complete');
@@ -97,8 +108,10 @@ const DocumentUploader: React.FC<DocumentUploaderProps> = ({
       // Use workflowId from upload response (stored in ref), not from job output
       workflowId: workflowIdRef.current,
     };
-    onUploadComplete?.(result);
-  }, [onUploadComplete]);
+    // Save completed data — user clicks "View Full Results" to navigate
+    setCompletedResult(result);
+    setCompletedJobData(jobData);
+  }, []);
 
   const handleJobError = useCallback((errorMsg: string) => {
     setState('error');
@@ -141,6 +154,33 @@ const DocumentUploader: React.FC<DocumentUploaderProps> = ({
 
     fetchWorkflowConfig();
   }, []);
+
+  // Poll AI analysis status after audit job completes (PDF only)
+  useEffect(() => {
+    if (state !== 'complete' || !completedResult?.jobId || fileTypeRef.current !== 'pdf') return;
+
+    setAiStatus('running');
+
+    const poll = async () => {
+      try {
+        const res = await api.get(`/pdf/${completedResult.jobId}/ai-analysis`);
+        const d = res.data.data;
+        if (d.status === 'complete') {
+          setAiStatus('complete');
+          setAiSuggestionCount(d.analyzed ?? 0);
+          if (d.stats) setAiTokenStats(d.stats);
+          if (aiPollRef.current) { clearInterval(aiPollRef.current); aiPollRef.current = null; }
+        } else if (d.status === 'error') {
+          setAiStatus('error');
+          if (aiPollRef.current) { clearInterval(aiPollRef.current); aiPollRef.current = null; }
+        }
+      } catch { /* ignore transient errors */ }
+    };
+
+    poll();
+    aiPollRef.current = setInterval(poll, 3000);
+    return () => { if (aiPollRef.current) { clearInterval(aiPollRef.current); aiPollRef.current = null; } };
+  }, [state, completedResult?.jobId]);
 
   const validateFile = useCallback((file: File): string | null => {
     const fileType = detectFileType(file);
@@ -459,25 +499,25 @@ const DocumentUploader: React.FC<DocumentUploaderProps> = ({
                         Page {currentPage.toLocaleString()} of {totalPages.toLocaleString()}
                       </p>
                     ) : (
-                      <div className="text-left mx-auto max-w-xs space-y-1">
+                      <div className="text-left mx-auto max-w-xs space-y-1.5">
                         {VALIDATOR_LABELS.map((label) => {
                           const done = doneNames.has(label);
                           const stat = validatorProgress?.find(v => v.label === label);
                           const isNext = !done && (validatorProgress ?? []).length === VALIDATOR_LABELS.indexOf(label);
                           return (
-                            <div key={label} className="flex items-center gap-2 text-xs">
+                            <div key={label} className="flex items-center gap-2 text-sm">
                               {done ? (
-                                <CheckCircle className="h-3.5 w-3.5 text-green-500 shrink-0" />
+                                <CheckCircle className="h-4 w-4 text-green-500 shrink-0" />
                               ) : isNext ? (
-                                <Loader2 className="h-3.5 w-3.5 text-primary-500 animate-spin shrink-0" />
+                                <Loader2 className="h-4 w-4 text-primary-500 animate-spin shrink-0" />
                               ) : (
-                                <Circle className="h-3.5 w-3.5 text-gray-300 shrink-0" />
+                                <Circle className="h-4 w-4 text-gray-300 shrink-0" />
                               )}
-                              <span className={done ? 'text-gray-700' : 'text-gray-400'}>
+                              <span className={done ? 'text-gray-800 font-medium' : isNext ? 'text-primary-700 font-medium' : 'text-gray-400'}>
                                 {label}
                                 {done && stat && (
-                                  <span className={stat.issuesFound > 0 ? 'text-amber-600' : 'text-green-600'}>
-                                    {' — '}{stat.issuesFound} {stat.issuesFound === 1 ? 'issue' : 'issues'}
+                                  <span className={`ml-1 font-normal text-xs ${stat.issuesFound > 0 ? 'text-amber-600' : 'text-green-600'}`}>
+                                    — {stat.issuesFound} {stat.issuesFound === 1 ? 'issue' : 'issues'}
                                   </span>
                                 )}
                               </span>
@@ -503,13 +543,26 @@ const DocumentUploader: React.FC<DocumentUploaderProps> = ({
               const auditStart = jobData?.startedAt ? new Date(jobData.startedAt) : null;
               const auditEnd   = jobData?.completedAt ? new Date(jobData.completedAt) : null;
               const totalPages = jobData?.input?.totalPages as number | undefined;
+              const autoTagProg = jobData?.input?.autoTagProgress as { startedAt?: string; completedAt?: string; status?: string; elementCounts?: Record<string, number> } | undefined;
+              const hasAutoTag = !!autoTagProg;
+              const autoTagEnd = autoTagProg?.completedAt ? new Date(autoTagProg.completedAt) : null;
               const extractionDone = (totalPages ? progress >= 88 : false) || vp.length > 0 || auditEnd !== null;
               const extractionEnd  = vp.length > 0 ? new Date(vp[0].startedAt) : (extractionDone ? auditEnd : null);
+              const extractionStart = hasAutoTag ? autoTagEnd : auditStart;
               const VLABELS = ['Structure & Tags', 'Alt Text', 'Color Contrast', 'Tables'];
               const rows: TR[] = [
                 { label: 'Upload',    start: uploadStartRef.current, end: uploadEndRef.current, status: uploadEndRef.current ? 'done' : 'running' },
                 { label: 'Queue',     start: uploadEndRef.current,   end: auditStart,            status: auditStart ? 'done' : uploadEndRef.current ? 'running' : 'pending' },
-                { label: 'Extraction', start: auditStart,            end: extractionEnd,          status: extractionDone ? 'done' : auditStart ? 'running' : 'pending' },
+                ...(hasAutoTag ? [{
+                  label: 'Adobe AutoTag',
+                  start: autoTagProg?.startedAt ? new Date(autoTagProg.startedAt) : auditStart,
+                  end: autoTagEnd,
+                  status: (autoTagProg?.status === 'complete' || autoTagProg?.status === 'failed') ? 'done' as const : auditStart ? 'running' as const : 'pending' as const,
+                  detail: autoTagProg?.status === 'complete' && autoTagProg.elementCounts
+                    ? `${autoTagProg.elementCounts.figures ?? 0}F · ${autoTagProg.elementCounts.tables ?? 0}T · ${autoTagProg.elementCounts.headings ?? 0}H`
+                    : autoTagProg?.status === 'failed' ? 'failed' : undefined,
+                }] : []),
+                { label: 'Extraction', start: extractionStart,       end: extractionEnd,          status: extractionDone ? 'done' : (hasAutoTag ? autoTagEnd : auditStart) ? 'running' : 'pending' },
                 ...VLABELS.map((lbl, idx) => {
                   const done = vp.find(v => v.label === lbl);
                   if (done) return { label: lbl, start: new Date(done.startedAt), end: new Date(done.completedAt), status: 'done' as const, detail: `${done.issuesFound} issue${done.issuesFound !== 1 ? 's' : ''}` };
@@ -519,36 +572,47 @@ const DocumentUploader: React.FC<DocumentUploaderProps> = ({
                 }),
               ];
               return (
-                <div className="mt-2 border border-gray-100 rounded-md overflow-hidden text-left text-xs">
-                  <div className="bg-gray-50 px-3 py-1 font-semibold text-gray-400 uppercase tracking-wide border-b border-gray-100 text-[10px]">
+                <div className="mt-3 border border-gray-200 rounded-lg overflow-hidden text-left">
+                  <div className="bg-gray-100 px-4 py-2 font-semibold text-gray-500 uppercase tracking-wider text-xs border-b border-gray-200">
                     Timing
                   </div>
-                  <table className="w-full">
+                  <table className="w-full text-sm">
                     <thead>
-                      <tr className="border-b border-gray-100 text-gray-400">
-                        <th className="px-3 py-1 text-left font-medium">Phase</th>
-                        <th className="px-3 py-1 text-left font-medium">Started</th>
-                        <th className="px-3 py-1 text-left font-medium">Ended</th>
-                        <th className="px-3 py-1 text-left font-medium">Duration</th>
+                      <tr className="border-b border-gray-200 bg-gray-50 text-gray-500">
+                        <th className="px-4 py-2 text-left font-semibold">Phase</th>
+                        <th className="px-4 py-2 text-left font-semibold">Started</th>
+                        <th className="px-4 py-2 text-left font-semibold">Ended</th>
+                        <th className="px-4 py-2 text-left font-semibold">Duration</th>
                       </tr>
                     </thead>
                     <tbody>
                       {rows.map(row => (
-                        <tr key={row.label} className="border-b border-gray-50 last:border-0">
-                          <td className="px-3 py-1 font-medium text-gray-700">
-                            {row.label}
-                            {row.detail && <span className="ml-1 font-normal text-gray-400">· {row.detail}</span>}
+                        <tr key={row.label} className={`border-b border-gray-100 last:border-0 ${row.status === 'running' ? 'bg-primary-50' : ''}`}>
+                          <td className="px-4 py-2 font-medium text-gray-800">
+                            <div className="flex items-center gap-2">
+                              {row.status === 'done' && <span className="inline-block w-2 h-2 rounded-full bg-green-500 shrink-0" />}
+                              {row.status === 'running' && <span className="inline-block w-2 h-2 rounded-full bg-primary-500 animate-pulse shrink-0" />}
+                              {row.status === 'pending' && <span className="inline-block w-2 h-2 rounded-full bg-gray-300 shrink-0" />}
+                              <span className={row.status === 'pending' ? 'text-gray-400' : 'text-gray-800'}>
+                                {row.label}
+                              </span>
+                              {row.detail && <span className="font-normal text-gray-400 text-xs">· {row.detail}</span>}
+                            </div>
                           </td>
-                          <td className="px-3 py-1 font-mono text-gray-500">{fmtTime(row.start)}</td>
-                          <td className="px-3 py-1 font-mono text-gray-500">
-                            {row.status === 'running' ? <span className="text-primary-500 not-italic">running…</span> : row.status === 'pending' ? <span className="text-gray-300">—</span> : fmtTime(row.end)}
+                          <td className="px-4 py-2 font-mono text-gray-600 text-xs">{fmtTime(row.start)}</td>
+                          <td className="px-4 py-2 font-mono text-xs">
+                            {row.status === 'running'
+                              ? <span className="text-primary-600 font-medium">running…</span>
+                              : row.status === 'pending'
+                                ? <span className="text-gray-300">—</span>
+                                : <span className="text-gray-600">{fmtTime(row.end)}</span>}
                           </td>
-                          <td className="px-3 py-1 font-mono">
+                          <td className="px-4 py-2 font-mono text-xs">
                             {row.status === 'pending'
                               ? <span className="text-gray-300">—</span>
                               : row.status === 'running'
-                                ? <span className="text-primary-500">{fmtDur(row.start)}</span>
-                                : <span className="text-gray-600">{fmtDur(row.start, row.end)}</span>}
+                                ? <span className="text-primary-600 font-semibold">{fmtDur(row.start)}</span>
+                                : <span className="text-gray-700 font-medium">{fmtDur(row.start, row.end)}</span>}
                           </td>
                         </tr>
                       ))}
@@ -560,15 +624,161 @@ const DocumentUploader: React.FC<DocumentUploaderProps> = ({
           </div>
         )}
 
-        {state === 'complete' && (
-          <div className="space-y-4">
-            <CheckCircle className="h-12 w-12 mx-auto text-green-600" />
-            <p className="font-medium text-gray-900">Audit Complete!</p>
-            <p className="text-sm text-gray-500">
-              Your document has been analyzed. View the results below.
-            </p>
-          </div>
-        )}
+        {state === 'complete' && completedResult && completedJobData && (() => {
+          const output = (completedJobData.output || {}) as Record<string, unknown>;
+          const auditReport = output.auditReport as Record<string, unknown> | undefined;
+          const issues = (auditReport?.issues as unknown[]) ?? [];
+          const totalIssues = issues.length;
+          const autoTagStatus = output.autoTagStatus as string | undefined;
+          const elementCounts = output.autoTagElementCounts as Record<string, number> | null | undefined;
+          const isPdf = fileTypeRef.current === 'pdf';
+          // Button is gated: for PDFs, wait for AI analysis to finish (or error)
+          const canProceed = !isPdf || aiStatus === 'complete' || aiStatus === 'error';
+
+          // Build timing rows from completed job data
+          type TR = { label: string; start: Date | null; end: Date | null; detail?: string };
+          const vp = (completedJobData.input?.validatorProgress ?? []) as Array<{ label: string; issuesFound: number; startedAt: string; completedAt: string }>;
+          const auditStart = completedJobData.startedAt ? new Date(completedJobData.startedAt) : null;
+          const autoTagProg = completedJobData.input?.autoTagProgress as { startedAt?: string; completedAt?: string; status?: string; elementCounts?: Record<string, number> } | undefined;
+          const hasAutoTag = !!autoTagProg;
+          const autoTagEnd = autoTagProg?.completedAt ? new Date(autoTagProg.completedAt) : null;
+          const extractionEnd = vp.length > 0 ? new Date(vp[0].startedAt) : (completedJobData.completedAt ? new Date(completedJobData.completedAt) : null);
+          const extractionStart = hasAutoTag ? autoTagEnd : auditStart;
+          const timingRows: TR[] = [
+            { label: 'Upload', start: uploadStartRef.current, end: uploadEndRef.current },
+            { label: 'Queue', start: uploadEndRef.current, end: auditStart },
+            ...(hasAutoTag ? [{
+              label: 'Adobe AutoTag',
+              start: autoTagProg?.startedAt ? new Date(autoTagProg.startedAt) : auditStart,
+              end: autoTagEnd,
+              detail: autoTagProg?.elementCounts
+                ? `${autoTagProg.elementCounts.figures ?? 0}F · ${autoTagProg.elementCounts.tables ?? 0}T · ${autoTagProg.elementCounts.headings ?? 0}H`
+                : undefined,
+            }] : []),
+            { label: 'Extraction', start: extractionStart, end: extractionEnd },
+            ...vp.map(v => ({
+              label: v.label,
+              start: new Date(v.startedAt),
+              end: new Date(v.completedAt),
+              detail: `${v.issuesFound} issue${v.issuesFound !== 1 ? 's' : ''}`,
+            })),
+          ];
+
+          return (
+            <div className="space-y-4">
+              <CheckCircle className="h-12 w-12 mx-auto text-green-600" />
+              <p className="font-semibold text-lg text-gray-900">Audit Complete</p>
+              <div className="text-left border border-gray-200 rounded-lg overflow-hidden bg-white shadow-sm">
+                {/* Summary header */}
+                <div className="bg-gray-50 border-b border-gray-200 px-4 py-3 space-y-1.5">
+                  <div className="flex flex-wrap gap-x-4 gap-y-1 text-sm">
+                    <span className="font-semibold text-gray-800">{totalIssues.toLocaleString()} issues found</span>
+                    {autoTagStatus === 'complete' && (
+                      <span className="text-green-700 flex items-center gap-1">
+                        <CheckCircle className="h-3.5 w-3.5" />
+                        Auto-tagged by Adobe
+                        {elementCounts && (
+                          <span className="font-normal text-green-600 text-xs">
+                            ({elementCounts.figures ?? 0} figs · {elementCounts.tables ?? 0} tables · {elementCounts.headings ?? 0} headings)
+                          </span>
+                        )}
+                      </span>
+                    )}
+                    {isPdf && aiStatus === 'running' && (
+                      <span className="text-purple-600 flex items-center gap-1">
+                        <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                        AI analysis running…
+                      </span>
+                    )}
+                    {isPdf && aiStatus === 'complete' && (
+                      <span className="text-purple-700 flex items-center gap-1">
+                        <Sparkles className="h-3.5 w-3.5" />
+                        AI analysis complete — {aiSuggestionCount} suggestion{aiSuggestionCount !== 1 ? 's' : ''}
+                      </span>
+                    )}
+                    {isPdf && aiStatus === 'error' && (
+                      <span className="text-amber-600 flex items-center gap-1">
+                        <AlertCircle className="h-3.5 w-3.5" />
+                        AI analysis unavailable
+                      </span>
+                    )}
+                  </div>
+                  {/* AI token stats strip */}
+                  {isPdf && aiTokenStats && (
+                    <div className="flex flex-wrap items-center gap-3 pt-1.5 text-xs text-slate-600 border-t border-gray-200 mt-1">
+                      <span className="font-medium text-slate-700">AI Token Usage:</span>
+                      {aiTokenStats.gemini.totalTokens > 0 && (
+                        <span>Gemini: <span className="font-mono font-medium">{aiTokenStats.gemini.totalTokens.toLocaleString()}</span> tokens (${aiTokenStats.gemini.estimatedCostUsd.toFixed(4)})</span>
+                      )}
+                      {aiTokenStats.claude.totalTokens > 0 && (
+                        <span>Claude: <span className="font-mono font-medium">{aiTokenStats.claude.totalTokens.toLocaleString()}</span> tokens (${aiTokenStats.claude.estimatedCostUsd.toFixed(4)})</span>
+                      )}
+                      <span className="ml-auto font-medium">
+                        Total: <span className="font-mono">{aiTokenStats.totalTokens.toLocaleString()}</span> tokens · <span className="font-mono">${aiTokenStats.totalCostUsd.toFixed(4)}</span>
+                      </span>
+                    </div>
+                  )}
+                </div>
+                {/* Timing table */}
+                {uploadStartRef.current && timingRows.length > 0 && (
+                  <div className="border-b border-gray-200">
+                    <div className="bg-gray-100 px-4 py-2 font-semibold text-gray-500 uppercase tracking-wider text-xs border-b border-gray-200">
+                      Timing
+                    </div>
+                    <table className="w-full text-sm">
+                      <thead>
+                        <tr className="border-b border-gray-200 bg-gray-50 text-gray-500">
+                          <th className="px-4 py-2 text-left font-semibold">Phase</th>
+                          <th className="px-4 py-2 text-left font-semibold">Started</th>
+                          <th className="px-4 py-2 text-left font-semibold">Ended</th>
+                          <th className="px-4 py-2 text-left font-semibold">Duration</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {timingRows.map(row => (
+                          <tr key={row.label} className="border-b border-gray-100 last:border-0">
+                            <td className="px-4 py-2 font-medium text-gray-800">
+                              <div className="flex items-center gap-2">
+                                <span className="inline-block w-2 h-2 rounded-full bg-green-500 shrink-0" />
+                                <span className="text-gray-800">{row.label}</span>
+                                {row.detail && <span className="font-normal text-gray-400 text-xs">· {row.detail}</span>}
+                              </div>
+                            </td>
+                            <td className="px-4 py-2 font-mono text-gray-600 text-xs">{fmtTime(row.start)}</td>
+                            <td className="px-4 py-2 font-mono text-gray-600 text-xs">{fmtTime(row.end)}</td>
+                            <td className="px-4 py-2 font-mono text-xs">
+                              <span className="text-gray-700 font-medium">{fmtDur(row.start, row.end)}</span>
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                )}
+                {/* Actions */}
+                <div className="px-4 py-3 flex justify-end">
+                  <Button
+                    onClick={() => onUploadComplete?.(completedResult)}
+                    className="flex items-center gap-2"
+                    disabled={!canProceed}
+                  >
+                    {!canProceed ? (
+                      <>
+                        <Loader2 className="h-4 w-4 animate-spin" />
+                        Waiting for AI Analysis…
+                      </>
+                    ) : (
+                      <>
+                        View Full Results
+                        <ArrowRight className="h-4 w-4" />
+                      </>
+                    )}
+                  </Button>
+                </div>
+              </div>
+            </div>
+          );
+        })()}
 
         {state === 'error' && (
           <div className="space-y-4">

--- a/src/components/epub/EPUBUploader.tsx
+++ b/src/components/epub/EPUBUploader.tsx
@@ -351,6 +351,11 @@ const DocumentUploader: React.FC<DocumentUploaderProps> = ({
     setProgress(0);
     setError(null);
     setSelectedFile(null);
+    setCompletedResult(null);
+    setCompletedJobData(null);
+    setAiStatus(null);
+    setAiSuggestionCount(0);
+    setAiTokenStats(null);
     if (fileInputRef.current) {
       fileInputRef.current.value = '';
     }

--- a/src/components/pdf/PacReportModal.tsx
+++ b/src/components/pdf/PacReportModal.tsx
@@ -1,0 +1,211 @@
+/**
+ * PAC Report Modal
+ *
+ * Displays a Matterhorn Protocol 1.1 compliance report as a 31-checkpoint
+ * colour-coded grid. Each checkpoint shows its overall status and can be
+ * expanded to reveal individual condition results.
+ *
+ * Matterhorn Coverage Plan — Step 5 (frontend)
+ */
+
+import { useState, useEffect } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '../ui/Dialog';
+import { Button } from '../ui/Button';
+import { Loader2, CheckCircle2, XCircle, AlertTriangle, HelpCircle, ChevronDown, ChevronRight } from 'lucide-react';
+import { getPacReport } from '../../services/pac-report.service';
+import type {
+  PacReport,
+  PacCheckpointResult,
+  PacCheckpointStatus,
+  PacConditionStatus,
+} from '../../services/pac-report.service';
+
+// ─── Status helpers ───────────────────────────────────────────────────────────
+
+const CHECKPOINT_COLORS: Record<PacCheckpointStatus, string> = {
+  PASS: 'bg-green-50 border-green-200 text-green-800',
+  FAIL: 'bg-red-50 border-red-200 text-red-800',
+  UNTESTED: 'bg-amber-50 border-amber-200 text-amber-800',
+  HUMAN_REQUIRED: 'bg-gray-50 border-gray-200 text-gray-600',
+};
+
+const CONDITION_COLORS: Record<PacConditionStatus, string> = {
+  PASS: 'text-green-700',
+  FAIL: 'text-red-700 font-medium',
+  UNTESTED: 'text-amber-700',
+  HUMAN_REQUIRED: 'text-gray-500',
+  NOT_APPLICABLE: 'text-gray-400',
+};
+
+const CHECKPOINT_ICON: Record<PacCheckpointStatus, React.ReactNode> = {
+  PASS: <CheckCircle2 className="h-4 w-4 text-green-600 flex-shrink-0" />,
+  FAIL: <XCircle className="h-4 w-4 text-red-600 flex-shrink-0" />,
+  UNTESTED: <AlertTriangle className="h-4 w-4 text-amber-600 flex-shrink-0" />,
+  HUMAN_REQUIRED: <HelpCircle className="h-4 w-4 text-gray-400 flex-shrink-0" />,
+};
+
+function statusLabel(status: PacCheckpointStatus | PacConditionStatus): string {
+  switch (status) {
+    case 'PASS': return 'PASS';
+    case 'FAIL': return 'FAIL';
+    case 'UNTESTED': return 'UNTESTED';
+    case 'HUMAN_REQUIRED': return 'HUMAN';
+    case 'NOT_APPLICABLE': return 'N/A';
+    default: return status;
+  }
+}
+
+// ─── Checkpoint row ───────────────────────────────────────────────────────────
+
+function CheckpointRow({ cp }: { cp: PacCheckpointResult }) {
+  const [expanded, setExpanded] = useState(cp.status === 'FAIL');
+
+  return (
+    <div className={`border rounded-md overflow-hidden ${CHECKPOINT_COLORS[cp.status]}`}>
+      <button
+        className="w-full flex items-center gap-2 px-3 py-2 text-left hover:opacity-80 transition-opacity"
+        onClick={() => setExpanded((v) => !v)}
+      >
+        {expanded
+          ? <ChevronDown className="h-3.5 w-3.5 flex-shrink-0" />
+          : <ChevronRight className="h-3.5 w-3.5 flex-shrink-0" />
+        }
+        {CHECKPOINT_ICON[cp.status]}
+        <span className="text-xs font-semibold w-6 flex-shrink-0">CP{cp.id}</span>
+        <span className="text-xs flex-1 truncate">{cp.title}</span>
+        <span className="text-xs font-mono flex-shrink-0 opacity-70">{statusLabel(cp.status)}</span>
+      </button>
+
+      {expanded && (
+        <div className="border-t border-current border-opacity-10 px-3 py-2 space-y-1 bg-white bg-opacity-60">
+          {cp.conditions.map((cond) => (
+            <div key={cond.id} className="flex items-start gap-2 text-xs">
+              <span className={`font-mono flex-shrink-0 w-14 ${CONDITION_COLORS[cond.status]}`}>
+                {cond.id}
+              </span>
+              <span className={`flex-1 ${CONDITION_COLORS[cond.status]}`}>
+                {cond.description}
+              </span>
+              <span className={`font-mono flex-shrink-0 ${CONDITION_COLORS[cond.status]}`}>
+                {statusLabel(cond.status)}
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── Summary bar ─────────────────────────────────────────────────────────────
+
+function SummaryBar({ report }: { report: PacReport }) {
+  const { summary } = report;
+  return (
+    <div className="grid grid-cols-5 gap-2 text-center text-xs mb-4">
+      <div className="bg-green-50 border border-green-200 rounded p-2">
+        <div className="text-lg font-bold text-green-700">{summary.pass}</div>
+        <div className="text-green-600">PASS</div>
+      </div>
+      <div className="bg-red-50 border border-red-200 rounded p-2">
+        <div className="text-lg font-bold text-red-700">{summary.fail}</div>
+        <div className="text-red-600">FAIL</div>
+      </div>
+      <div className="bg-amber-50 border border-amber-200 rounded p-2">
+        <div className="text-lg font-bold text-amber-700">{summary.untested}</div>
+        <div className="text-amber-600">UNTESTED</div>
+      </div>
+      <div className="bg-gray-50 border border-gray-200 rounded p-2">
+        <div className="text-lg font-bold text-gray-600">{summary.humanRequired}</div>
+        <div className="text-gray-500">HUMAN</div>
+      </div>
+      <div className="bg-gray-50 border border-gray-200 rounded p-2">
+        <div className="text-lg font-bold text-gray-400">{summary.notApplicable}</div>
+        <div className="text-gray-400">N/A</div>
+      </div>
+    </div>
+  );
+}
+
+// ─── Modal ────────────────────────────────────────────────────────────────────
+
+interface PacReportModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  jobId: string;
+}
+
+export function PacReportModal({ isOpen, onClose, jobId }: PacReportModalProps) {
+  const [report, setReport] = useState<PacReport | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!isOpen || !jobId) return;
+    setIsLoading(true);
+    setError(null);
+    getPacReport(jobId)
+      .then(setReport)
+      .catch((err: unknown) => {
+        const msg = err instanceof Error ? err.message : 'Failed to load PAC report';
+        setError(msg);
+      })
+      .finally(() => setIsLoading(false));
+  }, [isOpen, jobId]);
+
+  return (
+    <Dialog open={isOpen} onOpenChange={(open) => { if (!open) onClose(); }}>
+      <DialogContent className="max-w-3xl max-h-[90vh] flex flex-col">
+        <DialogHeader>
+          <DialogTitle>Matterhorn Protocol 1.1 Compliance Report</DialogTitle>
+          <DialogDescription>
+            {report
+              ? `${report.fileName} · ${report.summary.total} conditions across 31 checkpoints`
+              : 'PDF/UA-1 accessibility compliance assessment'
+            }
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="flex-1 overflow-y-auto pr-1">
+          {isLoading && (
+            <div className="flex items-center justify-center py-16 text-gray-400">
+              <Loader2 className="h-6 w-6 animate-spin mr-2" />
+              Generating report…
+            </div>
+          )}
+
+          {error && (
+            <div className="py-8 text-center text-red-600 text-sm">{error}</div>
+          )}
+
+          {report && !isLoading && (
+            <>
+              <SummaryBar report={report} />
+
+              <div className="space-y-1.5">
+                {report.checkpoints.map((cp) => (
+                  <CheckpointRow key={cp.id} cp={cp} />
+                ))}
+              </div>
+
+              <p className="mt-4 text-xs text-gray-400 italic text-center">
+                UNTESTED conditions are not confirmed passing. This report does not constitute
+                full PDF/UA-1 certification.
+              </p>
+            </>
+          )}
+        </div>
+
+        <div className="flex justify-end pt-3 border-t">
+          <Button variant="outline" size="sm" onClick={onClose}>Close</Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/pdf/PacReportModal.tsx
+++ b/src/components/pdf/PacReportModal.tsx
@@ -148,15 +148,20 @@ export function PacReportModal({ isOpen, onClose, jobId }: PacReportModalProps) 
 
   useEffect(() => {
     if (!isOpen || !jobId) return;
+    // Guard against a stale response (close/reopen or jobId change) overwriting
+    // current state once an earlier request resolves late.
+    let cancelled = false;
     setIsLoading(true);
     setError(null);
     getPacReport(jobId)
-      .then(setReport)
+      .then((r) => { if (!cancelled) setReport(r); })
       .catch((err: unknown) => {
+        if (cancelled) return;
         const msg = err instanceof Error ? err.message : 'Failed to load PAC report';
         setError(msg);
       })
-      .finally(() => setIsLoading(false));
+      .finally(() => { if (!cancelled) setIsLoading(false); });
+    return () => { cancelled = true; };
   }, [isOpen, jobId]);
 
   return (

--- a/src/components/pdf/PdfPreviewPanel.tsx
+++ b/src/components/pdf/PdfPreviewPanel.tsx
@@ -50,6 +50,7 @@ export interface PdfPreviewPanelProps {
   selectedIssueId?: string;
   onPageChange: (page: number) => void;
   onIssueSelect: (issue: PdfAuditIssue) => void;
+  issueNumberMap?: Map<string, number>;
   className?: string;
 }
 
@@ -134,7 +135,8 @@ const IssueOverlay: React.FC<{
   isSelected: boolean;
   onClick: () => void;
   index: number;
-}> = ({ highlight, isSelected, onClick, index }) => {
+  globalNumber?: number;
+}> = ({ highlight, isSelected, onClick, index, globalNumber }) => {
   const severity = highlight.issue.severity as keyof typeof SEVERITY_BORDER_COLORS;
 
   return (
@@ -172,7 +174,7 @@ const IssueOverlay: React.FC<{
           backgroundColor: SEVERITY_BORDER_COLORS[severity],
         }}
       >
-        {index + 1}
+        {globalNumber ?? index + 1}
       </div>
     </div>
   );
@@ -185,6 +187,7 @@ export const PdfPreviewPanel: React.FC<PdfPreviewPanelProps> = ({
   selectedIssueId,
   onPageChange,
   onIssueSelect,
+  issueNumberMap,
   className,
 }) => {
   const [numPages, setNumPages] = useState<number | null>(null);
@@ -458,6 +461,7 @@ export const PdfPreviewPanel: React.FC<PdfPreviewPanelProps> = ({
                         isSelected={highlight.issue.id === selectedIssueId}
                         onClick={() => onIssueSelect(highlight.issue)}
                         index={index}
+                        globalNumber={issueNumberMap?.get(highlight.issue.id)}
                       />
                     ))}
                   </div>

--- a/src/components/pdf/PdfPreviewPanel.tsx
+++ b/src/components/pdf/PdfPreviewPanel.tsx
@@ -20,6 +20,17 @@ import {
   EyeOff,
   Loader2,
   AlertCircle,
+  ImageIcon,
+  Table2,
+  Type,
+  List,
+  Sun,
+  Link as LinkIcon,
+  Bookmark,
+  Globe,
+  AlignLeft,
+  Shield,
+  FileInput,
 } from 'lucide-react';
 import { cn } from '@/utils/cn';
 import { Button } from '../ui/Button';
@@ -46,19 +57,59 @@ type ZoomLevel = 'fit-width' | 'fit-page' | 50 | 75 | 100 | 125 | 150 | 200;
 
 const ZOOM_LEVELS: ZoomLevel[] = [50, 75, 100, 125, 150, 200];
 
-const SEVERITY_COLORS = {
-  critical: 'rgba(239, 68, 68, 0.3)',    // red-500
-  serious: 'rgba(249, 115, 22, 0.3)',    // orange-500
-  moderate: 'rgba(234, 179, 8, 0.3)',    // yellow-500
-  minor: 'rgba(59, 130, 246, 0.3)',      // blue-500
-};
-
 const SEVERITY_BORDER_COLORS = {
   critical: '#ef4444',
   serious: '#f97316',
   moderate: '#eab308',
   minor: '#3b82f6',
 };
+
+// ─── Issue category mapping ───────────────────────────────────────────────────
+
+interface RuleCategory {
+  prefixes: string[];
+  label: string;
+  icon: React.ReactNode;
+  color: string;
+  bgColor: string;
+}
+
+const RULE_CATEGORIES: RuleCategory[] = [
+  { prefixes: ['ALT-TEXT', 'MATTERHORN-ALT'], label: 'Alt Text',      icon: <ImageIcon size={11} />, color: 'text-orange-700', bgColor: 'bg-orange-100' },
+  { prefixes: ['TABLE'],                       label: 'Tables',        icon: <Table2 size={11} />,    color: 'text-blue-700',   bgColor: 'bg-blue-100'   },
+  { prefixes: ['HEADING'],                     label: 'Headings',      icon: <Type size={11} />,      color: 'text-purple-700', bgColor: 'bg-purple-100' },
+  { prefixes: ['LIST'],                        label: 'Lists',         icon: <List size={11} />,      color: 'text-teal-700',   bgColor: 'bg-teal-100'   },
+  { prefixes: ['CONTRAST', 'COLOR-CONTRAST'],  label: 'Contrast',      icon: <Sun size={11} />,       color: 'text-yellow-700', bgColor: 'bg-yellow-100' },
+  { prefixes: ['LINK'],                        label: 'Links',         icon: <LinkIcon size={11} />,  color: 'text-cyan-700',   bgColor: 'bg-cyan-100'   },
+  { prefixes: ['FORM', 'FIELD'],               label: 'Forms',         icon: <FileInput size={11} />, color: 'text-green-700',  bgColor: 'bg-green-100'  },
+  { prefixes: ['BOOKMARK'],                    label: 'Bookmarks',     icon: <Bookmark size={11} />,  color: 'text-indigo-700', bgColor: 'bg-indigo-100' },
+  { prefixes: ['LANGUAGE', 'PDF-NO-LANG'],     label: 'Language',      icon: <Globe size={11} />,     color: 'text-rose-700',   bgColor: 'bg-rose-100'   },
+  { prefixes: ['READING'],                     label: 'Reading Order', icon: <AlignLeft size={11} />, color: 'text-gray-700',   bgColor: 'bg-gray-100'   },
+  { prefixes: ['MATTERHORN', 'PDFUA', 'PDF-UA', 'PDF/UA'], label: 'PDF/UA', icon: <Shield size={11} />, color: 'text-red-700', bgColor: 'bg-red-100'  },
+];
+
+const OTHER_CATEGORY: Omit<RuleCategory, 'prefixes'> = {
+  label: 'Other', icon: <AlertCircle size={11} />, color: 'text-gray-600', bgColor: 'bg-gray-100',
+};
+
+// p-8 padding on the PDF container — overlays must offset by this amount
+const OVERLAY_PADDING_PX = 32;
+
+function categorizePageIssues(issues: PdfAuditIssue[]) {
+  const counts = new Map<string, number>();
+  for (const issue of issues) {
+    const ruleId = (issue.ruleId || '').toUpperCase();
+    const cat = RULE_CATEGORIES.find(c => c.prefixes.some(p => ruleId.startsWith(p)));
+    const label = cat?.label ?? OTHER_CATEGORY.label;
+    counts.set(label, (counts.get(label) ?? 0) + 1);
+  }
+  return Array.from(counts.entries()).map(([label, count]) => {
+    const cat = RULE_CATEGORIES.find(c => c.label === label) ?? OTHER_CATEGORY;
+    return { label, count, icon: cat.icon, color: cat.color, bgColor: cat.bgColor };
+  });
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 
 interface IssueHighlight {
   issue: PdfAuditIssue;
@@ -69,20 +120,13 @@ interface IssueHighlight {
 }
 
 /**
- * Parse issue location to extract coordinates
- * Format examples:
- * - "Page 5, x:100 y:200 w:300 h:50"
- * - "x:100, y:200, width:300, height:50"
- *
- * @param _issue - Prefixed with underscore to indicate intentionally unused.
- *                 Reserved for future implementation when backend provides location data.
+ * Parse issue bounding box at scale=1 (PDF points, top-left origin).
+ * Returns raw coords without scale or padding applied — the caller scales them.
  */
-function parseIssueLocation(_issue: PdfAuditIssue): IssueHighlight | null {
-  // This is a placeholder - actual implementation would parse
-  // _issue.elementPath or a dedicated location field
-  // For now, return null if no valid location data
-  // TODO: Implement coordinate parsing when backend provides location data
-  return null;
+function parseIssueLocation(issue: PdfAuditIssue): { x: number; y: number; width: number; height: number } | null {
+  const bb = issue.boundingBox;
+  if (!bb || bb.width <= 0 || bb.height <= 0) return null;
+  return { x: bb.x, y: bb.y, width: bb.width, height: bb.height };
 }
 
 const IssueOverlay: React.FC<{
@@ -91,21 +135,20 @@ const IssueOverlay: React.FC<{
   onClick: () => void;
   index: number;
 }> = ({ highlight, isSelected, onClick, index }) => {
-  const severity = highlight.issue.severity as keyof typeof SEVERITY_COLORS;
+  const severity = highlight.issue.severity as keyof typeof SEVERITY_BORDER_COLORS;
 
   return (
     <div
-      className={cn(
-        'absolute cursor-pointer transition-all',
-        isSelected && 'animate-pulse'
-      )}
+      className="absolute cursor-pointer transition-all"
       style={{
         left: `${highlight.x}px`,
         top: `${highlight.y}px`,
         width: `${highlight.width}px`,
         height: `${highlight.height}px`,
-        backgroundColor: SEVERITY_COLORS[severity],
-        border: `2px solid ${SEVERITY_BORDER_COLORS[severity]}`,
+        backgroundColor: 'transparent',
+        border: `3px solid #ef4444`,
+        outline: isSelected ? '3px solid #fbbf24' : undefined,
+        outlineOffset: '2px',
         zIndex: isSelected ? 20 : 10,
       }}
       onClick={onClick}
@@ -176,10 +219,29 @@ export const PdfPreviewPanel: React.FC<PdfPreviewPanelProps> = ({
   }, [issues, currentPage]);
 
   const highlights = useMemo(() => {
+    const scale = typeof zoomLevel === 'number' ? zoomLevel / 100 : 1;
     return currentPageIssues
-      .map((issue) => parseIssueLocation(issue))
-      .filter((h): h is IssueHighlight => h !== null);
-  }, [currentPageIssues]);
+      .flatMap((issue) => {
+        const raw = parseIssueLocation(issue);
+        if (!raw) return [];
+        return [{
+          issue,
+          x: raw.x * scale + OVERLAY_PADDING_PX,
+          y: raw.y * scale + OVERLAY_PADDING_PX,
+          width: raw.width * scale,
+          height: raw.height * scale,
+        } as IssueHighlight];
+      });
+  }, [currentPageIssues, zoomLevel]);
+
+  const categoryBreakdown = useMemo(() => categorizePageIssues(currentPageIssues), [currentPageIssues]);
+
+  const selectedIssue = useMemo(() => {
+    if (!selectedIssueId) return null;
+    return currentPageIssues.find(i => i.id === selectedIssueId)
+      ?? issues.find(i => i.id === selectedIssueId)
+      ?? null;
+  }, [selectedIssueId, currentPageIssues, issues]);
 
   const handleDocumentLoadSuccess = useCallback(({ numPages }: { numPages: number }) => {
     setNumPages(numPages);
@@ -404,13 +466,49 @@ export const PdfPreviewPanel: React.FC<PdfPreviewPanelProps> = ({
             </div>
           )}
         </div>
+
+        {/* Selected issue context strip — below the PDF page, inside the scrollable area */}
+        {!error && selectedIssue && (
+          <div className="mt-3 mx-auto max-w-3xl px-4 py-2.5 bg-purple-50 border border-purple-200 rounded-lg text-xs">
+            <div className="flex items-center gap-2 flex-wrap">
+              <span className={cn(
+                'px-1.5 py-0.5 rounded font-medium',
+                selectedIssue.severity === 'critical' && 'bg-red-100 text-red-700',
+                selectedIssue.severity === 'serious' && 'bg-orange-100 text-orange-700',
+                selectedIssue.severity === 'moderate' && 'bg-yellow-100 text-yellow-700',
+                selectedIssue.severity === 'minor' && 'bg-blue-100 text-blue-700',
+              )}>
+                {selectedIssue.severity}
+              </span>
+              <span className="font-semibold text-purple-900">{selectedIssue.ruleId}</span>
+              {selectedIssue.elementPath && (
+                <span className="font-mono text-purple-600 bg-purple-100 px-1.5 py-0.5 rounded truncate max-w-xs">
+                  {selectedIssue.elementPath}
+                </span>
+              )}
+            </div>
+            <p className="text-purple-800 mt-1 leading-relaxed">{selectedIssue.message}</p>
+          </div>
+        )}
       </div>
 
-      {/* Issue count indicator */}
+      {/* Issue type breakdown bar */}
       {currentPageIssues.length > 0 && (
-        <div className="px-4 py-2 bg-white border-t border-gray-200 text-sm text-gray-600">
-          {currentPageIssues.length} {currentPageIssues.length === 1 ? 'issue' : 'issues'} on this
-          page
+        <div className="px-4 py-2 bg-white border-t border-gray-200">
+          <div className="flex items-center gap-1.5 flex-wrap">
+            <span className="text-xs text-gray-500 shrink-0">
+              Page {currentPage} — {currentPageIssues.length} {currentPageIssues.length === 1 ? 'issue' : 'issues'}:
+            </span>
+            {categoryBreakdown.map(({ label, count, icon, color, bgColor }) => (
+              <span
+                key={label}
+                className={cn('inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium', bgColor, color)}
+              >
+                {icon}
+                {count} {label}
+              </span>
+            ))}
+          </div>
         </div>
       )}
     </div>

--- a/src/components/pdf/PdfPreviewPanel.tsx
+++ b/src/components/pdf/PdfPreviewPanel.tsx
@@ -501,7 +501,7 @@ export const PdfPreviewPanel: React.FC<PdfPreviewPanelProps> = ({
         <div className="px-4 py-2 bg-white border-t border-gray-200">
           <div className="flex items-center gap-1.5 flex-wrap">
             <span className="text-xs text-gray-500 shrink-0">
-              Page {currentPage} — {currentPageIssues.length} {currentPageIssues.length === 1 ? 'issue' : 'issues'}:
+              {currentPageIssues.length} {currentPageIssues.length === 1 ? 'issue' : 'issues'} on this page
             </span>
             {categoryBreakdown.map(({ label, count, icon, color, bgColor }) => (
               <span

--- a/src/components/pdf/PdfStatsCards.tsx
+++ b/src/components/pdf/PdfStatsCards.tsx
@@ -1,0 +1,561 @@
+import React, { useState, useMemo } from 'react';
+import {
+  ChevronDown, ChevronUp, CheckCircle, AlertTriangle,
+  Loader2, Sparkles, Tag,
+} from 'lucide-react';
+import { cn } from '@/utils/cn';
+import { api } from '@/services/api';
+import type { PdfAuditResult, PdfAuditIssue } from '@/types/pdf.types';
+import type { AiAnalysis } from '@/components/remediation/IssueCard';
+
+// ─── localStorage persistence ─────────────────────────────────────────────────
+
+const STORAGE_KEY = 'ninja:pdf-stats-cards';
+interface CardState { autoTag: boolean; issues: boolean; ai: boolean }
+const DEFAULTS: CardState = { autoTag: true, issues: true, ai: true };
+
+function readStorage(): CardState {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return DEFAULTS;
+    return { ...DEFAULTS, ...(JSON.parse(raw) as Partial<CardState>) };
+  } catch { return DEFAULTS; }
+}
+
+function writeStorage(s: CardState): void {
+  try { localStorage.setItem(STORAGE_KEY, JSON.stringify(s)); } catch { /* quota */ }
+}
+
+// ─── Matterhorn detection (mirrors PdfAuditResultsPage) ──────────────────────
+
+const CAT_MAP: Record<string, string> = {
+  structure: '01', metadata: '07', language: '16', headings: '06',
+  'reading-order': '09', lists: '04', tables: '11',
+  'table-structure': '11', 'table-headers': '11',
+};
+const MATTERHORN_PREFIXES = [
+  'TABLE-', 'ALT-TEXT-', 'LIST-',
+  'PDF-LOW-CONTRAST', 'PDF-UNTAGGED', 'PDF-NO-LANGUAGE',
+];
+
+type AugIssue = PdfAuditIssue & { category?: string; code?: string };
+
+function isMatterhorn(issue: AugIssue): boolean {
+  if (issue.matterhornCheckpoint) return true;
+  if (issue.category && CAT_MAP[issue.category]) return true;
+  const code = ((issue as { code?: string }).code || issue.ruleId || '').toUpperCase();
+  if (/^MATTERHORN-\d{2}-/.test(code)) return true;
+  return MATTERHORN_PREFIXES.some(p => code.startsWith(p));
+}
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface AutoTagInfo {
+  status?: string;
+  hasTaggingReport?: boolean;
+  hasWordExport?: boolean;
+  elementCounts?: Record<string, number> | null;
+  adobeFlags?: Array<{
+    elementType?: string;
+    page?: number;
+    confidence?: string;
+    reviewComment?: string;
+  }>;
+  postRemediationStatus?: 'pending' | 'complete' | 'failed';
+  postRemediationAudit?: {
+    runAt: string;
+    resolved: number;
+    remaining: number;
+    regressions: number;
+    resolutionRate: number;
+  };
+}
+
+export interface AiStatsData {
+  gemini: { totalTokens: number; estimatedCostUsd: number };
+  claude: { totalTokens: number; estimatedCostUsd: number };
+  totalTokens: number;
+  totalCostUsd: number;
+}
+
+export interface PdfStatsCardsProps {
+  autoTagInfo: AutoTagInfo | null;
+  auditResult: PdfAuditResult;
+  aiSuggestions: Map<string, AiAnalysis>;
+  aiStats: AiStatsData | null;
+  matterhornIssueCount: number;
+  isAnalyzingAi: boolean;
+  aiProgress: { analyzed: number; total: number } | null;
+  onViewAutoTagReport: () => void;
+  onRetryAutoTag: () => void;
+  isRetryingAutoTag: boolean;
+  jobId: string;
+}
+
+// ─── Card shell ───────────────────────────────────────────────────────────────
+
+interface StatsCardProps {
+  title: string;
+  icon: React.ReactNode;
+  expanded: boolean;
+  onToggle: () => void;
+  /** Shown when collapsed — compact key figures on one line */
+  summary: React.ReactNode;
+  /** Shown when expanded — full detail */
+  children: React.ReactNode;
+  accentColor: string;
+}
+
+function StatsCard({ title, icon, expanded, onToggle, summary, children, accentColor }: StatsCardProps) {
+  return (
+    <div
+      className="flex-1 border border-gray-200 rounded-lg bg-white overflow-hidden"
+      style={{ borderTop: `4px solid ${accentColor}` }}
+    >
+      <button
+        type="button"
+        className="w-full flex items-center justify-between px-4 py-2.5 hover:bg-gray-50 transition-colors"
+        onClick={onToggle}
+        aria-expanded={expanded}
+      >
+        <div className="flex items-center gap-2">
+          {icon}
+          <span className="font-semibold text-sm text-gray-900">{title}</span>
+        </div>
+        {expanded
+          ? <ChevronUp className="h-4 w-4 text-gray-400 flex-shrink-0" />
+          : <ChevronDown className="h-4 w-4 text-gray-400 flex-shrink-0" />
+        }
+      </button>
+
+      {/* Collapsed summary */}
+      {!expanded && (
+        <div className="px-4 pb-3 pt-2 border-t border-gray-100 flex flex-wrap items-center gap-x-3 gap-y-1">
+          {summary}
+        </div>
+      )}
+
+      {/* Expanded detail */}
+      {expanded && (
+        <div className="px-4 pb-4 pt-3 border-t border-gray-100 space-y-3">
+          {children}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── Tiny shared atoms ────────────────────────────────────────────────────────
+
+/** Inline metric used in summary row */
+function SummaryMetric({ n, label, className }: { n: number | string; label: string; className?: string }) {
+  return (
+    <span className={cn('text-xs', className)}>
+      <span className="font-bold tabular-nums">{n}</span>
+      {' '}
+      <span className="text-gray-500">{label}</span>
+    </span>
+  );
+}
+
+/** Justified key/value row used in detail sections */
+function DetailRow({ label, value, sub }: { label: string; value: string | number; sub?: string }) {
+  return (
+    <div className="flex items-baseline justify-between text-xs">
+      <span className="text-gray-600">{label}</span>
+      <span className="font-mono font-semibold text-gray-900">
+        {value}
+        {sub && <span className="text-gray-400 ml-1">{sub}</span>}
+      </span>
+    </div>
+  );
+}
+
+// ─── Main export ──────────────────────────────────────────────────────────────
+
+export function PdfStatsCards({
+  autoTagInfo,
+  auditResult,
+  aiSuggestions,
+  aiStats,
+  matterhornIssueCount,
+  isAnalyzingAi,
+  aiProgress,
+  onViewAutoTagReport,
+  onRetryAutoTag,
+  isRetryingAutoTag,
+  jobId,
+}: PdfStatsCardsProps) {
+  const [expanded, setExpanded] = useState<CardState>(() => readStorage());
+
+  const toggle = (card: keyof CardState) =>
+    setExpanded(prev => {
+      const next = { ...prev, [card]: !prev[card] };
+      writeStorage(next);
+      return next;
+    });
+
+  const issues = auditResult.issues ?? [];
+
+  const derived = useMemo(() => {
+    const sugs = Array.from(aiSuggestions.values());
+
+    const mattIds = new Set<string>();
+    for (const issue of issues) {
+      if (isMatterhorn(issue as AugIssue)) mattIds.add(issue.id);
+    }
+
+    const mattSugs = sugs.filter(s => mattIds.has(s.issueId));
+    const otherSugs = sugs.filter(s => !mattIds.has(s.issueId));
+
+    // Provider split: use model field (accurate, not inferred)
+    const geminiSugs = sugs.filter(s => s.model?.toLowerCase().includes('gemini'));
+    const claudeSugs = sugs.filter(s => !s.model?.toLowerCase().includes('gemini'));
+
+    const fixes = (arr: AiAnalysis[]) => arr.filter(s => s.applyMode === 'apply-to-pdf').length;
+    const guidance = (arr: AiAnalysis[]) => arr.filter(s => s.applyMode === 'guidance-only').length;
+    const cnt = (arr: AiAnalysis[], pred: (s: AiAnalysis) => boolean) => arr.filter(pred).length;
+
+    return {
+      othersCount: issues.length - matterhornIssueCount,
+      aiTotal: sugs.length,
+      aiFixes: fixes(sugs),
+      aiGuidance: guidance(sugs),
+      aiApplied: cnt(sugs, s => s.status === 'applied'),
+      aiHighConf: cnt(sugs, s => s.confidence >= 0.9),
+      aiMedConf: cnt(sugs, s => s.confidence >= 0.7 && s.confidence < 0.9),
+      aiLowConf: cnt(sugs, s => s.confidence < 0.7),
+      coverage: issues.length > 0 ? Math.round((sugs.length / issues.length) * 100) : 0,
+      mattFixes: fixes(mattSugs),
+      mattGuidance: guidance(mattSugs),
+      mattHighConf: cnt(mattSugs, s => s.confidence >= 0.9),
+      otherFixes: fixes(otherSugs),
+      otherGuidance: guidance(otherSugs),
+      geminiFixes: fixes(geminiSugs),
+      geminiGuidance: guidance(geminiSugs),
+      claudeFixes: fixes(claudeSugs),
+      claudeGuidance: guidance(claudeSugs),
+    };
+  }, [issues, aiSuggestions, matterhornIssueCount]);
+
+  // ─── Card 1: Auto Tag ────────────────────────────────────────────────────────
+
+  const atStatus = autoTagInfo?.status;
+  const elems = autoTagInfo?.elementCounts;
+
+  const autoTagIcon = atStatus === 'complete'
+    ? <CheckCircle className="h-4 w-4 text-green-600" />
+    : atStatus === 'failed'
+      ? <AlertTriangle className="h-4 w-4 text-amber-500" />
+      : atStatus === 'processing'
+        ? <Loader2 className="h-4 w-4 text-blue-500 animate-spin" />
+        : <Tag className="h-4 w-4 text-gray-400" />;
+
+  const autoTagSummary = atStatus === 'complete' ? (
+    <>
+      <span className="text-xs font-medium text-green-700">✓ Adobe</span>
+      {elems && (
+        <>
+          <SummaryMetric n={elems.figures ?? 0} label="Fig" />
+          <SummaryMetric n={elems.tables ?? 0} label="Tab" />
+          <SummaryMetric n={elems.headings ?? 0} label="Head" />
+          <SummaryMetric n={elems.paragraphs ?? 0} label="Para" />
+        </>
+      )}
+    </>
+  ) : atStatus === 'failed' ? (
+    <span className="text-xs text-amber-700 font-medium">Auto-tagging failed</span>
+  ) : atStatus === 'processing' ? (
+    <span className="text-xs text-blue-700">Auto-tagging in progress…</span>
+  ) : (
+    <span className="text-xs text-gray-400">No auto-tag data</span>
+  );
+
+  const autoTagDetail = (
+    <>
+      {atStatus === 'complete' && elems && (
+        <div className="space-y-1">
+          <DetailRow label="Figures" value={elems.figures ?? 0} />
+          <DetailRow label="Tables" value={elems.tables ?? 0} />
+          <DetailRow label="Headings" value={elems.headings ?? 0} />
+          <DetailRow label="Paragraphs" value={elems.paragraphs ?? 0} />
+        </div>
+      )}
+      {autoTagInfo?.adobeFlags && autoTagInfo.adobeFlags.length > 0 && (
+        <div className="flex items-center gap-2 text-xs text-amber-700 bg-amber-50 rounded px-3 py-2">
+          <AlertTriangle className="h-3.5 w-3.5 flex-shrink-0" />
+          <span><strong>{autoTagInfo.adobeFlags.length}</strong> elements flagged for manual review</span>
+        </div>
+      )}
+      {atStatus === 'failed' && (
+        <div className="flex items-center justify-between text-xs">
+          <span className="text-amber-700">Auto-tagging failed</span>
+          <button
+            type="button"
+            onClick={onRetryAutoTag}
+            disabled={isRetryingAutoTag}
+            className="text-amber-700 underline disabled:opacity-50"
+          >
+            {isRetryingAutoTag ? 'Retrying…' : 'Retry'}
+          </button>
+        </div>
+      )}
+      {atStatus === 'processing' && (
+        <div className="flex items-center gap-2 text-xs text-blue-700">
+          <Loader2 className="h-3.5 w-3.5 animate-spin" />
+          Auto-tagging with Adobe…
+        </div>
+      )}
+      {(autoTagInfo?.hasTaggingReport || autoTagInfo?.hasWordExport) && (
+        <div className="flex items-center gap-3 pt-1">
+          {autoTagInfo.hasTaggingReport && (
+            <button
+              type="button"
+              onClick={onViewAutoTagReport}
+              className="text-xs text-blue-600 hover:underline"
+            >
+              View Report
+            </button>
+          )}
+          {autoTagInfo.hasWordExport && (
+            <a
+              href={`${api.defaults.baseURL}/pdf/${encodeURIComponent(jobId)}/auto-tag/word`}
+              download
+              className="text-xs text-blue-600 hover:underline"
+            >
+              Download Word
+            </a>
+          )}
+        </div>
+      )}
+      {!autoTagInfo && (
+        <span className="text-xs text-gray-400">No auto-tag data for this job</span>
+      )}
+    </>
+  );
+
+  // ─── Card 2: Issues ──────────────────────────────────────────────────────────
+
+  const issuesSummary = (
+    <>
+      <SummaryMetric n={issues.length} label="Total" className="font-bold text-gray-900" />
+      <SummaryMetric n={matterhornIssueCount} label="Matterhorn" className="text-red-700" />
+      <SummaryMetric n={derived.othersCount} label="Others" />
+      {derived.aiTotal > 0 && (
+        <SummaryMetric n={derived.aiTotal} label="AI suggestions" className="text-purple-700" />
+      )}
+    </>
+  );
+
+  const issuesDetail = (
+    <>
+      <div className="flex items-baseline gap-2">
+        <span className="text-2xl font-bold text-gray-900 tabular-nums">{issues.length}</span>
+        <span className="text-sm text-gray-500">Total Issues</span>
+        {derived.coverage > 0 && (
+          <span className="ml-auto text-xs text-gray-400">{derived.coverage}% AI coverage</span>
+        )}
+      </div>
+
+      <div className="grid grid-cols-2 gap-3">
+        <div className="bg-red-50 rounded-md p-3 space-y-1.5">
+          <p className="text-xs font-semibold text-red-800 mb-2">
+            Matterhorn ({matterhornIssueCount})
+          </p>
+          {derived.mattFixes > 0 && <DetailRow label="AI Fixes" value={derived.mattFixes} />}
+          {derived.mattGuidance > 0 && <DetailRow label="AI Guidance" value={derived.mattGuidance} />}
+          {derived.mattHighConf > 0 && <DetailRow label="High conf" value={derived.mattHighConf} />}
+          {derived.mattFixes === 0 && derived.mattGuidance === 0 && (
+            <span className="text-xs text-gray-400">No AI coverage</span>
+          )}
+        </div>
+        <div className="bg-gray-50 rounded-md p-3 space-y-1.5">
+          <p className="text-xs font-semibold text-gray-700 mb-2">
+            Others ({derived.othersCount})
+          </p>
+          {derived.otherFixes > 0 && <DetailRow label="AI Fixes" value={derived.otherFixes} />}
+          {derived.otherGuidance > 0 && <DetailRow label="AI Guidance" value={derived.otherGuidance} />}
+          {derived.otherFixes === 0 && derived.otherGuidance === 0 && (
+            <span className="text-xs text-gray-400">No AI coverage</span>
+          )}
+        </div>
+      </div>
+
+      {autoTagInfo?.postRemediationStatus === 'complete' && autoTagInfo.postRemediationAudit && (
+        <div className="bg-green-50 rounded-md px-3 py-2 text-xs text-green-800 space-y-1">
+          <div className="flex items-center gap-2 font-medium">
+            <CheckCircle className="h-3.5 w-3.5 flex-shrink-0" />
+            Post-fix validation · {Math.round(autoTagInfo.postRemediationAudit.resolutionRate * 100)}% resolved
+          </div>
+          <div className="flex gap-3 pl-5 text-green-700">
+            <span><strong>{autoTagInfo.postRemediationAudit.resolved}</strong> resolved</span>
+            <span><strong>{autoTagInfo.postRemediationAudit.remaining}</strong> remaining</span>
+            {autoTagInfo.postRemediationAudit.regressions > 0 && (
+              <span className="text-amber-700">
+                <strong>{autoTagInfo.postRemediationAudit.regressions}</strong> regressions
+              </span>
+            )}
+          </div>
+        </div>
+      )}
+      {autoTagInfo?.postRemediationStatus === 'failed' && (
+        <div className="flex items-center gap-2 text-xs text-amber-700 bg-amber-50 rounded px-3 py-2">
+          <AlertTriangle className="h-3.5 w-3.5" />
+          Post-fix validation failed
+        </div>
+      )}
+      {autoTagInfo?.postRemediationStatus === 'pending' && (
+        <div className="flex items-center gap-2 text-xs text-blue-700 bg-blue-50 rounded px-3 py-2">
+          <Loader2 className="h-3.5 w-3.5 animate-spin" />
+          Validating fixes…
+        </div>
+      )}
+    </>
+  );
+
+  // ─── Card 3: AI Analysis ─────────────────────────────────────────────────────
+
+  const aiSummary = isAnalyzingAi ? (
+    <>
+      <Loader2 className="h-3.5 w-3.5 animate-spin text-purple-600" />
+      <span className="text-xs text-purple-700">
+        Analyzing {aiProgress?.analyzed ?? 0}/{aiProgress?.total ?? '…'}
+      </span>
+    </>
+  ) : (
+    <>
+      <SummaryMetric n={derived.aiTotal} label="Suggestions" className="text-purple-700" />
+      <SummaryMetric n={derived.aiFixes} label="Fixes" className="text-green-700" />
+      <SummaryMetric n={derived.aiGuidance} label="Guidance" />
+      {aiStats && (
+        <SummaryMetric
+          n={`$${aiStats.totalCostUsd.toFixed(4)}`}
+          label="total cost"
+          className="text-gray-600"
+        />
+      )}
+    </>
+  );
+
+  const aiDetail = isAnalyzingAi ? (
+    <div className="flex items-center gap-2 text-sm text-purple-700">
+      <Loader2 className="h-4 w-4 animate-spin" />
+      Analyzing {aiProgress?.analyzed ?? 0} / {aiProgress?.total ?? '…'} issues…
+    </div>
+  ) : derived.aiTotal === 0 && !aiStats ? (
+    <span className="text-xs text-gray-400">AI analysis not yet run</span>
+  ) : (
+    <>
+      {/* Suggestions row */}
+      <div className="grid grid-cols-3 gap-2 text-center">
+        <div className="bg-purple-50 rounded-md py-2">
+          <div className="text-xl font-bold text-purple-800 tabular-nums">{derived.aiFixes}</div>
+          <div className="text-xs text-purple-600">Fixes</div>
+        </div>
+        <div className="bg-blue-50 rounded-md py-2">
+          <div className="text-xl font-bold text-blue-800 tabular-nums">{derived.aiGuidance}</div>
+          <div className="text-xs text-blue-600">Guidance</div>
+        </div>
+        <div className="bg-green-50 rounded-md py-2">
+          <div className="text-xl font-bold text-green-800 tabular-nums">{derived.aiApplied}</div>
+          <div className="text-xs text-green-600">Applied</div>
+        </div>
+      </div>
+
+      {/* Confidence breakdown */}
+      <div>
+        <p className="text-xs font-semibold text-gray-600 mb-1.5">Confidence</p>
+        <div className="space-y-1">
+          <DetailRow label="High (≥ 90%)" value={derived.aiHighConf} />
+          <DetailRow label="Medium (70–89%)" value={derived.aiMedConf} />
+          <DetailRow label="Low (< 70%)" value={derived.aiLowConf} />
+        </div>
+      </div>
+
+      {/* Provider breakdown */}
+      {aiStats && (
+        <div>
+          <p className="text-xs font-semibold text-gray-600 mb-1.5">Provider</p>
+          <div className="space-y-2">
+            {aiStats.gemini.totalTokens > 0 && (
+              <div className="bg-orange-50 rounded px-3 py-2 space-y-1">
+                <div className="flex items-center justify-between text-xs font-medium text-orange-800">
+                  <span>Gemini</span>
+                  <span className="text-orange-600">
+                    {derived.geminiFixes} fixes · {derived.geminiGuidance} guidance
+                  </span>
+                </div>
+                <DetailRow
+                  label="Tokens"
+                  value={aiStats.gemini.totalTokens.toLocaleString()}
+                  sub={`($${aiStats.gemini.estimatedCostUsd.toFixed(4)})`}
+                />
+              </div>
+            )}
+            {aiStats.claude.totalTokens > 0 && (
+              <div className="bg-purple-50 rounded px-3 py-2 space-y-1">
+                <div className="flex items-center justify-between text-xs font-medium text-purple-800">
+                  <span>Claude</span>
+                  <span className="text-purple-600">
+                    {derived.claudeFixes} fixes · {derived.claudeGuidance} guidance
+                  </span>
+                </div>
+                <DetailRow
+                  label="Tokens"
+                  value={aiStats.claude.totalTokens.toLocaleString()}
+                  sub={`($${aiStats.claude.estimatedCostUsd.toFixed(4)})`}
+                />
+              </div>
+            )}
+            <div className="border-t border-gray-200 pt-1">
+              <DetailRow
+                label="Total"
+                value={aiStats.totalTokens.toLocaleString()}
+                sub={`($${aiStats.totalCostUsd.toFixed(4)})`}
+              />
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+
+  // ─── Render ──────────────────────────────────────────────────────────────────
+
+  return (
+    <div className="flex gap-4 items-start px-6 py-4 bg-gray-50 border-b border-gray-200">
+      <StatsCard
+        title="Auto Tag"
+        icon={autoTagIcon}
+        expanded={expanded.autoTag}
+        onToggle={() => toggle('autoTag')}
+        summary={autoTagSummary}
+        accentColor="#22c55e"
+      >
+        {autoTagDetail}
+      </StatsCard>
+
+      <StatsCard
+        title="Issues"
+        icon={<AlertTriangle className="h-4 w-4 text-red-500" />}
+        expanded={expanded.issues}
+        onToggle={() => toggle('issues')}
+        summary={issuesSummary}
+        accentColor="#ef4444"
+      >
+        {issuesDetail}
+      </StatsCard>
+
+      <StatsCard
+        title="AI Analysis"
+        icon={<Sparkles className="h-4 w-4 text-purple-600" />}
+        expanded={expanded.ai}
+        onToggle={() => toggle('ai')}
+        summary={aiSummary}
+        accentColor="#a855f7"
+      >
+        {aiDetail}
+      </StatsCard>
+    </div>
+  );
+}

--- a/src/components/pdf/PdfStatsCards.tsx
+++ b/src/components/pdf/PdfStatsCards.tsx
@@ -195,7 +195,7 @@ export function PdfStatsCards({
       return next;
     });
 
-  const issues = auditResult.issues ?? [];
+  const issues = useMemo(() => auditResult.issues ?? [], [auditResult.issues]);
 
   const derived = useMemo(() => {
     const sugs = Array.from(aiSuggestions.values());

--- a/src/components/pdf/PdfStatsCards.tsx
+++ b/src/components/pdf/PdfStatsCards.tsx
@@ -238,6 +238,24 @@ export function PdfStatsCards({
     };
   }, [issues, aiSuggestions, matterhornIssueCount]);
 
+  // Download the Word export through the authenticated api client so the bearer
+  // token / interceptors apply (a plain <a href> would 401 in token-auth setups).
+  const handleDownloadWord = async () => {
+    try {
+      const res = await api.get(`/pdf/${encodeURIComponent(jobId)}/auto-tag/word`, {
+        responseType: 'blob',
+      });
+      const url = URL.createObjectURL(new Blob([res.data]));
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = `auto-tag-${jobId}.docx`;
+      link.click();
+      URL.revokeObjectURL(url);
+    } catch (err) {
+      console.error('Failed to download Word export', err);
+    }
+  };
+
   // ─── Card 1: Auto Tag ────────────────────────────────────────────────────────
 
   const atStatus = autoTagInfo?.status;
@@ -318,13 +336,13 @@ export function PdfStatsCards({
             </button>
           )}
           {autoTagInfo.hasWordExport && (
-            <a
-              href={`${api.defaults.baseURL}/pdf/${encodeURIComponent(jobId)}/auto-tag/word`}
-              download
+            <button
+              type="button"
+              onClick={handleDownloadWord}
               className="text-xs text-blue-600 hover:underline"
             >
               Download Word
-            </a>
+            </button>
           )}
         </div>
       )}

--- a/src/components/remediation/IssueCard.tsx
+++ b/src/components/remediation/IssueCard.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import toast from 'react-hot-toast';
-import { Zap, CheckCircle, AlertTriangle, FileText, ExternalLink, ChevronDown, ChevronUp, HelpCircle, Wrench, User, Sparkles, Info, Loader2 } from 'lucide-react';
+import { Zap, CheckCircle, AlertTriangle, FileText, ExternalLink, ChevronDown, ChevronUp, HelpCircle, Wrench, User, Sparkles, Info, Loader2, ShieldAlert } from 'lucide-react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { cn } from '@/utils/cn';
 import { Tooltip } from '../ui/Tooltip';
@@ -19,6 +19,7 @@ export interface AiAnalysis {
   model: string;
   applyMode: 'apply-to-pdf' | 'guidance-only' | 'auto-resolve';
   status: 'pending' | 'approved' | 'rejected' | 'applied';
+  requiresManualReview?: boolean;
   createdAt: string;
   updatedAt: string;
 }
@@ -61,6 +62,7 @@ interface IssueCardProps {
   pageLabels?: string[];
   aiSuggestion?: AiAnalysis;
   onAiSuggestionChange?: (updated: AiAnalysis) => void;
+  issueNumber?: number;
 }
 
 export function IssueCard({
@@ -73,9 +75,11 @@ export function IssueCard({
   pageLabels,
   aiSuggestion,
   onAiSuggestionChange,
+  issueNumber,
 }: IssueCardProps) {
   const isPdf = isPdfIssue(issue);
   const [explanationOpen, setExplanationOpen] = useState(false);
+  const [editedValue, setEditedValue] = useState<string | null>(null);
   const queryClient = useQueryClient();
 
   const updateStatusMutation = useMutation({
@@ -100,13 +104,15 @@ export function IssueCard({
   const applyMutation = useMutation({
     mutationFn: async () => {
       if (!jobId || !aiSuggestion) throw new Error('Missing jobId or suggestion');
+      const body = editedValue !== null ? { value: editedValue } : undefined;
       const res = await api.post<{ data: AiAnalysis }>(
-        `/pdf/${jobId}/ai-analysis/${aiSuggestion.issueId}/apply`
+        `/pdf/${jobId}/ai-analysis/${aiSuggestion.issueId}/apply`,
+        body
       );
       return res.data.data;
     },
-    onSuccess: (updated) => {
-      onAiSuggestionChange?.(updated);
+    onSuccess: () => {
+      onAiSuggestionChange?.({ ...aiSuggestion!, status: 'applied' });
       queryClient.invalidateQueries({ queryKey: ['ai-analysis', jobId] });
       toast.success('Fix applied to PDF');
     },
@@ -216,6 +222,7 @@ export function IssueCard({
 
   return (
     <div
+      id={`issue-card-${issue.id}`}
       className={cn(
         'border rounded-lg p-4 transition-colors',
         getSeverityStyles(),
@@ -237,6 +244,9 @@ export function IssueCard({
           <div className="flex items-center gap-2 flex-wrap mb-1">
             {isPdf && (
               <FileText className="h-4 w-4 text-red-600 flex-shrink-0" aria-label="PDF issue" />
+            )}
+            {issueNumber !== undefined && (
+              <span className="font-mono text-xs text-gray-400 tabular-nums">#{issueNumber}</span>
             )}
             <span className="font-medium text-gray-900">
               {issueCode}
@@ -320,7 +330,17 @@ export function IssueCard({
           className="mt-3 border-t border-current/10 pt-3"
           onClick={(e) => e.stopPropagation()}
         >
-          {aiSuggestion.applyMode === 'auto-resolve' ? (
+          {aiSuggestion.requiresManualReview ? (
+            <div className="flex items-start gap-2 p-2 bg-amber-50 rounded border border-amber-200 text-xs">
+              <ShieldAlert size={13} className="text-amber-600 flex-shrink-0 mt-0.5" />
+              <div className="flex-1 min-w-0">
+                <span className="font-medium text-amber-800">Manual Review Required</span>
+                <p className="text-amber-700 mt-0.5 leading-relaxed">
+                  {aiSuggestion.guidance || 'This issue requires a subject matter expert to review and remediate.'}
+                </p>
+              </div>
+            </div>
+          ) : aiSuggestion.applyMode === 'auto-resolve' ? (
             <div className="flex items-start gap-2 p-2 bg-green-50 rounded border border-green-200 text-xs">
               <CheckCircle size={13} className="text-green-600 flex-shrink-0 mt-0.5" />
               <div>
@@ -384,9 +404,19 @@ export function IssueCard({
                   </div>
                 )}
               </div>
-              <p className="text-purple-700 leading-relaxed font-mono break-all">
-                {aiSuggestion.value || aiSuggestion.guidance}
-              </p>
+              {(aiSuggestion.suggestionType === 'alt-text' || aiSuggestion.suggestionType === 'alt-text-improvement') ? (
+                <textarea
+                  className="w-full text-purple-700 font-mono text-xs leading-relaxed bg-purple-50 border border-purple-200 rounded p-1.5 resize-y focus:outline-none focus:ring-1 focus:ring-purple-400"
+                  rows={3}
+                  value={editedValue ?? aiSuggestion.value ?? aiSuggestion.guidance ?? ''}
+                  onChange={(e) => setEditedValue(e.target.value)}
+                  onClick={(e) => e.stopPropagation()}
+                />
+              ) : (
+                <p className="text-purple-700 leading-relaxed font-mono break-all">
+                  {aiSuggestion.value || aiSuggestion.guidance}
+                </p>
+              )}
               {aiSuggestion.rationale && (
                 <p className="text-purple-500 mt-1 italic">{aiSuggestion.rationale}</p>
               )}
@@ -395,8 +425,8 @@ export function IssueCard({
         </div>
       )}
 
-      {/* Explanation panel — only shown when jobId is provided */}
-      {jobId && (
+      {/* Explanation panel — only shown when jobId is provided and no AI suggestion */}
+      {jobId && !aiSuggestion && (
         <div className="mt-2 border-t border-current/10 pt-2">
           <button
             type="button"

--- a/src/components/remediation/IssueCard.tsx
+++ b/src/components/remediation/IssueCard.tsx
@@ -113,6 +113,9 @@ export function IssueCard({
     },
     onSuccess: (updated) => {
       onAiSuggestionChange?.(updated);
+      // Clear the local edit override so the textarea shows the server-normalized
+      // value (render prefers editedValue over aiSuggestion.value).
+      setEditedValue(null);
       queryClient.invalidateQueries({ queryKey: ['ai-analysis', jobId] });
       toast.success('Fix applied to PDF');
     },

--- a/src/components/remediation/IssueCard.tsx
+++ b/src/components/remediation/IssueCard.tsx
@@ -111,8 +111,8 @@ export function IssueCard({
       );
       return res.data.data;
     },
-    onSuccess: () => {
-      onAiSuggestionChange?.({ ...aiSuggestion!, status: 'applied' });
+    onSuccess: (updated) => {
+      onAiSuggestionChange?.(updated);
       queryClient.invalidateQueries({ queryKey: ['ai-analysis', jobId] });
       toast.success('Fix applied to PDF');
     },

--- a/src/pages/PdfAuditResultsPage.tsx
+++ b/src/pages/PdfAuditResultsPage.tsx
@@ -34,7 +34,6 @@ import { MatterhornSummary } from '@/components/pdf/MatterhornSummary';
 import { PdfPageNavigator } from '@/components/pdf/PdfPageNavigator';
 import { PdfPreviewPanel } from '@/components/pdf/PdfPreviewPanel';
 import { PdfStatsCards } from '@/components/pdf/PdfStatsCards';
-import { ScanLevelBanner } from '@/components/pdf/ScanLevelBanner';
 import { IssueCard, AiAnalysis } from '@/components/remediation/IssueCard';
 import { api } from '@/services/api';
 
@@ -550,6 +549,30 @@ export const PdfAuditResultsPage: React.FC = () => {
     navigate('/pdf');
   };
 
+  const [isDownloadingRemediated, setIsDownloadingRemediated] = useState(false);
+  const handleDownloadRemediatedPdf = async () => {
+    if (!jobId || !auditResult) return;
+    setIsDownloadingRemediated(true);
+    try {
+      const response = await api.get(`/pdf/${encodeURIComponent(jobId)}/remediation/download`, {
+        responseType: 'blob',
+      });
+      const url = window.URL.createObjectURL(response.data);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = auditResult.fileName.replace(/\.pdf$/i, '_remediated.pdf');
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      window.URL.revokeObjectURL(url);
+      toast.success('Download started');
+    } catch {
+      toast.error('Remediated PDF not available — apply at least one AI fix first');
+    } finally {
+      setIsDownloadingRemediated(false);
+    }
+  };
+
   const handleShareResults = async () => {
     const url = window.location.href;
     try {
@@ -810,6 +833,19 @@ export const PdfAuditResultsPage: React.FC = () => {
               <Download className="h-4 w-4 mr-1" />
               Download Report
             </Button>
+            {Array.from(aiSuggestions.values()).some(s => s.status === 'applied') && (
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={handleDownloadRemediatedPdf}
+                disabled={isDownloadingRemediated}
+              >
+                {isDownloadingRemediated
+                  ? <><Loader2 className="h-4 w-4 mr-1 animate-spin" />Downloading…</>
+                  : <><Download className="h-4 w-4 mr-1" />Download AI-Fixed PDF</>
+                }
+              </Button>
+            )}
             <Button variant="outline" size="sm" onClick={handleShareResults}>
               <Share2 className="h-4 w-4 mr-1" />
               Share
@@ -896,16 +932,6 @@ export const PdfAuditResultsPage: React.FC = () => {
         </div>
       )}
 
-      {/* Scan Level Banner - offer deeper analysis if not already comprehensive */}
-      {currentScanLevel !== 'comprehensive' && auditResult && (
-        <div className="px-6 py-4 bg-gray-50 border-b border-gray-200">
-          <ScanLevelBanner
-            currentScanLevel={currentScanLevel}
-            onReScan={handleReScan}
-            isScanning={isReScanning}
-          />
-        </div>
-      )}
 
       {/* Three-column layout */}
       <div className={isFullscreen ? 'fixed inset-0 z-50 flex flex-col bg-white' : 'flex h-[calc(100vh-320px)]'}>

--- a/src/pages/PdfAuditResultsPage.tsx
+++ b/src/pages/PdfAuditResultsPage.tsx
@@ -23,7 +23,7 @@
 
 import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
-import { FileText, Loader2, Download, Share2, RotateCw, Filter, X, ChevronDown, ListChecks } from 'lucide-react';
+import { FileText, Loader2, Download, Share2, RotateCw, Filter, X, ChevronDown, ListChecks, Maximize2, Minimize2 } from 'lucide-react';
 import toast from 'react-hot-toast';
 import { Card, CardContent } from '@/components/ui/Card';
 import { Alert } from '@/components/ui/Alert';
@@ -33,8 +33,9 @@ import { Breadcrumbs } from '@/components/ui/Breadcrumbs';
 import { MatterhornSummary } from '@/components/pdf/MatterhornSummary';
 import { PdfPageNavigator } from '@/components/pdf/PdfPageNavigator';
 import { PdfPreviewPanel } from '@/components/pdf/PdfPreviewPanel';
+import { PdfStatsCards } from '@/components/pdf/PdfStatsCards';
 import { ScanLevelBanner } from '@/components/pdf/ScanLevelBanner';
-import { IssueCard } from '@/components/remediation/IssueCard';
+import { IssueCard, AiAnalysis } from '@/components/remediation/IssueCard';
 import { api } from '@/services/api';
 
 /**
@@ -140,6 +141,31 @@ export const PdfAuditResultsPage: React.FC = () => {
   const [isDownloading] = useState(false);
   const [isReScanning, setIsReScanning] = useState(false);
   const [currentScanLevel, setCurrentScanLevel] = useState<ScanLevel>('basic');
+  const [isFullscreen, setIsFullscreen] = useState(false);
+
+  // AI analysis state
+  const [aiSuggestions, setAiSuggestions] = useState<Map<string, AiAnalysis>>(new Map());
+  const [isAnalyzingAi, setIsAnalyzingAi] = useState(false);
+  const [aiProgress, setAiProgress] = useState<{ analyzed: number; total: number } | null>(null);
+  const [aiStats, setAiStats] = useState<{
+    gemini: { totalTokens: number; estimatedCostUsd: number };
+    claude: { totalTokens: number; estimatedCostUsd: number };
+    totalTokens: number;
+    totalCostUsd: number;
+  } | null>(null);
+  const aiPollingRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  // Auto-tag status state
+  const [autoTagInfo, setAutoTagInfo] = useState<{
+    status?: string;
+    hasTaggingReport?: boolean;
+    hasWordExport?: boolean;
+    elementCounts?: Record<string, number> | null;
+    adobeFlags?: Array<{ elementType?: string; page?: number; confidence?: string; reviewComment?: string }>;
+    postRemediationStatus?: 'pending' | 'complete' | 'failed';
+    postRemediationAudit?: { runAt: string; resolved: number; remaining: number; regressions: number; resolutionRate: number };
+  } | null>(null);
+  const [isRetryingAutoTag, setIsRetryingAutoTag] = useState(false);
 
   // Fetch audit result
   const fetchAuditResult = useCallback(async () => {
@@ -233,6 +259,25 @@ export const PdfAuditResultsPage: React.FC = () => {
       }
       map.get(page)!.push(issue);
     });
+    return map;
+  }, [auditResult]);
+
+  // Compute global sequential issue numbers — stable across filter changes
+  // Order: page ascending → severity weight descending → original array index
+  const issueNumberMap = useMemo(() => {
+    if (!auditResult || !auditResult.issues) return new Map<string, number>();
+    const SEVERITY_WEIGHT: Record<string, number> = { critical: 4, serious: 3, moderate: 2, minor: 1 };
+    const sorted = auditResult.issues
+      .map((issue, originalIndex) => ({ issue, originalIndex }))
+      .sort((a, b) => {
+        const pageDiff = (a.issue.pageNumber ?? 0) - (b.issue.pageNumber ?? 0);
+        if (pageDiff !== 0) return pageDiff;
+        const weightDiff = (SEVERITY_WEIGHT[b.issue.severity] ?? 0) - (SEVERITY_WEIGHT[a.issue.severity] ?? 0);
+        if (weightDiff !== 0) return weightDiff;
+        return a.originalIndex - b.originalIndex;
+      });
+    const map = new Map<string, number>();
+    sorted.forEach(({ issue }, idx) => map.set(issue.id, idx + 1));
     return map;
   }, [auditResult]);
 
@@ -350,12 +395,17 @@ export const PdfAuditResultsPage: React.FC = () => {
     setCurrentPage(page);
   }, []);
 
+  const scrollToIssueCard = useCallback((issueId: string) => {
+    document.getElementById(`issue-card-${issueId}`)?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+  }, []);
+
   const handleIssueSelect = useCallback((issue: PdfAuditIssue) => {
     setSelectedIssueId(issue.id);
     if (issue.pageNumber && issue.pageNumber !== currentPage) {
       setCurrentPage(issue.pageNumber);
     }
-  }, [currentPage]);
+    scrollToIssueCard(issue.id);
+  }, [currentPage, scrollToIssueCard]);
 
   const handlePageClick = useCallback((pageNumber: number) => {
     setCurrentPage(pageNumber);
@@ -366,6 +416,18 @@ export const PdfAuditResultsPage: React.FC = () => {
     }
   }, [issuesByPage]);
 
+  const handleViewAutoTagReport = useCallback(async () => {
+    if (!jobId) return;
+    try {
+      const res = await api.get(`/pdf/${encodeURIComponent(jobId)}/auto-tag/report`, { responseType: 'blob' });
+      const url = URL.createObjectURL(res.data as Blob);
+      window.open(url, '_blank');
+      setTimeout(() => URL.revokeObjectURL(url), 10000);
+    } catch {
+      toast.error('Failed to open report');
+    }
+  }, [jobId]);
+
   const handleMatterhornCheckpointClick = useCallback((checkpointId: string) => {
     // Filter to show issues for this checkpoint
     setFilters((prev) => ({
@@ -374,6 +436,102 @@ export const PdfAuditResultsPage: React.FC = () => {
     }));
     setShowFilters(true);
   }, []);
+
+  // Fetch AI suggestions and update state
+  const fetchAiSuggestions = useCallback(async () => {
+    if (!jobId) return;
+    try {
+      const res = await api.get<{
+        data: {
+          suggestions: AiAnalysis[];
+          analyzed: number;
+          total: number;
+          status: string;
+          stats?: {
+            gemini: { totalTokens: number; estimatedCostUsd: number };
+            claude: { totalTokens: number; estimatedCostUsd: number };
+            totalTokens: number;
+            totalCostUsd: number;
+          } | null;
+        };
+      }>(`/pdf/${encodeURIComponent(jobId)}/ai-analysis`);
+      const { suggestions, analyzed, total, status, stats } = res.data.data;
+      const map = new Map<string, AiAnalysis>();
+      suggestions.forEach((s) => map.set(s.issueId, s));
+      // DEBUG: log to help diagnose ID matching
+      if (suggestions.length > 0) {
+        console.log('[AI Debug] map size:', map.size, 'status:', status);
+        console.log('[AI Debug] sample issueIds:', suggestions.slice(0, 5).map(s => s.issueId));
+      }
+      if (isMountedRef.current) {
+        setAiSuggestions(map);
+        setAiProgress({ analyzed, total });
+        if (stats) setAiStats(stats);
+        if (status === 'complete') {
+          setIsAnalyzingAi(false);
+          if (aiPollingRef.current) {
+            clearInterval(aiPollingRef.current);
+            aiPollingRef.current = null;
+          }
+        } else if (status === 'processing' && !aiPollingRef.current) {
+          // AI analysis is running in the background (triggered automatically by worker) — start polling
+          setIsAnalyzingAi(true);
+          aiPollingRef.current = setInterval(fetchAiSuggestions, 3000);
+        }
+      }
+    } catch {
+      // Non-fatal — silently ignore fetch errors during polling
+    }
+  }, [jobId]);
+
+  // Load existing AI suggestions on mount (in case analysis was already run)
+  useEffect(() => {
+    if (jobId && auditResult) {
+      fetchAiSuggestions();
+    }
+  }, [jobId, auditResult, fetchAiSuggestions]);
+
+  // Cleanup AI polling interval on unmount
+  useEffect(() => {
+    return () => {
+      if (aiPollingRef.current) clearInterval(aiPollingRef.current);
+    };
+  }, []);
+
+  // Fetch auto-tag status after audit result loads
+  useEffect(() => {
+    if (!jobId || !auditResult) return;
+    api.get(`/pdf/${encodeURIComponent(jobId)}/auto-tag/status`)
+      .then(res => {
+        if (isMountedRef.current) setAutoTagInfo(res.data.data);
+      })
+      .catch(() => {});
+  }, [jobId, auditResult]);
+
+  const handleRetryAutoTag = async () => {
+    if (!jobId || isRetryingAutoTag) return;
+    setIsRetryingAutoTag(true);
+    try {
+      await api.post(`/pdf/${encodeURIComponent(jobId)}/auto-tag`);
+      setAutoTagInfo(prev => ({ ...prev, status: 'processing' }));
+      toast.success('Auto-tagging started — this may take a minute');
+      // Poll status every 5s until complete
+      const poll = setInterval(async () => {
+        try {
+          const res = await api.get(`/pdf/${encodeURIComponent(jobId)}/auto-tag/status`);
+          const info = res.data.data;
+          if (isMountedRef.current) setAutoTagInfo(info);
+          if (info?.status === 'complete' || info?.status === 'failed') {
+            clearInterval(poll);
+            setIsRetryingAutoTag(false);
+          }
+        } catch { clearInterval(poll); setIsRetryingAutoTag(false); }
+      }, 5000);
+    } catch (err) {
+      setIsRetryingAutoTag(false);
+      toast.error(err instanceof Error ? err.message : 'Failed to start auto-tag');
+    }
+  };
 
   const handleDownloadReport = (_format: 'pdf' | 'docx' | 'json' = 'json') => {
     if (!auditResult || !jobId) return;
@@ -664,13 +822,32 @@ export const PdfAuditResultsPage: React.FC = () => {
               variant="outline"
               size="sm"
               onClick={() => navigate(`/acr/workflow?jobId=${jobId}&jobType=PDF_ACCESSIBILITY`)}
+              disabled={autoTagInfo?.postRemediationStatus === 'pending'}
+              title={autoTagInfo?.postRemediationStatus === 'pending' ? 'Validating fixes — please wait…' : undefined}
             >
-              <FileText className="h-4 w-4 mr-1" />
-              Generate ACR
+              {autoTagInfo?.postRemediationStatus === 'pending'
+                ? <><Loader2 className="h-4 w-4 mr-1 animate-spin" />Validating…</>
+                : <><FileText className="h-4 w-4 mr-1" />Generate ACR</>
+              }
             </Button>
           </div>
+
         </div>
       </div>
+
+      <PdfStatsCards
+        autoTagInfo={autoTagInfo}
+        auditResult={auditResult}
+        aiSuggestions={aiSuggestions}
+        aiStats={aiStats}
+        matterhornIssueCount={matterhornIssueCount}
+        isAnalyzingAi={isAnalyzingAi}
+        aiProgress={aiProgress}
+        onViewAutoTagReport={handleViewAutoTagReport}
+        onRetryAutoTag={handleRetryAutoTag}
+        isRetryingAutoTag={isRetryingAutoTag}
+        jobId={jobId!}
+      />
 
       {/* Matterhorn Summary */}
       <div className="px-6 py-4 bg-white border-b border-gray-200">
@@ -731,7 +908,24 @@ export const PdfAuditResultsPage: React.FC = () => {
       )}
 
       {/* Three-column layout */}
-      <div className="flex h-[calc(100vh-320px)]">
+      <div className={isFullscreen ? 'fixed inset-0 z-50 flex flex-col bg-white' : 'flex h-[calc(100vh-320px)]'}>
+        {/* Fullscreen toolbar */}
+        {isFullscreen && (
+          <div className="flex items-center justify-between px-4 py-2 border-b border-gray-200 bg-white shrink-0">
+            <span className="text-sm font-medium text-gray-700">
+              {auditResult.fileName} — {auditResult.issues.length} issues
+            </span>
+            <button
+              type="button"
+              onClick={() => setIsFullscreen(false)}
+              className="flex items-center gap-1.5 px-3 py-1.5 text-sm text-gray-600 hover:text-gray-900 hover:bg-gray-100 rounded transition-colors"
+            >
+              <Minimize2 className="h-4 w-4" />
+              Exit full screen
+            </button>
+          </div>
+        )}
+        <div className={isFullscreen ? 'flex flex-1 overflow-hidden' : 'flex h-full w-full'}>
         {/* Left: Page Navigator */}
         <div className="w-64 border-r border-gray-200 bg-white overflow-hidden">
           <PdfPageNavigator
@@ -754,6 +948,7 @@ export const PdfAuditResultsPage: React.FC = () => {
             selectedIssueId={selectedIssueId}
             onPageChange={handlePageChange}
             onIssueSelect={handleIssueSelect}
+            issueNumberMap={issueNumberMap}
           />
         </div>
 
@@ -765,6 +960,15 @@ export const PdfAuditResultsPage: React.FC = () => {
               <h2 className="text-lg font-semibold text-gray-900">
                 Issues ({filteredIssues.length})
               </h2>
+              <div className="flex items-center gap-2">
+                <button
+                  type="button"
+                  title={isFullscreen ? 'Exit full screen' : 'Full screen'}
+                  onClick={() => setIsFullscreen((v) => !v)}
+                  className="p-1.5 text-gray-500 hover:text-gray-800 hover:bg-gray-100 rounded transition-colors"
+                >
+                  {isFullscreen ? <Minimize2 className="h-4 w-4" /> : <Maximize2 className="h-4 w-4" />}
+                </button>
               <Button
                 variant="outline"
                 size="sm"
@@ -779,6 +983,7 @@ export const PdfAuditResultsPage: React.FC = () => {
                   )}
                 />
               </Button>
+              </div>
             </div>
 
             {/* Matterhorn Toggle */}
@@ -921,19 +1126,39 @@ export const PdfAuditResultsPage: React.FC = () => {
                 )}
               </div>
             ) : (
-              filteredIssues.map((issue) => (
-                <IssueCard
-                  key={issue.id}
-                  issue={issue}
-                  jobId={jobId}
-                  onPageClick={handlePageClick}
-                  showMatterhorn={true}
-                  pageLabels={auditResult.metadata?.pageLabels}
-                />
-              ))
+              <>
+                {/* DEBUG: one-time log when aiSuggestions has data */}
+                {aiSuggestions.size > 0 && filteredIssues.length > 0 && (() => {
+                  console.log('[AI Debug] map size:', aiSuggestions.size);
+                  console.log('[AI Debug] issue ids (first 5):', filteredIssues.slice(0, 5).map(i => i.id));
+                  console.log('[AI Debug] map lookup result (first 5):', filteredIssues.slice(0, 5).map(i => aiSuggestions.get(i.id)?.suggestionType ?? 'MISS'));
+                  return null;
+                })()}
+                {filteredIssues.map((issue) => (
+                  <IssueCard
+                    key={issue.id}
+                    issue={issue}
+                    jobId={jobId}
+                    onPageClick={handlePageClick}
+                    showMatterhorn={true}
+                    pageLabels={auditResult.metadata?.pageLabels}
+                    aiSuggestion={aiSuggestions.get(issue.id)}
+                    issueNumber={issueNumberMap.get(issue.id)}
+                    onClick={() => handleIssueSelect(issue)}
+                    onAiSuggestionChange={(updated) => {
+                      setAiSuggestions((prev) => {
+                        const next = new Map(prev);
+                        next.set(updated.issueId, updated);
+                        return next;
+                      });
+                    }}
+                  />
+                ))}
+              </>
             )}
           </div>
         </div>
+        </div> {/* inner flex row */}
       </div>
     </div>
   );

--- a/src/pages/PdfAuditResultsPage.tsx
+++ b/src/pages/PdfAuditResultsPage.tsx
@@ -31,6 +31,7 @@ import { Badge } from '@/components/ui/Badge';
 import { Button } from '@/components/ui/Button';
 import { Breadcrumbs } from '@/components/ui/Breadcrumbs';
 import { MatterhornSummary } from '@/components/pdf/MatterhornSummary';
+import { PacReportModal } from '@/components/pdf/PacReportModal';
 import { PdfPageNavigator } from '@/components/pdf/PdfPageNavigator';
 import { PdfPreviewPanel } from '@/components/pdf/PdfPreviewPanel';
 import { PdfStatsCards } from '@/components/pdf/PdfStatsCards';
@@ -165,6 +166,7 @@ export const PdfAuditResultsPage: React.FC = () => {
     postRemediationAudit?: { runAt: string; resolved: number; remaining: number; regressions: number; resolutionRate: number };
   } | null>(null);
   const [isRetryingAutoTag, setIsRetryingAutoTag] = useState(false);
+  const [showPacReport, setShowPacReport] = useState(false);
 
   // Fetch audit result
   const fetchAuditResult = useCallback(async () => {
@@ -866,6 +868,14 @@ export const PdfAuditResultsPage: React.FC = () => {
                 : <><FileText className="h-4 w-4 mr-1" />Generate ACR</>
               }
             </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setShowPacReport(true)}
+            >
+              <FileText className="h-4 w-4 mr-1" />
+              PAC Report
+            </Button>
           </div>
 
         </div>
@@ -1186,6 +1196,12 @@ export const PdfAuditResultsPage: React.FC = () => {
         </div>
         </div> {/* inner flex row */}
       </div>
+
+      <PacReportModal
+        isOpen={showPacReport}
+        onClose={() => setShowPacReport(false)}
+        jobId={jobId!}
+      />
     </div>
   );
 };

--- a/src/pages/PdfAuditResultsPage.tsx
+++ b/src/pages/PdfAuditResultsPage.tsx
@@ -73,9 +73,9 @@ function getIssueCheckpoint(issue: PdfAuditIssue & { category?: string; code?: s
 import { cn } from '@/utils/cn';
 import { validateJobId } from '@/utils/validation';
 import { useCreateRemediationPlan } from '@/hooks/usePdfRemediation';
-import type { PdfAuditResult, PdfAuditIssue, MatterhornSummary as MatterhornSummaryType, PdfMetadata } from '@/types/pdf.types';
+import type { PdfAuditResult, PdfAuditIssue } from '@/types/pdf.types';
 import type { IssueSeverity } from '@/types/accessibility.types';
-import type { ScanLevel, ValidatorType } from '@/types/scan-level.types';
+import type { ScanLevel } from '@/types/scan-level.types';
 
 // Filter state interface
 interface IssueFilters {
@@ -614,97 +614,6 @@ export const PdfAuditResultsPage: React.FC = () => {
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Failed to create remediation plan';
       toast.error(message);
-    }
-  };
-
-  const handleReScan = async (scanLevel: ScanLevel, customValidators?: ValidatorType[]) => {
-    if (!jobId) return;
-
-    // Capture previous scan level for rollback on error
-    const previousScanLevel = currentScanLevel;
-
-    setIsReScanning(true);
-    setIsPolling(false); // Don't poll - we'll get the result directly from the POST response
-    // Optimistically update scan level immediately
-    setCurrentScanLevel(scanLevel);
-
-    // Declare toastId before try so it can be dismissed in catch
-    let toastId: string | number | undefined;
-
-    try {
-      // Show loading toast
-      toastId = toast.loading(`Running ${scanLevel} scan... This may take a few minutes.`);
-
-      // Call re-scan API - the response will contain the full audit results
-      const response = await api.post(`/pdf/job/${encodeURIComponent(jobId)}/re-scan`, {
-        scanLevel,
-        customValidators,
-      });
-
-      // Extract audit report from response
-      const data = response.data.data || response.data;
-      if (data.auditReport) {
-        // Transform the audit report to match PdfAuditResult structure
-        // Backend returns pageCount and matterhornSummary in metadata, but frontend expects them at root
-        const report = data.auditReport;
-        // Extract metadata with proper typing
-        const reportMetadata = report.metadata as Record<string, unknown> | undefined;
-        const matterhornSummaryData = reportMetadata?.matterhornSummary as MatterhornSummaryType | undefined;
-        const metadataData = reportMetadata as PdfMetadata | undefined;
-
-        // Create default metadata if none available
-        const defaultMetadata: PdfMetadata = {
-          pdfVersion: '1.7',
-          isTagged: false,
-          hasStructureTree: false,
-        };
-
-        // Create default Matterhorn summary if none available
-        const defaultMatterhornSummary: MatterhornSummaryType = {
-          totalCheckpoints: 0,
-          passed: 0,
-          failed: 0,
-          notApplicable: 0,
-          categories: [],
-        };
-
-        const transformedResult: PdfAuditResult = {
-          id: report.jobId || jobId!,
-          jobId: report.jobId || jobId!,
-          fileName: report.fileName,
-          fileSize: auditResult?.fileSize || 0, // Preserve from previous result
-          pageCount: (reportMetadata?.pageCount as number) || auditResult?.pageCount || 0,
-          score: report.score,
-          status: 'completed',
-          createdAt: auditResult?.createdAt || new Date().toISOString(),
-          completedAt: new Date().toISOString(),
-          issues: report.issues || [],
-          matterhornSummary: matterhornSummaryData || auditResult?.matterhornSummary || defaultMatterhornSummary,
-          metadata: metadataData || auditResult?.metadata || defaultMetadata,
-        };
-
-        setAuditResult(transformedResult);
-        setCurrentScanLevel(data.scanLevel || scanLevel);
-        toast.success(`${scanLevel} scan complete! Found ${report.issues?.length || 0} issues.`, { id: toastId });
-        // Only clear isReScanning when we have immediate results
-        setIsReScanning(false);
-      } else {
-        // Fallback to polling if response doesn't contain audit report
-        setIsPolling(true);
-        toast.success(`${scanLevel} scan started. Loading results...`, { id: toastId });
-        // Don't clear isReScanning here - let fetchAuditResult clear it when polling completes
-      }
-    } catch (err) {
-      const message = err instanceof Error ? err.message : 'Failed to start re-scan';
-      // Dismiss the loading toast before showing error
-      if (toastId !== undefined) {
-        toast.dismiss(String(toastId));
-      }
-      toast.error(message);
-      setIsReScanning(false);
-      setIsPolling(false);
-      // Revert scan level to previous value on error
-      setCurrentScanLevel(previousScanLevel);
     }
   };
 

--- a/src/pages/PdfAuditResultsPage.tsx
+++ b/src/pages/PdfAuditResultsPage.tsx
@@ -154,6 +154,7 @@ export const PdfAuditResultsPage: React.FC = () => {
     totalCostUsd: number;
   } | null>(null);
   const aiPollingRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const autoTagPollRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   // Auto-tag status state
   const [autoTagInfo, setAutoTagInfo] = useState<{
@@ -474,8 +475,16 @@ export const PdfAuditResultsPage: React.FC = () => {
             clearInterval(aiPollingRef.current);
             aiPollingRef.current = null;
           }
-        } else if (status === 'processing' && !aiPollingRef.current) {
-          // AI analysis is running in the background (triggered automatically by worker) — start polling
+        } else if (status === 'error' || status === 'failed') {
+          // Terminal failure — stop polling so we don't loop forever
+          setIsAnalyzingAi(false);
+          if (aiPollingRef.current) {
+            clearInterval(aiPollingRef.current);
+            aiPollingRef.current = null;
+          }
+        } else if ((status === 'processing' || status === 'pending') && !aiPollingRef.current) {
+          // AI analysis is queued ('pending') or running ('processing') in the
+          // background — start polling so suggestions appear without a manual refresh.
           setIsAnalyzingAi(true);
           aiPollingRef.current = setInterval(fetchAiSuggestions, 3000);
         }
@@ -492,10 +501,11 @@ export const PdfAuditResultsPage: React.FC = () => {
     }
   }, [jobId, auditResult, fetchAiSuggestions]);
 
-  // Cleanup AI polling interval on unmount
+  // Cleanup polling intervals on unmount
   useEffect(() => {
     return () => {
       if (aiPollingRef.current) clearInterval(aiPollingRef.current);
+      if (autoTagPollRef.current) clearInterval(autoTagPollRef.current);
     };
   }, []);
 
@@ -516,17 +526,28 @@ export const PdfAuditResultsPage: React.FC = () => {
       await api.post(`/pdf/${encodeURIComponent(jobId)}/auto-tag`);
       setAutoTagInfo(prev => ({ ...prev, status: 'processing' }));
       toast.success('Auto-tagging started — this may take a minute');
-      // Poll status every 5s until complete
-      const poll = setInterval(async () => {
+      // Poll status every 5s until complete; track in a ref so it can be cleared
+      // on unmount and so state updates are guarded against late firings.
+      if (autoTagPollRef.current) clearInterval(autoTagPollRef.current);
+      autoTagPollRef.current = setInterval(async () => {
         try {
           const res = await api.get(`/pdf/${encodeURIComponent(jobId)}/auto-tag/status`);
           const info = res.data.data;
           if (isMountedRef.current) setAutoTagInfo(info);
           if (info?.status === 'complete' || info?.status === 'failed') {
-            clearInterval(poll);
-            setIsRetryingAutoTag(false);
+            if (autoTagPollRef.current) {
+              clearInterval(autoTagPollRef.current);
+              autoTagPollRef.current = null;
+            }
+            if (isMountedRef.current) setIsRetryingAutoTag(false);
           }
-        } catch { clearInterval(poll); setIsRetryingAutoTag(false); }
+        } catch {
+          if (autoTagPollRef.current) {
+            clearInterval(autoTagPollRef.current);
+            autoTagPollRef.current = null;
+          }
+          if (isMountedRef.current) setIsRetryingAutoTag(false);
+        }
       }, 5000);
     } catch (err) {
       setIsRetryingAutoTag(false);

--- a/src/services/pac-report.service.ts
+++ b/src/services/pac-report.service.ts
@@ -1,0 +1,61 @@
+/**
+ * PAC Report API Service
+ *
+ * Fetches the Matterhorn Protocol 1.1 compliance report for a completed
+ * PDF audit job.
+ */
+
+import { api } from './api';
+
+// ─── Types (mirrors backend PacReport interfaces) ─────────────────────────────
+
+export type PacConditionStatus =
+  | 'PASS'
+  | 'FAIL'
+  | 'UNTESTED'
+  | 'HUMAN_REQUIRED'
+  | 'NOT_APPLICABLE';
+
+export type PacCheckpointStatus = 'PASS' | 'FAIL' | 'UNTESTED' | 'HUMAN_REQUIRED';
+
+export interface PacConditionResult {
+  id: string;
+  description: string;
+  how: 'M' | 'H' | '--';
+  status: PacConditionStatus;
+  issueIds?: string[];
+  source?: 'ninja' | 'verapdf';
+}
+
+export interface PacCheckpointResult {
+  id: string;
+  title: string;
+  status: PacCheckpointStatus;
+  conditions: PacConditionResult[];
+}
+
+export interface PacReportSummary {
+  total: number;
+  pass: number;
+  fail: number;
+  untested: number;
+  humanRequired: number;
+  notApplicable: number;
+}
+
+export interface PacReport {
+  jobId: string;
+  fileName: string;
+  generatedAt: string;
+  ninjaVersion: string;
+  isTagged: boolean;
+  summary: PacReportSummary;
+  checkpoints: PacCheckpointResult[];
+}
+
+// ─── API call ─────────────────────────────────────────────────────────────────
+
+export async function getPacReport(jobId: string): Promise<PacReport> {
+  const response = await api.get(`/pdf/${jobId}/pac-report`);
+  return response.data.data;
+}

--- a/src/services/pac-report.service.ts
+++ b/src/services/pac-report.service.ts
@@ -56,6 +56,6 @@ export interface PacReport {
 // ─── API call ─────────────────────────────────────────────────────────────────
 
 export async function getPacReport(jobId: string): Promise<PacReport> {
-  const response = await api.get(`/pdf/${jobId}/pac-report`);
+  const response = await api.get(`/pdf/${encodeURIComponent(jobId)}/pac-report`);
   return response.data.data;
 }

--- a/src/types/pdf.types.ts
+++ b/src/types/pdf.types.ts
@@ -311,6 +311,22 @@ export function isPdfAuditIssue(value: unknown): value is PdfAuditIssue {
   if (obj.matterhornCheckpoint !== undefined && typeof obj.matterhornCheckpoint !== 'string') return false;
   if (obj.suggestedFix !== undefined && typeof obj.suggestedFix !== 'string') return false;
 
+  // Validate boundingBox shape when present (coordinates feed overlay math)
+  if (obj.boundingBox !== undefined) {
+    if (typeof obj.boundingBox !== 'object' || obj.boundingBox === null) return false;
+    const bb = obj.boundingBox as Record<string, unknown>;
+    if (
+      typeof bb.x !== 'number' ||
+      typeof bb.y !== 'number' ||
+      typeof bb.width !== 'number' ||
+      typeof bb.height !== 'number'
+    ) {
+      return false;
+    }
+    if (bb.pageWidth !== undefined && typeof bb.pageWidth !== 'number') return false;
+    if (bb.pageHeight !== undefined && typeof bb.pageHeight !== 'number') return false;
+  }
+
   // Validate wcagCriteria is array of strings when present
   if (obj.wcagCriteria !== undefined) {
     if (!Array.isArray(obj.wcagCriteria)) return false;

--- a/src/types/pdf.types.ts
+++ b/src/types/pdf.types.ts
@@ -109,6 +109,20 @@ export interface PdfAuditIssue {
   matterhornCheckpoint?: string;
   /** Recommended remediation action */
   suggestedFix?: string;
+  /**
+   * Spatial location of the issue on the page, in PDF points (top-left origin).
+   * Optional — only present when the backend audit emits coordinates. The PDF
+   * preview highlights the issue when this is set and skips it otherwise.
+   * Mirrors the backend's optional boundingBox (base-audit.service.ts).
+   */
+  boundingBox?: {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+    pageWidth?: number;
+    pageHeight?: number;
+  };
 }
 
 /**


### PR DESCRIPTION
## What

Revives **#166** (PDF Matterhorn Step 2/5 frontend + audit UX) — open and red since March — into a clean, green, reviewable state. **Supersedes #166** (rebased onto current `main`, 163 commits forward; the merge was conflict-free).

This brings in the finished PDF audit-results work: collapsible 3-card stats panel, PAC Report modal (31-checkpoint grid), Matterhorn Step 2 changes, issue-highlight overlay, and EPUB uploader / IssueCard updates.

## Why it was red, and what I changed to make it green

The original branch failed CI on current `main`. Fixes (one new commit on top of #166's rebased commits):

1. **`types/pdf.ts` — add optional `boundingBox` to `PdfAuditIssue`.** The preview's highlight code reads `issue.boundingBox`, which the type lacked. The field mirrors the backend's optional shape (`base-audit.service.ts`); highlighting degrades gracefully when coordinates are absent.
2. **`PdfAuditResultsPage` — remove the orphaned `handleReScan` handler** (+ its now-unused type imports). Its trigger, `ScanLevelBanner`, was **deliberately removed in `c073a59`** ("all scans now comprehensive"); the handler was left behind and tripped `no-unused-locals`. Removing it **completes that intended cleanup** rather than re-introducing a scan-level UI the PR chose to drop.
3. **`PdfPreviewPanel` — render the bottom "N issue(s) on this page" indicator** its own tests expect (test file and component were out of sync).
4. **`PdfStatsCards` — memoize `issues`** to satisfy `react-hooks/exhaustive-deps` (lint runs `--max-warnings 0`).

## Verification

- `npx tsc --noEmit` — pass
- `npm run lint` (`--max-warnings 0`) — pass
- `npx vitest run` — **851 passed**, 10 skipped, 0 failed (65 files)

## ⚠️ Reviewer notes

- **1,816 lines of feature code authored back in March that has never had a human review** — please review the substance (PAC report, stats panel, highlight overlay), not just the green CI.
- The PDF-preview **issue highlighting only renders when the backend emits `boundingBox`** on issues. Worth confirming the audit response actually populates it end-to-end; otherwise highlights silently no-op (by design).
- Vestigial `isReScanning` / `currentScanLevel` state + a dev-only debug block remain from the original; left as-is to keep this change minimal. Easy follow-up to remove if you want.

Closes #166.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added stable global issue numbering across PDF overlays and issue cards (stays consistent during filtering) with synchronized selection (overlay clicks scroll to the card).
  * PDF overlays now use accurate bounding boxes, and the UI includes a selected-issue context strip and issue type breakdown.
  * Added a Matterhorn PAC compliance report modal.
  * Expanded AI audit experience: AutoTag + AI analysis progress, AI token/cost metrics, PDF stats cards, fullscreen controls, and gated “full results” plus AI-fixed PDF download.

* **Bug Fixes**
  * Improved remediation flow for manual-review required issues and editable alt-text suggestions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->