### PR TITLE
feat(pdf): surface issue locatability in preview (honesty UX)

### DIFF
--- a/src/components/pdf/PdfPreviewPanel.test.tsx
+++ b/src/components/pdf/PdfPreviewPanel.test.tsx
@@ -237,6 +237,41 @@ describe('PdfPreviewPanel', () => {
 
       expect(screen.queryByText(/issues on this page/)).not.toBeInTheDocument();
     });
+
+    it('notes when no page issues have location data (cannot be highlighted)', () => {
+      const issues = [
+        createMockIssue('1', 1, 'critical'),
+        createMockIssue('2', 1, 'serious'),
+      ];
+
+      render(<PdfPreviewPanel {...defaultProps} currentPage={1} issues={issues} />);
+
+      // Mock issues carry no boundingBox, so none are locatable on the page.
+      expect(screen.getByText('2 issues on this page')).toBeInTheDocument();
+      expect(screen.getByText('· none can be located')).toBeInTheDocument();
+    });
+
+    it('shows the located count when only some issues have location data', () => {
+      const issues = [
+        { ...createMockIssue('1', 1, 'critical'), boundingBox: { x: 10, y: 10, width: 20, height: 20 } },
+        createMockIssue('2', 1, 'serious'),
+      ];
+
+      render(<PdfPreviewPanel {...defaultProps} currentPage={1} issues={issues} />);
+
+      expect(screen.getByText('· 1 can be located')).toBeInTheDocument();
+    });
+
+    it('shows no locatability note when every issue has location data', () => {
+      const issues = [
+        { ...createMockIssue('1', 1, 'critical'), boundingBox: { x: 10, y: 10, width: 20, height: 20 } },
+      ];
+
+      render(<PdfPreviewPanel {...defaultProps} currentPage={1} issues={issues} />);
+
+      expect(screen.getByText('1 issue on this page')).toBeInTheDocument();
+      expect(screen.queryByText(/can be located/)).not.toBeInTheDocument();
+    });
   });
 
   describe('Toolbar Layout', () => {

--- a/src/components/pdf/PdfPreviewPanel.tsx
+++ b/src/components/pdf/PdfPreviewPanel.tsx
@@ -404,6 +404,7 @@ export const PdfPreviewPanel: React.FC<PdfPreviewPanelProps> = ({
             size="sm"
             onClick={() => setShowHighlights(!showHighlights)}
             aria-label={showHighlights ? 'Hide issue highlights' : 'Show issue highlights'}
+            title="Highlights mark only issues that include location data from the audit."
           >
             {showHighlights ? (
               <>
@@ -503,6 +504,16 @@ export const PdfPreviewPanel: React.FC<PdfPreviewPanelProps> = ({
             <span className="text-xs text-gray-500 shrink-0">
               {currentPageIssues.length} {currentPageIssues.length === 1 ? 'issue' : 'issues'} on this page
             </span>
+            {highlights.length < currentPageIssues.length && (
+              <span
+                className="text-xs text-amber-600 shrink-0"
+                title="Only issues that include location data from the audit can be highlighted on the page."
+              >
+                {highlights.length === 0
+                  ? '· none can be located'
+                  : `· ${highlights.length} can be located`}
+              </span>
+            )}
             {categoryBreakdown.map(({ label, count, icon, color, bgColor }) => (
               <span
                 key={label}


### PR DESCRIPTION
## What

The PDF preview can only highlight issues that carry `boundingBox` coordinates — today a minority of audit issues (most validators + all veraPDF/Matterhorn issues emit none, per the end-to-end check). The page issue count didn't match the number of highlight circles, so highlighting could look broken.

## Change (informational only — no control disabled)

- **`PdfPreviewPanel`:** when not all of a page's issues are locatable, show a muted note next to the page issue count — `· N can be located` / `· none can be located`.
- Tooltip on the highlight toggle explaining highlights mark only issues with location data.
- Tests cover none / some / all-locatable cases.

## Context

Companion to the backend `boundingBox`-coverage work (prompts saved at `Ninja-Documentation/04-Sprint-Prompts/pdf-boundingbox-backend-prompts.md`). As backend validators start emitting `boundingBox`, the "can be located" count rises automatically — no further FE change needed.

## Verification

- `npx tsc --noEmit` ✓ · `npx eslint` ✓ · `PdfPreviewPanel.test.tsx` 33 passed ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a tooltip to the Highlights toggle button explaining that highlighted marks only appear for issues with location data.
  * Added a status message displaying how many issues can be located and highlighted, providing clarity when only some issues have location information available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->