### PR TITLE
feat(calibration): Load more pagination for the Document Queue

### DIFF
--- a/src/components/bootstrap/DocumentQueueView.tsx
+++ b/src/components/bootstrap/DocumentQueueView.tsx
@@ -1,7 +1,7 @@
 import { useState, useMemo, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Loader2 } from 'lucide-react';
-import { useCorpusDocumentsWithPolling, useUploadTaggedPdf, useTriggerCorpusCalibrationRun, useReopenAnnotation } from '@/hooks/useCalibration';
+import { useCorpusDocumentsInfinite, useUploadTaggedPdf, useTriggerCorpusCalibrationRun, useReopenAnnotation } from '@/hooks/useCalibration';
 import { EmptyPagesModal } from './EmptyPagesModal';
 import { getCorpusDocumentStatus, resetCorpus } from '@/services/calibration.service';
 import type { CorpusDocument, CorpusDocumentStatus } from '@/services/calibration.service';
@@ -159,12 +159,15 @@ export default function DocumentQueueView() {
   const fileInputRefs = useRef<Record<string, HTMLInputElement | null>>({});
   const [emptyPagesModalDocId, setEmptyPagesModalDocId] = useState<string | null>(null);
 
-  const { data, isLoading, isError, error } = useCorpusDocumentsWithPolling();
+  const {
+    data, isLoading, isError, error,
+    hasNextPage, fetchNextPage, isFetchingNextPage,
+  } = useCorpusDocumentsInfinite();
   const uploadMutation = useUploadTaggedPdf();
   const triggerMutation = useTriggerCorpusCalibrationRun();
   const reopen = useReopenAnnotation();
 
-  const documents = useMemo(() => data?.documents ?? [], [data]);
+  const documents = useMemo(() => data?.pages.flatMap((p) => p.documents) ?? [], [data]);
 
   const publishers = useMemo(() => {
     const set = new Set<string>();
@@ -520,6 +523,22 @@ export default function DocumentQueueView() {
             </tbody>
           </table>
         </div>
+      )}
+      {hasNextPage && (
+        <div className="flex justify-center py-4">
+          <button
+            onClick={() => fetchNextPage()}
+            disabled={isFetchingNextPage}
+            className="px-4 py-2 text-sm font-medium rounded border border-gray-300 text-gray-700 hover:bg-gray-50 disabled:opacity-50 transition-colors"
+          >
+            {isFetchingNextPage ? 'Loading…' : 'Load more'}
+          </button>
+        </div>
+      )}
+      {!hasNextPage && documents.length > 0 && (
+        <p className="text-center text-xs text-gray-400 py-3">
+          All {documents.length} documents loaded
+        </p>
       )}
       {emptyPagesModalDocId && (() => {
         const doc = documents.find((d) => d.id === emptyPagesModalDocId);

--- a/src/components/bootstrap/__tests__/DocumentQueueView.test.tsx
+++ b/src/components/bootstrap/__tests__/DocumentQueueView.test.tsx
@@ -8,7 +8,7 @@ import type { CorpusDocument } from '@/services/calibration.service';
 const { reopenMutate } = vi.hoisted(() => ({ reopenMutate: vi.fn() }));
 
 vi.mock('@/hooks/useCalibration', () => ({
-  useCorpusDocumentsWithPolling: vi.fn(),
+  useCorpusDocumentsInfinite: vi.fn(),
   useUploadTaggedPdf: () => ({
     mutate: vi.fn(),
     isPending: false,
@@ -26,8 +26,26 @@ vi.mock('@/hooks/useCalibration', () => ({
   },
 }));
 
-const { useCorpusDocumentsWithPolling } = await import('@/hooks/useCalibration');
-const mockUseCorpus = vi.mocked(useCorpusDocumentsWithPolling);
+const { useCorpusDocumentsInfinite } = await import('@/hooks/useCalibration');
+const mockUseCorpus = vi.mocked(useCorpusDocumentsInfinite);
+
+// Build the infinite-query result the component expects: a single loaded page of
+// `docs` (or no data), with paging flags overridable per test.
+function infiniteResult(
+  docs: CorpusDocument[] | undefined,
+  overrides: Record<string, unknown> = {},
+) {
+  return {
+    data: docs === undefined ? undefined : { pages: [{ documents: docs }] },
+    isLoading: false,
+    isError: false,
+    error: null,
+    hasNextPage: false,
+    fetchNextPage: vi.fn(),
+    isFetchingNextPage: false,
+    ...overrides,
+  } as unknown as ReturnType<typeof mockUseCorpus>;
+}
 
 function renderWithRouter() {
   const queryClient = new QueryClient({
@@ -60,12 +78,7 @@ describe('DocumentQueueView', () => {
   });
 
   it('shows skeleton rows when loading', () => {
-    mockUseCorpus.mockReturnValue({
-      data: undefined,
-      isLoading: true,
-      isError: false,
-      error: null,
-    } as unknown as ReturnType<typeof mockUseCorpus>);
+    mockUseCorpus.mockReturnValue(infiniteResult(undefined, { isLoading: true }));
 
     renderWithRouter();
     const pulseElements = document.querySelectorAll('.animate-pulse');
@@ -73,30 +86,20 @@ describe('DocumentQueueView', () => {
   });
 
   it('shows empty state when no documents', () => {
-    mockUseCorpus.mockReturnValue({
-      data: { documents: [] },
-      isLoading: false,
-      isError: false,
-      error: null,
-    } as unknown as ReturnType<typeof mockUseCorpus>);
+    mockUseCorpus.mockReturnValue(infiniteResult([]));
 
     renderWithRouter();
     expect(screen.getByText('No documents in queue')).toBeInTheDocument();
   });
 
   it('renders document list with 3 documents', () => {
-    mockUseCorpus.mockReturnValue({
-      data: {
-        documents: [
-          makeDoc({ id: '1', filename: 'alpha.pdf' }),
-          makeDoc({ id: '2', filename: 'beta.pdf' }),
-          makeDoc({ id: '3', filename: 'gamma.pdf' }),
-        ],
-      },
-      isLoading: false,
-      isError: false,
-      error: null,
-    } as unknown as ReturnType<typeof mockUseCorpus>);
+    mockUseCorpus.mockReturnValue(
+      infiniteResult([
+        makeDoc({ id: '1', filename: 'alpha.pdf' }),
+        makeDoc({ id: '2', filename: 'beta.pdf' }),
+        makeDoc({ id: '3', filename: 'gamma.pdf' }),
+      ]),
+    );
 
     renderWithRouter();
     expect(screen.getByText('alpha.pdf')).toBeInTheDocument();
@@ -108,24 +111,19 @@ describe('DocumentQueueView', () => {
   // completedAt set (getCorpusDocumentStatus -> 'COMPLETED'). That block is the
   // only place the per-doc actions (Review Zones, Reopen, ...) render.
   it('shows "Reopen" button for a completed doc and calls reopen on click', () => {
-    mockUseCorpus.mockReturnValue({
-      data: {
-        documents: [
-          makeDoc({
-            calibrationRuns: [
-              {
-                id: 'run-1',
-                runDate: '2026-01-01T00:00:00Z',
-                completedAt: '2026-01-02T00:00:00Z',
-              },
-            ],
-          }),
-        ],
-      },
-      isLoading: false,
-      isError: false,
-      error: null,
-    } as unknown as ReturnType<typeof mockUseCorpus>);
+    mockUseCorpus.mockReturnValue(
+      infiniteResult([
+        makeDoc({
+          calibrationRuns: [
+            {
+              id: 'run-1',
+              runDate: '2026-01-01T00:00:00Z',
+              completedAt: '2026-01-02T00:00:00Z',
+            },
+          ],
+        }),
+      ]),
+    );
 
     renderWithRouter();
     const reopenBtn = screen.getByRole('button', {
@@ -141,18 +139,13 @@ describe('DocumentQueueView', () => {
   });
 
   it('filters documents by publisher', () => {
-    mockUseCorpus.mockReturnValue({
-      data: {
-        documents: [
-          makeDoc({ id: '1', filename: 'pub-a.pdf', publisher: 'Publisher A' }),
-          makeDoc({ id: '2', filename: 'pub-b.pdf', publisher: 'Publisher B' }),
-          makeDoc({ id: '3', filename: 'pub-a2.pdf', publisher: 'Publisher A' }),
-        ],
-      },
-      isLoading: false,
-      isError: false,
-      error: null,
-    } as unknown as ReturnType<typeof mockUseCorpus>);
+    mockUseCorpus.mockReturnValue(
+      infiniteResult([
+        makeDoc({ id: '1', filename: 'pub-a.pdf', publisher: 'Publisher A' }),
+        makeDoc({ id: '2', filename: 'pub-b.pdf', publisher: 'Publisher B' }),
+        makeDoc({ id: '3', filename: 'pub-a2.pdf', publisher: 'Publisher A' }),
+      ]),
+    );
 
     renderWithRouter();
     // All 3 visible initially
@@ -168,5 +161,35 @@ describe('DocumentQueueView', () => {
     expect(screen.getByText('pub-a.pdf')).toBeInTheDocument();
     expect(screen.getByText('pub-a2.pdf')).toBeInTheDocument();
     expect(screen.queryByText('pub-b.pdf')).not.toBeInTheDocument();
+  });
+
+  it('shows "Load more" and calls fetchNextPage on click when more pages exist', () => {
+    const fetchNextPage = vi.fn();
+    mockUseCorpus.mockReturnValue(
+      infiniteResult([makeDoc({ id: '1', filename: 'alpha.pdf' })], {
+        hasNextPage: true,
+        fetchNextPage,
+      }),
+    );
+
+    renderWithRouter();
+    const loadMore = screen.getByRole('button', { name: /load more/i });
+    expect(loadMore).toBeInTheDocument();
+
+    fireEvent.click(loadMore);
+    expect(fetchNextPage).toHaveBeenCalled();
+  });
+
+  it('shows the "all loaded" footer and no Load more when there are no more pages', () => {
+    mockUseCorpus.mockReturnValue(
+      infiniteResult([
+        makeDoc({ id: '1', filename: 'alpha.pdf' }),
+        makeDoc({ id: '2', filename: 'beta.pdf' }),
+      ]),
+    );
+
+    renderWithRouter();
+    expect(screen.getByText('All 2 documents loaded')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /load more/i })).not.toBeInTheDocument();
   });
 });

--- a/src/hooks/useCalibration.ts
+++ b/src/hooks/useCalibration.ts
@@ -1,4 +1,4 @@
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useQuery, useInfiniteQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import {
   getCorpusDocuments,
   startCalibration,
@@ -110,6 +110,37 @@ export function useCorpusDocumentsWithPolling(params?: {
     refetchInterval: (query) => {
       const docs = (query.state.data as { documents: CorpusDocument[] } | undefined)?.documents ?? [];
       const hasActive = docs.some((d: CorpusDocument) => {
+        const latestRun = d.calibrationRuns?.[0];
+        if (latestRun && !latestRun.completedAt) return true;
+        const latestJob = d.bootstrapJobs?.[0];
+        if (latestJob && !['COMPLETED', 'COMPLETE', 'FAILED'].includes(latestJob.status.toUpperCase())) return true;
+        return false;
+      });
+      return hasActive ? 5000 : false;
+    },
+  });
+}
+
+const PAGE_SIZE = 25;
+
+// Cursor-paginated variant of the document queue, for the "Load more" control.
+// Separate from useCorpusDocumentsWithPolling so ZoneReviewWorkspace's
+// useCorpusDocuments stays untouched. Polling refetches all loaded pages.
+export function useCorpusDocumentsInfinite(params?: {
+  publisher?: string;
+  contentType?: string;
+}) {
+  return useInfiniteQuery({
+    queryKey: [...CALIBRATION_KEYS.documents(params), 'infinite'],
+    queryFn: ({ pageParam }) =>
+      getCorpusDocuments({ ...params, limit: PAGE_SIZE, cursor: pageParam }),
+    initialPageParam: undefined as string | undefined,
+    getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
+    refetchInterval: (query) => {
+      const pages =
+        (query.state.data as { pages: { documents: CorpusDocument[] }[] } | undefined)?.pages ?? [];
+      const docs = pages.flatMap((p) => p.documents);
+      const hasActive = docs.some((d) => {
         const latestRun = d.calibrationRuns?.[0];
         if (latestRun && !latestRun.completedAt) return true;
         const latestJob = d.bootstrapJobs?.[0];


### PR DESCRIPTION
## What

Adds a **"Load more"** control to the Bootstrap Console **Document Queue**, which previously showed a single page with no pagination — so older uploads were unreachable once the corpus grows past the backend page size. The backend already supports cursor pagination (`GET /calibration/corpus-docs` → `{ documents, nextCursor }`, accepts `limit` + `cursor`).

## Changes

- **`useCalibration`:** new `useCorpusDocumentsInfinite` (cursor pagination via `useInfiniteQuery`, `PAGE_SIZE=25`), passing an explicit `limit` so paging is exercised regardless of the backend default. Keeps the active-doc polling behaviour (poll every 5s only while a doc is in progress). `useCorpusDocuments` and `useCorpusDocumentsWithPolling` are **unchanged** (ZoneReviewWorkspace unaffected).
- **`DocumentQueueView`:** consumes the infinite hook, flattens `data.pages`, and renders a **Load more** button + an **"All N documents loaded"** footer.
- Existing mutations invalidate the `['calibration','documents']` prefix, which also matches the new `[...,'infinite']` key — so reopen/upload/trigger refetch the queue automatically.
- **Tests:** mock the infinite hook (with a small `infiniteResult` helper) and add coverage for Load more (button → `fetchNextPage`) and the all-loaded footer.

## Out of scope (flagged, not done)

- Server-side filtering across pages — publisher/contentType filters remain client-side over loaded pages, matching prior behaviour.
- Reordering so in-progress work surfaces first — that's a backend `uploadedAt` ordering change; client-sorting across pages would break cursor pagination.

## Verification

- `npx tsc --noEmit` ✓ · `npm run lint` (`--max-warnings 0`) ✓ · `npx vitest run` → **856 passed**, 10 skipped, 0 failed ✓
- Manual `PAGE_SIZE=5` walkthrough (per the prompt) not run here (needs the live app + auth); the Load-more behaviour is covered by unit tests instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Document queues now support paginated loading with a **Load more** control.
  * Users can keep browsing additional documents until everything is loaded.
* **Bug Fixes**
  * Improved document queue behavior so results display correctly across multiple pages.
  * Pagination state now updates smoothly while more items are being fetched.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->