### PR TITLE
fix(calibration): load the latest CALIBRATION run in zone review

### DIFF
--- a/src/components/bootstrap/ZoneReviewWorkspace.tsx
+++ b/src/components/bootstrap/ZoneReviewWorkspace.tsx
@@ -108,9 +108,13 @@ export default function ZoneReviewWorkspace({
   // Right panel URL: togglable between tagged and source
   const rightPanelUrl = rightPanelMode === 'tagged' ? taggedPdfUrl : sourcePdfUrl;
 
-  // Calibration data — fetch latest run if runId not provided
+  // Calibration data — fetch the latest CALIBRATION run if runId not provided.
+  // Filter by type: a doc that was also used in a non-calibration run (e.g. a
+  // PIKE_PDF_SPIKE run from the PDF write-spike) can have a newer run of that
+  // type carrying no operator zones; loading it shows "No zones on this page"
+  // even though the annotator's zones live on the CALIBRATION run.
   const { data: runsData } = useCalibrationRuns(
-    runIdProp ? undefined : { documentId: docId, limit: 1 },
+    runIdProp ? undefined : { documentId: docId, type: 'CALIBRATION', limit: 1 },
   );
   const runId = runIdProp || runsData?.runs?.[0]?.id || '';
 

--- a/src/hooks/useCalibration.ts
+++ b/src/hooks/useCalibration.ts
@@ -42,6 +42,7 @@ export function useStartCalibration() {
 
 export function useCalibrationRuns(params?: {
   documentId?: string;
+  type?: string;
   limit?: number;
 }) {
   return useQuery({

--- a/src/services/calibration.service.ts
+++ b/src/services/calibration.service.ts
@@ -120,6 +120,7 @@ export const startCalibration = async (payload: {
 
 export const getCalibrationRuns = async (params?: {
   documentId?: string;
+  type?: string;
   limit?: number;
   cursor?: string;
   fromDate?: string;


### PR DESCRIPTION
## Problem (annotator-reported)
> Acharya: the right-side Zone panel displays "No zones on this page" for every page, so we are unable to proceed with the re-annotation.

## Root cause
`ZoneReviewWorkspace` fetches the **latest run of ANY type** for a document and loads its zones:
```ts
useCalibrationRuns({ documentId, limit: 1 }) → runs[0]
```
Acharya was also used in the May pikepdf write-spike, so its newest run is a `PIKE_PDF_SPIKE` run with **0 operator zones**; the workspace loads it → "No zones on this page" on every page. The annotator's 229 table zones actually live on the older `CALIBRATION` run. (PR #419 fixed this run-shadowing for the *document queue* but not for the *review workspace*.)

## Blast radius
Verified live against staging: **only Acharya** among the 12 table docs is affected — it's the only one with extra non-calibration runs. The other 11 have a single CALIBRATION run and open fine.

## Fix
Request `type: 'CALIBRATION'` when selecting the run, so the workspace loads the run that holds the annotator's zones. Threads an optional `type` through `getCalibrationRuns` / `useCalibrationRuns`.

**Depends on** s4cindia/ninja-backend#421 (adds the `type` filter to `GET /calibration/runs`). Deploy backend first.

## Testing
- `tsc --noEmit` ✓ · `eslint` (changed files, `--max-warnings 0`) ✓
- Bootstrap suite `vitest run src/components/bootstrap` — 92/92 pass ✓

## Note
A temporary staging data unblock is in place so the annotator can work on Acharya today (its CALIBRATION run's `runDate` was bumped to become the latest). That will be reverted once this + the backend fix deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Calibration zone review now consistently loads data from a matching calibration run, avoiding cases where a newer non-calibration run could be used instead.
  * Calibration run selection now supports filtering by run type, improving the accuracy of results shown in the workspace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->