### PR TITLE
feat(calibration): bulk-reject and draw-box tools for the zone editor

### DIFF
--- a/src/components/bootstrap/ZoneOverlay.tsx
+++ b/src/components/bootstrap/ZoneOverlay.tsx
@@ -1,6 +1,13 @@
-import { memo } from 'react';
+import { memo, useCallback, useEffect, useRef, useState } from 'react';
 import type { CalibrationZone } from '../../services/zone-correction.service';
 import { friendlyLabel } from './zone-label-utils';
+
+interface Rect {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
 
 interface ZoneOverlayProps {
   zones: CalibrationZone[];
@@ -11,6 +18,20 @@ interface ZoneOverlayProps {
   onZoneClick: (zoneId: string) => void;
   source?: 'docling' | 'pdfxt';
   zoneNumberMap?: Map<string, number>;
+  /** Ids currently held in the multi-select set (Shift/Ctrl-click or rubber-band). */
+  selectedIds?: Set<string>;
+  /** Shift/Ctrl-click on a zone toggles it in/out of `selectedIds`. */
+  onZoneToggle?: (zoneId: string) => void;
+  /** When true, zone rects stop intercepting pointer events so a drag anywhere
+   * on the page draws a new box instead of interacting with existing zones. */
+  drawMode?: boolean;
+  /** Fired on mouseup in draw mode with the dragged rectangle already converted
+   * to PDF points (using this overlay's own scaleX/scaleY). Tiny drags (<4px in
+   * either dimension) are ignored and never fire this callback. */
+  onDrawComplete?: (boundsPdf: Rect) => void;
+  /** Fired on mouseup after a non-draw-mode drag over empty space, with the ids
+   * of every zone whose bounds intersect the dragged rectangle. */
+  onRubberBandSelect?: (zoneIds: string[]) => void;
 }
 
 const BUCKET_STYLE = {
@@ -19,6 +40,12 @@ const BUCKET_STYLE = {
   RED: { stroke: '#dc2626', fill: 'rgba(220,38,38,0.08)' },
 };
 
+const MULTI_SELECT_STROKE = '#2563eb';
+const MIN_DRAG_PX = 4;
+
+function rectsIntersect(a: Rect, b: Rect): boolean {
+  return a.x < b.x + b.w && a.x + a.w > b.x && a.y < b.y + b.h && a.y + a.h > b.y;
+}
 
 function ZoneOverlayInner({
   zones,
@@ -29,30 +56,124 @@ function ZoneOverlayInner({
   onZoneClick,
   source,
   zoneNumberMap,
+  selectedIds,
+  onZoneToggle,
+  drawMode,
+  onDrawComplete,
+  onRubberBandSelect,
 }: ZoneOverlayProps) {
+  const svgRef = useRef<SVGSVGElement>(null);
+  const dragStartRef = useRef<{ x: number; y: number } | null>(null);
+  const dragLatestRef = useRef<Rect | null>(null);
+  const [isDragging, setIsDragging] = useState(false);
+  const [liveRect, setLiveRect] = useState<Rect | null>(null);
+
+  const pageZones = zones.filter((z) => z.pageNumber === pageNumber && z.bounds != null) as Array<
+    CalibrationZone & { bounds: NonNullable<CalibrationZone['bounds']> }
+  >;
+
+  const handleBackgroundMouseDown = useCallback((e: React.MouseEvent) => {
+    if (e.button !== 0) return;
+    const svg = svgRef.current;
+    if (!svg) return;
+    const rect = svg.getBoundingClientRect();
+    const start = { x: e.clientX - rect.left, y: e.clientY - rect.top };
+    dragStartRef.current = start;
+    dragLatestRef.current = { ...start, w: 0, h: 0 };
+    setLiveRect(dragLatestRef.current);
+    setIsDragging(true);
+  }, []);
+
+  useEffect(() => {
+    if (!isDragging) return;
+
+    const handleMove = (e: MouseEvent) => {
+      const svg = svgRef.current;
+      const start = dragStartRef.current;
+      if (!svg || !start) return;
+      const rect = svg.getBoundingClientRect();
+      const curX = e.clientX - rect.left;
+      const curY = e.clientY - rect.top;
+      const next: Rect = {
+        x: Math.min(start.x, curX),
+        y: Math.min(start.y, curY),
+        w: Math.abs(curX - start.x),
+        h: Math.abs(curY - start.y),
+      };
+      dragLatestRef.current = next;
+      setLiveRect(next);
+    };
+
+    const handleUp = () => {
+      const finalRect = dragLatestRef.current;
+      setIsDragging(false);
+      setLiveRect(null);
+      dragStartRef.current = null;
+      dragLatestRef.current = null;
+
+      if (!finalRect || finalRect.w < MIN_DRAG_PX || finalRect.h < MIN_DRAG_PX) return;
+
+      if (drawMode) {
+        onDrawComplete?.({
+          x: finalRect.x / scaleX,
+          y: finalRect.y / scaleY,
+          w: finalRect.w / scaleX,
+          h: finalRect.h / scaleY,
+        });
+      } else if (onRubberBandSelect) {
+        const ids = pageZones
+          .filter((z) => {
+            const zw = Math.abs(z.bounds.w) * scaleX;
+            const zh = Math.abs(z.bounds.h) * scaleY;
+            const zx = (z.bounds.w < 0 ? z.bounds.x + z.bounds.w : z.bounds.x) * scaleX;
+            const zy = (z.bounds.h < 0 ? z.bounds.y + z.bounds.h : z.bounds.y) * scaleY;
+            return rectsIntersect(finalRect, { x: zx, y: zy, w: zw, h: zh });
+          })
+          .map((z) => z.id);
+        if (ids.length > 0) onRubberBandSelect(ids);
+      }
+    };
+
+    window.addEventListener('mousemove', handleMove);
+    window.addEventListener('mouseup', handleUp);
+    return () => {
+      window.removeEventListener('mousemove', handleMove);
+      window.removeEventListener('mouseup', handleUp);
+    };
+    // pageZones is derived fresh each render from `zones`/`pageNumber`; including
+    // the array itself would re-subscribe every render, so its inputs stand in.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isDragging, drawMode, onDrawComplete, onRubberBandSelect, zones, pageNumber, scaleX, scaleY]);
+
   if (scaleX <= 0 || scaleY <= 0) {
     return null;
   }
 
   // Filter zones by source if specified
   const displayZones = source
-    ? zones.filter((z) =>
+    ? pageZones.filter((z) =>
         source === 'docling' ? z.doclingLabel != null : z.pdfxtLabel != null,
       )
-    : zones;
+    : pageZones;
 
   return (
     <svg
+      ref={svgRef}
       width="100%"
       height="100%"
       style={{ position: 'absolute', top: 0, left: 0, pointerEvents: 'none' }}
       aria-label="Zone detection overlay"
     >
-      {displayZones
-        .filter((z): z is CalibrationZone & { bounds: NonNullable<CalibrationZone['bounds']> } =>
-          z.pageNumber === pageNumber && z.bounds != null,
-        )
-        .map((zone, index) => {
+      <rect
+        x={0}
+        y={0}
+        width="100%"
+        height="100%"
+        fill="transparent"
+        style={{ pointerEvents: 'all', cursor: drawMode ? 'crosshair' : 'default' }}
+        onMouseDown={handleBackgroundMouseDown}
+      />
+      {displayZones.map((zone, index) => {
           const zoneNumber = zoneNumberMap?.get(zone.id) ?? index + 1;
           const rawW = Math.abs(zone.bounds.w) * scaleX;
           const rawH = Math.abs(zone.bounds.h) * scaleY;
@@ -62,16 +183,21 @@ function ZoneOverlayInner({
           const h = rawH;
 
           const isSelected = zone.id === selectedZoneId;
+          const isMultiSelected = selectedIds?.has(zone.id) ?? false;
           const isVerified = zone.operatorVerified;
           const bucketStyle =
             BUCKET_STYLE[zone.reconciliationBucket as keyof typeof BUCKET_STYLE];
-          const strokeColor = isVerified
-            ? '#0f766e'
-            : bucketStyle?.stroke ?? '#6b7280';
-          const fillColor = isVerified
-            ? 'rgba(15,118,110,0.12)'
-            : bucketStyle?.fill ?? 'rgba(0,0,0,0.05)';
-          const strokeWidth = isSelected ? 3 : 1.5;
+          const strokeColor = isMultiSelected
+            ? MULTI_SELECT_STROKE
+            : isVerified
+              ? '#0f766e'
+              : bucketStyle?.stroke ?? '#6b7280';
+          const fillColor = isMultiSelected
+            ? 'rgba(37,99,235,0.15)'
+            : isVerified
+              ? 'rgba(15,118,110,0.12)'
+              : bucketStyle?.fill ?? 'rgba(0,0,0,0.05)';
+          const strokeWidth = isSelected || isMultiSelected ? 3 : 1.5;
 
           const abbrev = source ? friendlyLabel(zone, source) : '?';
           const badgeText = `#${zoneNumber} ${abbrev}`;
@@ -80,15 +206,27 @@ function ZoneOverlayInner({
           return (
             <g
               key={zone.id}
-              style={{ pointerEvents: 'all', cursor: 'pointer' }}
+              style={{ pointerEvents: drawMode ? 'none' : 'all', cursor: 'pointer' }}
               role="button"
               aria-label={`Zone ${zoneNumber}: ${abbrev}, ${zone.reconciliationBucket}`}
+              aria-pressed={isMultiSelected}
               tabIndex={0}
-              onClick={() => onZoneClick(zone.id)}
+              onClick={(e) => {
+                if ((e.shiftKey || e.ctrlKey || e.metaKey) && onZoneToggle) {
+                  e.stopPropagation();
+                  onZoneToggle(zone.id);
+                } else {
+                  onZoneClick(zone.id);
+                }
+              }}
               onKeyDown={(e) => {
                 if (e.key === 'Enter' || e.key === ' ') {
                   e.preventDefault();
-                  onZoneClick(zone.id);
+                  if ((e.shiftKey || e.ctrlKey) && onZoneToggle) {
+                    onZoneToggle(zone.id);
+                  } else {
+                    onZoneClick(zone.id);
+                  }
                 }
               }}
             >
@@ -171,6 +309,19 @@ function ZoneOverlayInner({
             </g>
           );
         })}
+      {liveRect && (
+        <rect
+          x={liveRect.x}
+          y={liveRect.y}
+          width={liveRect.w}
+          height={liveRect.h}
+          fill={drawMode ? 'rgba(37,99,235,0.1)' : 'rgba(107,114,128,0.1)'}
+          stroke={drawMode ? MULTI_SELECT_STROKE : '#6b7280'}
+          strokeWidth={1.5}
+          strokeDasharray="4 3"
+          style={{ pointerEvents: 'none' }}
+        />
+      )}
     </svg>
   );
 }

--- a/src/components/bootstrap/ZonePdfPanel.tsx
+++ b/src/components/bootstrap/ZonePdfPanel.tsx
@@ -19,6 +19,11 @@ interface ZonePdfPanelProps {
   onDocumentLoad?: (numPages: number) => void;
   label: string;
   zoneNumberMap?: Map<string, number>;
+  selectedIds?: Set<string>;
+  onZoneToggle?: (zoneId: string) => void;
+  drawMode?: boolean;
+  onDrawComplete?: (boundsPdf: { x: number; y: number; w: number; h: number }) => void;
+  onRubberBandSelect?: (zoneIds: string[]) => void;
 }
 
 const FALLBACK_WIDTH = 600;
@@ -47,6 +52,11 @@ function ZonePdfPanelInner({
   onDocumentLoad,
   label,
   zoneNumberMap,
+  selectedIds,
+  onZoneToggle,
+  drawMode,
+  onDrawComplete,
+  onRubberBandSelect,
 }: ZonePdfPanelProps) {
   const scrollRef = useRef<HTMLDivElement>(null);
   const isExternalScroll = useRef(false);
@@ -156,6 +166,11 @@ function ZonePdfPanelInner({
                   onZoneClick={onZoneClick}
                   source={source}
                   zoneNumberMap={zoneNumberMap}
+                  selectedIds={selectedIds}
+                  onZoneToggle={onZoneToggle}
+                  drawMode={drawMode}
+                  onDrawComplete={onDrawComplete}
+                  onRubberBandSelect={onRubberBandSelect}
                 />
               )}
             </div>

--- a/src/components/bootstrap/ZoneReviewWorkspace.tsx
+++ b/src/components/bootstrap/ZoneReviewWorkspace.tsx
@@ -16,6 +16,8 @@ import {
   useCorrectZone,
   useRejectZone,
   useConfirmAllGreen,
+  useBulkRejectZones,
+  useCreateZone,
   useAutoAnnotate,
   useRunComparison,
 } from '@/hooks/useZoneReview';
@@ -34,6 +36,7 @@ import ZoneListSidebar from './ZoneListSidebar';
 import { EmptyPagesChip } from './EmptyPagesChip';
 import { EmptyPageReviewSidebar } from './EmptyPageReviewSidebar';
 import { MarkCompleteModal, type MarkCompleteRequest } from './MarkCompleteModal';
+import ZoneLabelDropdown from './ZoneLabelDropdown';
 import { useZoneNumberMap } from '@/hooks/useZoneNumberMap';
 import { TableStructureEditor } from '../quickfix/TableStructureEditor';
 import type { TableSection } from '@/types/zone.types';
@@ -42,6 +45,13 @@ import type { CalibrationZone } from '@/services/zone-correction.service';
 pdfjs.GlobalWorkerOptions.workerSrc = '/pdf.worker.min.js';
 
 type BucketFilter = 'ALL' | 'GREEN' | 'AMBER' | 'RED';
+
+// Best-available raw label for a zone — same fallback precedence used
+// elsewhere (e.g. ZoneComparisonDetailBar's decision dropdown), so "reject
+// all remaining <label>" matches what the operator sees on screen.
+function effectiveZoneLabel(zone: CalibrationZone): string {
+  return zone.operatorLabel ?? zone.pdfxtLabel ?? zone.doclingLabel ?? zone.type;
+}
 
 interface ZoneReviewWorkspaceProps {
   documentId: string;
@@ -87,6 +97,17 @@ export default function ZoneReviewWorkspace({
   const [completeBanner, setCompleteBanner] = useState<{ type: 'success' | 'error'; message: string } | null>(null);
   const [analysisGenerated, setAnalysisGenerated] = useState(false);
   const [markCompleteModalOpen, setMarkCompleteModalOpen] = useState(false);
+
+  // Multi-select (Shift/Ctrl-click or rubber-band) — "Reject selected"
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  // Draw-box mode — drag a new zone directly onto the page
+  const [drawMode, setDrawMode] = useState(false);
+  const [pendingDraw, setPendingDraw] = useState<{
+    pageNumber: number;
+    bounds: { x: number; y: number; w: number; h: number };
+  } | null>(null);
+  const [drawOperatorLabel, setDrawOperatorLabel] = useState('formula');
+  const [rejectAllLabel, setRejectAllLabel] = useState('formula');
 
   // Keep page input in sync with currentPage (arrow buttons, thumbnail clicks, etc.)
   useEffect(() => {
@@ -145,6 +166,8 @@ export default function ZoneReviewWorkspace({
   const correctZone = useCorrectZone(runId);
   const rejectZone = useRejectZone(runId);
   const confirmAllGreen = useConfirmAllGreen(runId);
+  const bulkRejectZones = useBulkRejectZones(runId);
+  const createZone = useCreateZone(runId);
   const autoAnnotateMutation = useAutoAnnotate(runId);
   const comparisonMutation = useRunComparison(runId);
 
@@ -188,6 +211,16 @@ export default function ZoneReviewWorkspace({
 
   // Selected zone number
   const selectedZoneNumber = selectedZone ? zoneNumberMap.get(selectedZone.id) ?? undefined : undefined;
+
+  // Count of zones on the current page matching `rejectAllLabel` — drives the
+  // "Reject all remaining <label>" button's enabled state and count preview.
+  const rejectAllCount = useMemo(
+    () =>
+      zones.filter(
+        (z) => z.pageNumber === currentPage && effectiveZoneLabel(z) === rejectAllLabel,
+      ).length,
+    [zones, currentPage, rejectAllLabel],
+  );
 
   // Per-page zone counts
   const pageZoneCounts = useMemo(() => {
@@ -263,6 +296,66 @@ export default function ZoneReviewWorkspace({
     });
   }, [confirmAllGreen, recordBulkDecision]);
 
+  const handleZoneToggle = useCallback((zoneId: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(zoneId)) next.delete(zoneId);
+      else next.add(zoneId);
+      return next;
+    });
+  }, []);
+
+  const handleRubberBandSelect = useCallback((zoneIds: string[]) => {
+    setSelectedIds(new Set(zoneIds));
+  }, []);
+
+  const handleRejectSelected = useCallback(() => {
+    if (selectedIds.size === 0) return;
+    const count = selectedIds.size;
+    bulkRejectZones.mutate(
+      { zoneIds: [...selectedIds] },
+      {
+        onSuccess: (data) => {
+          recordBulkDecision(data?.rejectedCount ?? count, 'reject');
+          setSelectedIds(new Set());
+        },
+      },
+    );
+  }, [selectedIds, bulkRejectZones, recordBulkDecision]);
+
+  const handleRejectAllOnPage = useCallback(() => {
+    if (!runId || rejectAllCount === 0) return;
+    const confirmed = window.confirm(
+      `Reject all ${rejectAllCount} ${rejectAllLabel} zone${rejectAllCount === 1 ? '' : 's'} on page ${currentPage}?`,
+    );
+    if (!confirmed) return;
+    bulkRejectZones.mutate(
+      { filter: { calibrationRunId: runId, pageNumber: currentPage, operatorLabel: rejectAllLabel } },
+      {
+        onSuccess: (data) => {
+          if (data?.rejectedCount) recordBulkDecision(data.rejectedCount, 'reject');
+        },
+      },
+    );
+  }, [runId, rejectAllCount, rejectAllLabel, currentPage, bulkRejectZones, recordBulkDecision]);
+
+  const handleDrawComplete = useCallback(
+    (boundsPdf: { x: number; y: number; w: number; h: number }) => {
+      setPendingDraw({ pageNumber: currentPage, bounds: boundsPdf });
+    },
+    [currentPage],
+  );
+
+  const handleConfirmDraw = useCallback(() => {
+    if (!pendingDraw) return;
+    createZone.mutate(
+      { pageNumber: pendingDraw.pageNumber, operatorLabel: drawOperatorLabel, bounds: pendingDraw.bounds },
+      { onSuccess: () => setPendingDraw(null) },
+    );
+  }, [pendingDraw, drawOperatorLabel, createZone]);
+
+  const handleCancelDraw = useCallback(() => setPendingDraw(null), []);
+
   // Keyboard shortcuts
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
@@ -281,6 +374,8 @@ export default function ZoneReviewWorkspace({
         handleReject(selectedZoneId);
       } else if (e.key === 'Escape') {
         setSelectedZoneId(null);
+        setSelectedIds(new Set());
+        setPendingDraw(null);
       }
     };
     window.addEventListener('keydown', handler);
@@ -290,6 +385,14 @@ export default function ZoneReviewWorkspace({
   // Reset scroll when page changes
   useEffect(() => {
     setSyncedScrollTop(0);
+  }, [currentPage]);
+
+  // Multi-select and any in-progress draw are page-scoped — carrying them
+  // across a page navigation would silently apply to zones the operator
+  // can no longer see.
+  useEffect(() => {
+    setSelectedIds(new Set());
+    setPendingDraw(null);
   }, [currentPage]);
 
   // Measure right panel width — only update on meaningful changes
@@ -507,6 +610,53 @@ export default function ZoneReviewWorkspace({
               </button>
             </>
           )}
+
+          {/* Draw box mode */}
+          <button
+            onClick={() => setDrawMode((v) => !v)}
+            className={`px-3 py-1.5 text-xs font-medium rounded border transition-colors ${
+              drawMode
+                ? 'bg-blue-600 text-white border-blue-600'
+                : 'bg-white text-gray-600 border-gray-300 hover:bg-gray-50'
+            }`}
+            title="Drag on the page to draw a new zone"
+          >
+            {drawMode ? 'Drawing… (click to stop)' : 'Draw box'}
+          </button>
+
+          {/* Multi-select: Shift/Ctrl-click a zone, or drag over empty space */}
+          {selectedIds.size > 0 && (
+            <>
+              <button
+                onClick={handleRejectSelected}
+                disabled={bulkRejectZones.isPending}
+                className="px-3 py-1.5 text-xs font-medium rounded bg-red-600 text-white hover:bg-red-700 disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {bulkRejectZones.isPending ? 'Rejecting…' : `Reject selected (${selectedIds.size})`}
+              </button>
+              <button
+                onClick={() => setSelectedIds(new Set())}
+                className="text-xs text-gray-400 hover:text-gray-600"
+              >
+                Clear
+              </button>
+            </>
+          )}
+
+          {/* Reject all remaining <label> on this page */}
+          <div className="flex items-center gap-1">
+            <div className="w-32">
+              <ZoneLabelDropdown value={rejectAllLabel} onChange={setRejectAllLabel} />
+            </div>
+            <button
+              onClick={handleRejectAllOnPage}
+              disabled={rejectAllCount === 0 || bulkRejectZones.isPending}
+              title={`Reject all ${rejectAllLabel} zones on page ${currentPage}`}
+              className="px-3 py-1.5 text-xs font-medium rounded border border-red-300 text-red-600 hover:bg-red-50 disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              Reject all ({rejectAllCount})
+            </button>
+          </div>
 
           {/* Confirm All Green (hidden for OPERATOR) */}
           {!isOperator && (
@@ -849,6 +999,11 @@ export default function ZoneReviewWorkspace({
           onDocumentLoad={setNumPages}
           label="Docling — Source PDF"
           zoneNumberMap={zoneNumberMap}
+          selectedIds={selectedIds}
+          onZoneToggle={handleZoneToggle}
+          drawMode={drawMode}
+          onDrawComplete={handleDrawComplete}
+          onRubberBandSelect={handleRubberBandSelect}
         />
 
         {/* Right panel: Tagged PDF (default) + pdfxt zones */}
@@ -890,6 +1045,11 @@ export default function ZoneReviewWorkspace({
                     onZoneClick={setSelectedZoneId}
                     width={(rightPanelWidth || 600) - 16}
                     zoneNumberMap={zoneNumberMap}
+                    selectedIds={selectedIds}
+                    onZoneToggle={handleZoneToggle}
+                    drawMode={drawMode}
+                    onDrawComplete={handleDrawComplete}
+                    onRubberBandSelect={handleRubberBandSelect}
                   />
                 </div>
               </div>
@@ -939,6 +1099,47 @@ export default function ZoneReviewWorkspace({
         />
       )}
 
+      {/* New-zone label prompt — shown after a draw-box drag completes */}
+      {pendingDraw && (
+        <div
+          className="fixed inset-0 bg-black/50 flex items-center justify-center z-50"
+          onClick={(e) => {
+            if (e.target === e.currentTarget && !createZone.isPending) handleCancelDraw();
+          }}
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="new-zone-title"
+        >
+          <div className="bg-white rounded-lg shadow-xl w-80 mx-4 p-4">
+            <h3 id="new-zone-title" className="text-sm font-semibold text-gray-900 mb-3">
+              New zone — page {pendingDraw.pageNumber}
+            </h3>
+            <label className="block text-xs font-medium text-gray-700 mb-1">Zone type</label>
+            <ZoneLabelDropdown
+              value={drawOperatorLabel}
+              onChange={setDrawOperatorLabel}
+              disabled={createZone.isPending}
+            />
+            <div className="flex justify-end gap-2 mt-4">
+              <button
+                onClick={handleCancelDraw}
+                disabled={createZone.isPending}
+                className="px-3 py-1.5 text-xs font-medium rounded border border-gray-300 text-gray-600 hover:bg-gray-50 disabled:opacity-50"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleConfirmDraw}
+                disabled={createZone.isPending}
+                className="px-3 py-1.5 text-xs font-medium rounded bg-teal-600 text-white hover:bg-teal-700 disabled:opacity-50"
+              >
+                {createZone.isPending ? 'Creating…' : 'Create Zone'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
       {/* Table editor modal */}
       {tableEditorZone && (
         <TableStructureEditor
@@ -986,6 +1187,11 @@ function RightPanelPdf({
   onZoneClick,
   width,
   zoneNumberMap,
+  selectedIds,
+  onZoneToggle,
+  drawMode,
+  onDrawComplete,
+  onRubberBandSelect,
 }: {
   pdfUrl: string;
   page: number;
@@ -994,6 +1200,11 @@ function RightPanelPdf({
   onZoneClick: (zoneId: string) => void;
   width: number;
   zoneNumberMap?: Map<string, number>;
+  selectedIds?: Set<string>;
+  onZoneToggle?: (zoneId: string) => void;
+  drawMode?: boolean;
+  onDrawComplete?: (boundsPdf: { x: number; y: number; w: number; h: number }) => void;
+  onRubberBandSelect?: (zoneIds: string[]) => void;
 }) {
   const [pageHeight, setPageHeight] = useState(0);
   const [pdfWidth, setPdfWidth] = useState(595);
@@ -1043,6 +1254,11 @@ function RightPanelPdf({
           onZoneClick={onZoneClick}
           source="pdfxt"
           zoneNumberMap={zoneNumberMap}
+          selectedIds={selectedIds}
+          onZoneToggle={onZoneToggle}
+          drawMode={drawMode}
+          onDrawComplete={onDrawComplete}
+          onRubberBandSelect={onRubberBandSelect}
         />
       )}
     </>

--- a/src/components/bootstrap/__tests__/ZoneOverlay.test.tsx
+++ b/src/components/bootstrap/__tests__/ZoneOverlay.test.tsx
@@ -65,7 +65,7 @@ describe('ZoneOverlay', () => {
         zones={[makeZone({ reconciliationBucket: 'GREEN' })]}
       />
     );
-    const rect = container.querySelector('rect');
+    const rect = container.querySelector('g rect');
     expect(rect?.getAttribute('stroke')).toBe('#16a34a');
   });
 
@@ -76,7 +76,7 @@ describe('ZoneOverlay', () => {
         zones={[makeZone({ reconciliationBucket: 'AMBER' })]}
       />
     );
-    const rect = container.querySelector('rect');
+    const rect = container.querySelector('g rect');
     expect(rect?.getAttribute('stroke')).toBe('#d97706');
   });
 
@@ -87,7 +87,7 @@ describe('ZoneOverlay', () => {
         zones={[makeZone({ reconciliationBucket: 'RED' })]}
       />
     );
-    const rect = container.querySelector('rect');
+    const rect = container.querySelector('g rect');
     expect(rect?.getAttribute('stroke')).toBe('#dc2626');
   });
 
@@ -99,7 +99,7 @@ describe('ZoneOverlay', () => {
         selectedZoneId="z1"
       />
     );
-    const rect = container.querySelector('rect');
+    const rect = container.querySelector('g rect');
     expect(rect?.getAttribute('stroke-width')).toBe('3');
   });
 
@@ -129,5 +129,63 @@ describe('ZoneOverlay', () => {
     const g = container.querySelector('g');
     fireEvent.keyDown(g!, { key: 'Enter' });
     expect(onZoneClick).toHaveBeenCalledWith('z-enter');
+  });
+
+  it('shift-click on a zone calls onZoneToggle instead of onZoneClick', () => {
+    const onZoneClick = vi.fn();
+    const onZoneToggle = vi.fn();
+    const { container } = render(
+      <ZoneOverlay
+        {...defaultProps}
+        zones={[makeZone({ id: 'z-shift' })]}
+        onZoneClick={onZoneClick}
+        onZoneToggle={onZoneToggle}
+      />
+    );
+    const g = container.querySelector('g');
+    fireEvent.click(g!, { shiftKey: true });
+    expect(onZoneToggle).toHaveBeenCalledWith('z-shift');
+    expect(onZoneClick).not.toHaveBeenCalled();
+  });
+
+  it('ctrl-click on a zone calls onZoneToggle instead of onZoneClick', () => {
+    const onZoneClick = vi.fn();
+    const onZoneToggle = vi.fn();
+    const { container } = render(
+      <ZoneOverlay
+        {...defaultProps}
+        zones={[makeZone({ id: 'z-ctrl' })]}
+        onZoneClick={onZoneClick}
+        onZoneToggle={onZoneToggle}
+      />
+    );
+    const g = container.querySelector('g');
+    fireEvent.click(g!, { ctrlKey: true });
+    expect(onZoneToggle).toHaveBeenCalledWith('z-ctrl');
+    expect(onZoneClick).not.toHaveBeenCalled();
+  });
+
+  it('multi-selected zone has blue stroke colour', () => {
+    const { container } = render(
+      <ZoneOverlay
+        {...defaultProps}
+        zones={[makeZone({ id: 'z1', reconciliationBucket: 'GREEN' })]}
+        selectedIds={new Set(['z1'])}
+      />
+    );
+    const rect = container.querySelector('g rect');
+    expect(rect?.getAttribute('stroke')).toBe('#2563eb');
+  });
+
+  it('draw mode disables pointer events on zone groups', () => {
+    const { container } = render(
+      <ZoneOverlay
+        {...defaultProps}
+        zones={[makeZone({ id: 'z1' })]}
+        drawMode
+      />
+    );
+    const g = container.querySelector('g');
+    expect(g?.getAttribute('style')).toContain('pointer-events: none');
   });
 });

--- a/src/hooks/useZoneReview.ts
+++ b/src/hooks/useZoneReview.ts
@@ -11,6 +11,8 @@ import {
   correctZone,
   rejectZone,
   confirmAllGreen,
+  bulkRejectZones,
+  createZone,
   runAutoAnnotation,
   runAiAnnotation,
   runComparison,
@@ -143,6 +145,24 @@ export function useConfirmAllGreen(runId: string) {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: () => confirmAllGreen(runId),
+    onSuccess: () =>
+      qc.invalidateQueries({ queryKey: ['calibration', 'zones', runId] }),
+  });
+}
+
+export function useBulkRejectZones(runId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: bulkRejectZones,
+    onSuccess: () =>
+      qc.invalidateQueries({ queryKey: ['calibration', 'zones', runId] }),
+  });
+}
+
+export function useCreateZone(runId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (payload: Parameters<typeof createZone>[1]) => createZone(runId, payload),
     onSuccess: () =>
       qc.invalidateQueries({ queryKey: ['calibration', 'zones', runId] }),
   });

--- a/src/services/zone-correction.service.ts
+++ b/src/services/zone-correction.service.ts
@@ -54,6 +54,19 @@ export const confirmAllGreen = async (
 ): Promise<{ confirmedCount: number }> =>
   (await api.post(`/calibration/runs/${encodeURIComponent(runId)}/confirm-all-green`)).data.data;
 
+export const bulkRejectZones = async (
+  payload:
+    | { zoneIds: string[]; correctionReason?: string }
+    | { filter: { calibrationRunId: string; pageNumber?: number; operatorLabel?: string }; correctionReason?: string },
+): Promise<{ rejectedCount: number }> =>
+  (await api.post('/calibration/zones/bulk-reject', payload)).data.data;
+
+export const createZone = async (
+  runId: string,
+  payload: { pageNumber: number; operatorLabel: string; bounds: { x: number; y: number; w: number; h: number }; type?: string },
+): Promise<CalibrationZone> =>
+  (await api.post(`/calibration/runs/${encodeURIComponent(runId)}/zones`, payload)).data.data;
+
 export interface AutoAnnotationResult {
   runId: string;
   patternsApplied: {


### PR DESCRIPTION
## Summary
- Multi-select (Shift/Ctrl-click, rubber-band drag) + "Reject selected (N)" for clearing dense pages fast
- "Reject all remaining <label>" page sweep with a confirm dialog
- Draw-box mode: drag on the page to hand-draw a whole-matrix zone where extraction only produced per-cell boxes; prompts for a label (default `formula`) then creates the zone
- Depends on `ninja-backend` PR #422 (`POST /calibration/zones/bulk-reject`, `POST /calibration/runs/:runId/zones`), which is merged/ready

## Test plan
- [x] `npm run type-check` passes
- [x] `npm run lint` passes
- [x] `npm run build` passes
- [x] `ZoneOverlay` unit tests updated + new coverage for shift/ctrl-click toggle, multi-select styling, draw-mode pointer-events (13/13 passing, 96/96 across bootstrap components)
- [ ] Manual: draw a box on a dense corpus doc page, confirm it persists and lands in training export (needs live backend + corpus data — not run in this session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Select multiple zones using Shift/Ctrl/Meta-click or rubber-band selection.
  * Reject multiple selected zones at once, or reject all remaining zones matching a label.
  * Draw a box directly on the PDF to create a new zone and choose its type.
  * Added clearer visual styling for selected zones and active drawing areas.
* **Bug Fixes**
  * Improved label consistency for bulk rejection counts and actions.
* **Tests**
  * Added coverage for multi-selection, selected styling, and draw-mode interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->