### PR TITLE
fix(calibration): hide rejected zones and fix the "Reject all (N)" count

### DIFF
--- a/src/components/bootstrap/ZoneOverlay.tsx
+++ b/src/components/bootstrap/ZoneOverlay.tsx
@@ -32,6 +32,8 @@ interface ZoneOverlayProps {
   /** Fired on mouseup after a non-draw-mode drag over empty space, with the ids
    * of every zone whose bounds intersect the dragged rectangle. */
   onRubberBandSelect?: (zoneIds: string[]) => void;
+  /** When true, rejected zones render muted instead of being hidden. Default off. */
+  showRejected?: boolean;
 }
 
 const BUCKET_STYLE = {
@@ -61,6 +63,7 @@ function ZoneOverlayInner({
   drawMode,
   onDrawComplete,
   onRubberBandSelect,
+  showRejected,
 }: ZoneOverlayProps) {
   const svgRef = useRef<SVGSVGElement>(null);
   const dragStartRef = useRef<{ x: number; y: number } | null>(null);
@@ -68,9 +71,12 @@ function ZoneOverlayInner({
   const [isDragging, setIsDragging] = useState(false);
   const [liveRect, setLiveRect] = useState<Rect | null>(null);
 
-  const pageZones = zones.filter((z) => z.pageNumber === pageNumber && z.bounds != null) as Array<
-    CalibrationZone & { bounds: NonNullable<CalibrationZone['bounds']> }
-  >;
+  const pageZones = zones.filter(
+    (z) =>
+      z.pageNumber === pageNumber &&
+      z.bounds != null &&
+      (showRejected || z.decision !== 'REJECTED'),
+  ) as Array<CalibrationZone & { bounds: NonNullable<CalibrationZone['bounds']> }>;
 
   const handleBackgroundMouseDown = useCallback((e: React.MouseEvent) => {
     if (e.button !== 0) return;
@@ -122,6 +128,7 @@ function ZoneOverlayInner({
         });
       } else if (onRubberBandSelect) {
         const ids = pageZones
+          .filter((z) => z.decision !== 'REJECTED')
           .filter((z) => {
             const zw = Math.abs(z.bounds.w) * scaleX;
             const zh = Math.abs(z.bounds.h) * scaleY;
@@ -140,10 +147,10 @@ function ZoneOverlayInner({
       window.removeEventListener('mousemove', handleMove);
       window.removeEventListener('mouseup', handleUp);
     };
-    // pageZones is derived fresh each render from `zones`/`pageNumber`; including
-    // the array itself would re-subscribe every render, so its inputs stand in.
+    // pageZones is derived fresh each render from `zones`/`pageNumber`/`showRejected`;
+    // including the array itself would re-subscribe every render, so its inputs stand in.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isDragging, drawMode, onDrawComplete, onRubberBandSelect, zones, pageNumber, scaleX, scaleY]);
+  }, [isDragging, drawMode, onDrawComplete, onRubberBandSelect, zones, pageNumber, scaleX, scaleY, showRejected]);
 
   if (scaleX <= 0 || scaleY <= 0) {
     return null;
@@ -185,18 +192,23 @@ function ZoneOverlayInner({
           const isSelected = zone.id === selectedZoneId;
           const isMultiSelected = selectedIds?.has(zone.id) ?? false;
           const isVerified = zone.operatorVerified;
+          const isRejected = zone.decision === 'REJECTED';
           const bucketStyle =
             BUCKET_STYLE[zone.reconciliationBucket as keyof typeof BUCKET_STYLE];
-          const strokeColor = isMultiSelected
-            ? MULTI_SELECT_STROKE
-            : isVerified
-              ? '#0f766e'
-              : bucketStyle?.stroke ?? '#6b7280';
-          const fillColor = isMultiSelected
-            ? 'rgba(37,99,235,0.15)'
-            : isVerified
-              ? 'rgba(15,118,110,0.12)'
-              : bucketStyle?.fill ?? 'rgba(0,0,0,0.05)';
+          const strokeColor = isRejected
+            ? '#9ca3af'
+            : isMultiSelected
+              ? MULTI_SELECT_STROKE
+              : isVerified
+                ? '#0f766e'
+                : bucketStyle?.stroke ?? '#6b7280';
+          const fillColor = isRejected
+            ? 'rgba(156,163,175,0.08)'
+            : isMultiSelected
+              ? 'rgba(37,99,235,0.15)'
+              : isVerified
+                ? 'rgba(15,118,110,0.12)'
+                : bucketStyle?.fill ?? 'rgba(0,0,0,0.05)';
           const strokeWidth = isSelected || isMultiSelected ? 3 : 1.5;
 
           const abbrev = source ? friendlyLabel(zone, source) : '?';
@@ -206,9 +218,13 @@ function ZoneOverlayInner({
           return (
             <g
               key={zone.id}
-              style={{ pointerEvents: drawMode ? 'none' : 'all', cursor: 'pointer' }}
+              style={{
+                pointerEvents: drawMode ? 'none' : 'all',
+                cursor: 'pointer',
+                opacity: isRejected ? 0.4 : 1,
+              }}
               role="button"
-              aria-label={`Zone ${zoneNumber}: ${abbrev}, ${zone.reconciliationBucket}`}
+              aria-label={`Zone ${zoneNumber}: ${abbrev}, ${zone.reconciliationBucket}${isRejected ? ', rejected' : ''}`}
               aria-pressed={isMultiSelected}
               tabIndex={0}
               onClick={(e) => {
@@ -239,31 +255,36 @@ function ZoneOverlayInner({
                 stroke={strokeColor}
                 fill={fillColor}
                 strokeWidth={strokeWidth}
+                strokeDasharray={isRejected ? '4 3' : undefined}
                 rx={2}
               >
-                <title>{`#${zoneNumber} ${abbrev} · ${zone.reconciliationBucket}`}</title>
+                <title>{`#${zoneNumber} ${abbrev} · ${isRejected ? 'REJECTED' : zone.reconciliationBucket}`}</title>
               </rect>
-              {/* Number circle at top-left corner */}
-              <circle
-                cx={x + 10}
-                cy={y + 10}
-                r={9}
-                fill={strokeColor}
-                style={{ pointerEvents: 'none' }}
-              />
-              <text
-                x={x + 10}
-                y={y + 14}
-                fontSize={10}
-                fontWeight={700}
-                fill="white"
-                textAnchor="middle"
-                style={{ pointerEvents: 'none', userSelect: 'none' }}
-              >
-                {zoneNumber}
-              </text>
+              {/* Number circle at top-left corner — omitted for rejected zones */}
+              {!isRejected && (
+                <>
+                  <circle
+                    cx={x + 10}
+                    cy={y + 10}
+                    r={9}
+                    fill={strokeColor}
+                    style={{ pointerEvents: 'none' }}
+                  />
+                  <text
+                    x={x + 10}
+                    y={y + 14}
+                    fontSize={10}
+                    fontWeight={700}
+                    fill="white"
+                    textAnchor="middle"
+                    style={{ pointerEvents: 'none', userSelect: 'none' }}
+                  >
+                    {zoneNumber}
+                  </text>
+                </>
+              )}
               {/* AI confidence dot */}
-              {zone.aiConfidence != null && (
+              {!isRejected && zone.aiConfidence != null && (
                 <circle
                   cx={x + 22}
                   cy={y + 6}

--- a/src/components/bootstrap/ZonePdfPanel.tsx
+++ b/src/components/bootstrap/ZonePdfPanel.tsx
@@ -24,6 +24,7 @@ interface ZonePdfPanelProps {
   drawMode?: boolean;
   onDrawComplete?: (boundsPdf: { x: number; y: number; w: number; h: number }) => void;
   onRubberBandSelect?: (zoneIds: string[]) => void;
+  showRejected?: boolean;
 }
 
 const FALLBACK_WIDTH = 600;
@@ -57,6 +58,7 @@ function ZonePdfPanelInner({
   drawMode,
   onDrawComplete,
   onRubberBandSelect,
+  showRejected,
 }: ZonePdfPanelProps) {
   const scrollRef = useRef<HTMLDivElement>(null);
   const isExternalScroll = useRef(false);
@@ -171,6 +173,7 @@ function ZonePdfPanelInner({
                   drawMode={drawMode}
                   onDrawComplete={onDrawComplete}
                   onRubberBandSelect={onRubberBandSelect}
+                  showRejected={showRejected}
                 />
               )}
             </div>

--- a/src/components/bootstrap/ZoneReviewWorkspace.tsx
+++ b/src/components/bootstrap/ZoneReviewWorkspace.tsx
@@ -108,6 +108,8 @@ export default function ZoneReviewWorkspace({
   } | null>(null);
   const [drawOperatorLabel, setDrawOperatorLabel] = useState('formula');
   const [rejectAllLabel, setRejectAllLabel] = useState('formula');
+  const [showRejected, setShowRejected] = useState(false);
+  const [rejectToast, setRejectToast] = useState<string | null>(null);
 
   // Keep page input in sync with currentPage (arrow buttons, thumbnail clicks, etc.)
   useEffect(() => {
@@ -212,12 +214,16 @@ export default function ZoneReviewWorkspace({
   // Selected zone number
   const selectedZoneNumber = selectedZone ? zoneNumberMap.get(selectedZone.id) ?? undefined : undefined;
 
-  // Count of zones on the current page matching `rejectAllLabel` — drives the
-  // "Reject all remaining <label>" button's enabled state and count preview.
+  // Count of *active* (not already-rejected) zones on the current page matching
+  // `rejectAllLabel` — drives the "Reject all remaining <label>" button's
+  // enabled state and count preview.
   const rejectAllCount = useMemo(
     () =>
       zones.filter(
-        (z) => z.pageNumber === currentPage && effectiveZoneLabel(z) === rejectAllLabel,
+        (z) =>
+          z.pageNumber === currentPage &&
+          effectiveZoneLabel(z) === rejectAllLabel &&
+          z.decision !== 'REJECTED',
       ).length,
     [zones, currentPage, rejectAllLabel],
   );
@@ -309,6 +315,11 @@ export default function ZoneReviewWorkspace({
     setSelectedIds(new Set(zoneIds));
   }, []);
 
+  const showRejectToast = useCallback((n: number) => {
+    setRejectToast(`Rejected ${n} zone${n === 1 ? '' : 's'}`);
+    setTimeout(() => setRejectToast(null), 4000);
+  }, []);
+
   const handleRejectSelected = useCallback(() => {
     if (selectedIds.size === 0) return;
     const count = selectedIds.size;
@@ -316,12 +327,14 @@ export default function ZoneReviewWorkspace({
       { zoneIds: [...selectedIds] },
       {
         onSuccess: (data) => {
-          recordBulkDecision(data?.rejectedCount ?? count, 'reject');
+          const rejectedCount = data?.rejectedCount ?? count;
+          recordBulkDecision(rejectedCount, 'reject');
+          showRejectToast(rejectedCount);
           setSelectedIds(new Set());
         },
       },
     );
-  }, [selectedIds, bulkRejectZones, recordBulkDecision]);
+  }, [selectedIds, bulkRejectZones, recordBulkDecision, showRejectToast]);
 
   const handleRejectAllOnPage = useCallback(() => {
     if (!runId || rejectAllCount === 0) return;
@@ -333,11 +346,14 @@ export default function ZoneReviewWorkspace({
       { filter: { calibrationRunId: runId, pageNumber: currentPage, operatorLabel: rejectAllLabel } },
       {
         onSuccess: (data) => {
-          if (data?.rejectedCount) recordBulkDecision(data.rejectedCount, 'reject');
+          if (data?.rejectedCount) {
+            recordBulkDecision(data.rejectedCount, 'reject');
+            showRejectToast(data.rejectedCount);
+          }
         },
       },
     );
-  }, [runId, rejectAllCount, rejectAllLabel, currentPage, bulkRejectZones, recordBulkDecision]);
+  }, [runId, rejectAllCount, rejectAllLabel, currentPage, bulkRejectZones, recordBulkDecision, showRejectToast]);
 
   const handleDrawComplete = useCallback(
     (boundsPdf: { x: number; y: number; w: number; h: number }) => {
@@ -658,6 +674,19 @@ export default function ZoneReviewWorkspace({
             </button>
           </div>
 
+          {/* Show rejected zones (muted) */}
+          <button
+            onClick={() => setShowRejected((v) => !v)}
+            className={`px-3 py-1.5 text-xs font-medium rounded border transition-colors ${
+              showRejected
+                ? 'bg-gray-700 text-white border-gray-700'
+                : 'bg-white text-gray-600 border-gray-300 hover:bg-gray-50'
+            }`}
+            title="Toggle visibility of rejected zones"
+          >
+            {showRejected ? 'Hide rejected' : 'Show rejected'}
+          </button>
+
           {/* Confirm All Green (hidden for OPERATOR) */}
           {!isOperator && (
             <button
@@ -943,6 +972,19 @@ export default function ZoneReviewWorkspace({
         </div>
       )}
 
+      {/* Bulk-reject toast */}
+      {rejectToast && (
+        <div className="flex items-center justify-between px-4 py-2 bg-red-50 border-b border-red-200 text-sm text-red-800">
+          <span>{rejectToast}</span>
+          <button
+            onClick={() => setRejectToast(null)}
+            className="text-red-600 hover:text-red-800 text-lg leading-none"
+          >
+            &times;
+          </button>
+        </div>
+      )}
+
       {/* Mark-complete banner */}
       {completeBanner && (
         <div className={`flex items-center justify-between px-4 py-2 border-b text-sm ${
@@ -1004,6 +1046,7 @@ export default function ZoneReviewWorkspace({
           drawMode={drawMode}
           onDrawComplete={handleDrawComplete}
           onRubberBandSelect={handleRubberBandSelect}
+          showRejected={showRejected}
         />
 
         {/* Right panel: Tagged PDF (default) + pdfxt zones */}
@@ -1050,6 +1093,7 @@ export default function ZoneReviewWorkspace({
                     drawMode={drawMode}
                     onDrawComplete={handleDrawComplete}
                     onRubberBandSelect={handleRubberBandSelect}
+                    showRejected={showRejected}
                   />
                 </div>
               </div>
@@ -1192,6 +1236,7 @@ function RightPanelPdf({
   drawMode,
   onDrawComplete,
   onRubberBandSelect,
+  showRejected,
 }: {
   pdfUrl: string;
   page: number;
@@ -1205,6 +1250,7 @@ function RightPanelPdf({
   drawMode?: boolean;
   onDrawComplete?: (boundsPdf: { x: number; y: number; w: number; h: number }) => void;
   onRubberBandSelect?: (zoneIds: string[]) => void;
+  showRejected?: boolean;
 }) {
   const [pageHeight, setPageHeight] = useState(0);
   const [pdfWidth, setPdfWidth] = useState(595);
@@ -1259,6 +1305,7 @@ function RightPanelPdf({
           drawMode={drawMode}
           onDrawComplete={onDrawComplete}
           onRubberBandSelect={onRubberBandSelect}
+          showRejected={showRejected}
         />
       )}
     </>

--- a/src/components/bootstrap/__tests__/ZoneOverlay.test.tsx
+++ b/src/components/bootstrap/__tests__/ZoneOverlay.test.tsx
@@ -188,4 +188,44 @@ describe('ZoneOverlay', () => {
     const g = container.querySelector('g');
     expect(g?.getAttribute('style')).toContain('pointer-events: none');
   });
+
+  it('hides rejected zones by default', () => {
+    const { container } = render(
+      <ZoneOverlay
+        {...defaultProps}
+        zones={[makeZone({ id: 'z1', decision: 'REJECTED' })]}
+      />
+    );
+    expect(container.querySelectorAll('g').length).toBe(0);
+  });
+
+  it('shows rejected zones muted, with no number badge, when showRejected is on', () => {
+    const { container } = render(
+      <ZoneOverlay
+        {...defaultProps}
+        zones={[makeZone({ id: 'z1', decision: 'REJECTED' })]}
+        showRejected
+      />
+    );
+    const g = container.querySelector('g');
+    expect(g).toBeInTheDocument();
+    expect(g?.getAttribute('style')).toContain('opacity: 0.4');
+    expect(g?.querySelector('circle')).toBeNull();
+    const rect = g?.querySelector('rect');
+    expect(rect?.getAttribute('stroke')).toBe('#9ca3af');
+    expect(rect?.getAttribute('stroke-dasharray')).toBe('4 3');
+  });
+
+  it('non-rejected zones are unaffected by showRejected', () => {
+    const { container } = render(
+      <ZoneOverlay
+        {...defaultProps}
+        zones={[makeZone({ id: 'z1', reconciliationBucket: 'GREEN' })]}
+        showRejected
+      />
+    );
+    const g = container.querySelector('g');
+    expect(g?.getAttribute('style')).toContain('opacity: 1');
+    expect(g?.querySelector('circle')).not.toBeNull();
+  });
 });

--- a/src/services/zone-correction.service.ts
+++ b/src/services/zone-correction.service.ts
@@ -13,6 +13,7 @@ export interface CalibrationZone {
   pdfxtLabel?: string;
   operatorVerified: boolean;
   operatorLabel?: string;
+  decision?: 'CONFIRMED' | 'CORRECTED' | 'REJECTED' | null;
   tableStructure?: { thead: unknown; tbody: unknown };
   isArtefact: boolean;
   confidence?: number;


### PR DESCRIPTION
## Summary
- `ZoneOverlay` now excludes `decision === 'REJECTED'` zones by default instead of rendering every bounded zone regardless of decision
- New "Show rejected" toolbar toggle renders them back muted (grey dashed, 0.4 opacity, no number badge) so an accidental reject is recoverable by clicking + re-confirming
- Rubber-band select candidates exclude already-rejected zones
- `rejectAllCount` now only counts active (non-rejected) zones, so the button correctly drops to "Reject all (0)" once a page is cleared
- Toast (`Rejected N zones`) on bulk-reject success

Verified root cause on staging: Olszewski p279's "Reject all (367)" correctly set `decision=REJECTED` on all 367 boxes backend-side, but the UI kept rendering them and kept showing "(367)" — this was purely a frontend read gap, no backend change needed.

## Test plan
- [x] `npm run type-check` passes
- [x] `npm run lint` passes
- [x] `npm run build` passes
- [x] New `ZoneOverlay` tests: hides rejected by default, shows muted with no badge when toggled, non-rejected zones unaffected (99/99 bootstrap tests passing)
- [ ] Manual: p279 shows 0 formula boxes and "Reject all (0)"; "Show rejected" brings the 367 back greyed (needs live backend — not run in this session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added controls to show or hide rejected zones in review views.
  * Rejected zones now appear with muted, dashed styling when displayed.
  * Added confirmation feedback after bulk rejection actions.
  * Bulk rejection counts now exclude zones already rejected.

* **Bug Fixes**
  * Rejected zones remain excluded from new selection actions.
  * Active zone counts now accurately reflect current review status.

* **Tests**
  * Added coverage for rejected-zone visibility, styling, and selection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->