### PR TITLE
feat(pdf): surface auto-tagger source (Seam-C/Adobe) in audit results

### DIFF
--- a/src/pages/PdfAuditResultsPage.tsx
+++ b/src/pages/PdfAuditResultsPage.tsx
@@ -731,6 +731,16 @@ export const PdfAuditResultsPage: React.FC = () => {
                         Tagged
                       </Badge>
                     )}
+                    {auditResult.autoTagStatus === 'complete' && auditResult.taggerSource && (
+                      <Badge variant="info" className="ml-2">
+                        Auto-tagged: {auditResult.taggerSource === 'seam-c' ? 'Seam-C (YOLO)' : 'Adobe AutoTag'}
+                      </Badge>
+                    )}
+                    {auditResult.autoTagStatus === 'failed' && (
+                      <Badge variant="error" className="ml-2" title={auditResult.autoTagError ?? undefined}>
+                        Auto-tag failed
+                      </Badge>
+                    )}
                   </p>
                 </div>
               </div>

--- a/src/types/pdf.types.ts
+++ b/src/types/pdf.types.ts
@@ -153,6 +153,12 @@ export interface PdfAuditResult {
   matterhornSummary: MatterhornSummary;
   /** Extracted PDF document metadata */
   metadata: PdfMetadata;
+  /** Which auto-tagger ran, if any (only set when autoTagStatus is 'complete') */
+  taggerSource?: 'seam-c' | 'adobe' | null;
+  /** Outcome of the auto-tagging step run before the audit */
+  autoTagStatus?: 'complete' | 'failed' | 'skipped' | null;
+  /** Error message if autoTagStatus is 'failed' */
+  autoTagError?: string | null;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add `taggerSource` / `autoTagStatus` / `autoTagError` to `PdfAuditResult` (backend change already deployed to `GET /pdf/job/:jobId/audit/result`)
- Show a badge next to the filename in the PDF audit results header: "Auto-tagged: Seam-C (YOLO)" / "Auto-tagged: Adobe AutoTag" when `autoTagStatus === 'complete'`, or "Auto-tag failed" (with the error as a tooltip) when `autoTagStatus === 'failed'`

## Test plan
- [x] `npm run type-check`
- [x] `npm run lint`
- [ ] Upload an untagged PDF, wait for audit completion, confirm the "Auto-tagged: Seam-C (YOLO)" or "Adobe AutoTag" badge appears next to the filename
- [ ] Upload a PDF that's already tagged, confirm no auto-tag badge appears (only the existing "Tagged" badge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added status badges to PDF audit results showing when automatic tagging completes or fails.
  * Completed tagging identifies whether Seam-C (YOLO) or Adobe AutoTag was used.
  * Failed tagging displays the available error details in a tooltip.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->