### PR TITLE
fix(pdf): sync auto-tag badge after retry and expose failure reason to screen readers

### DIFF
--- a/src/pages/PdfAuditResultsPage.tsx
+++ b/src/pages/PdfAuditResultsPage.tsx
@@ -509,15 +509,36 @@ export const PdfAuditResultsPage: React.FC = () => {
     };
   }, []);
 
+  // Merge a terminal auto-tag outcome into auditResult so the header badge
+  // reflects the latest result. Skipped while status is 'processing' so the
+  // badge keeps showing the previous outcome instead of flickering away
+  // mid-retry (the stats card already shows a dedicated in-progress state).
+  const applyAutoTagStatus = useCallback((info: {
+    status?: string;
+    taggerSource?: string | null;
+    error?: string | null;
+  } | undefined) => {
+    if (!info || info.status === 'processing') return;
+    setAuditResult(prev => prev ? {
+      ...prev,
+      autoTagStatus: (info.status as PdfAuditResult['autoTagStatus']) ?? prev.autoTagStatus,
+      taggerSource: (info.taggerSource as PdfAuditResult['taggerSource']) ?? prev.taggerSource,
+      autoTagError: info.error ?? prev.autoTagError,
+    } : prev);
+  }, []);
+
   // Fetch auto-tag status after audit result loads
   useEffect(() => {
     if (!jobId || !auditResult) return;
     api.get(`/pdf/${encodeURIComponent(jobId)}/auto-tag/status`)
       .then(res => {
-        if (isMountedRef.current) setAutoTagInfo(res.data.data);
+        if (!isMountedRef.current) return;
+        const info = res.data.data;
+        setAutoTagInfo(info);
+        applyAutoTagStatus(info);
       })
       .catch(() => {});
-  }, [jobId, auditResult]);
+  }, [jobId, auditResult, applyAutoTagStatus]);
 
   const handleRetryAutoTag = async () => {
     if (!jobId || isRetryingAutoTag) return;
@@ -533,7 +554,10 @@ export const PdfAuditResultsPage: React.FC = () => {
         try {
           const res = await api.get(`/pdf/${encodeURIComponent(jobId)}/auto-tag/status`);
           const info = res.data.data;
-          if (isMountedRef.current) setAutoTagInfo(info);
+          if (isMountedRef.current) {
+            setAutoTagInfo(info);
+            applyAutoTagStatus(info);
+          }
           if (info?.status === 'complete' || info?.status === 'failed') {
             if (autoTagPollRef.current) {
               clearInterval(autoTagPollRef.current);
@@ -739,6 +763,9 @@ export const PdfAuditResultsPage: React.FC = () => {
                     {auditResult.autoTagStatus === 'failed' && (
                       <Badge variant="error" className="ml-2" title={auditResult.autoTagError ?? undefined}>
                         Auto-tag failed
+                        {auditResult.autoTagError && (
+                          <span className="sr-only"> — {auditResult.autoTagError}</span>
+                        )}
                       </Badge>
                     )}
                   </p>


### PR DESCRIPTION
## Summary
Follow-ups from #288:
- The header auto-tag badge read `auditResult.autoTagStatus`/`taggerSource`, but the auto-tag status fetch and the retry poll only updated the separate `autoTagInfo` state — the badge never reflected a manual retry's outcome. Both call sites now merge terminal auto-tag results (`complete`/`failed`/`skipped`) into `auditResult`, skipping `'processing'` so the badge holds its prior state instead of flickering away mid-retry (the stats card already shows a dedicated in-progress indicator).
- The "Auto-tag failed" badge exposed its error only via a `title` tooltip, which isn't reliably announced by screen readers. Added a visually-hidden (`sr-only`) text node with the error message alongside it.

## Test plan
- [x] `npm run type-check`
- [x] `npm run lint`
- [ ] Force an Adobe auto-tag failure, confirm "Auto-tag failed" badge shows, click retry via PdfStatsCards, confirm the header badge flips to "Auto-tagged: Adobe AutoTag" once the poll reports complete
- [ ] Confirm the error text is present in the DOM (not just the `title` attribute) via browser inspector / accessibility tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Audit results now accurately reflect completed or failed auto-tagging attempts, including status, source, and error details.
  * Previous status badges remain visible while auto-tagging is still processing.
  * Improved reliability when checking initial and retry status updates.
  * Added accessible screen-reader details for auto-tagging failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->