### PR TITLE
fix(pdf): stop infinite auto-tag status polling loop (regression from #289)

### DIFF
--- a/src/pages/PdfAuditResultsPage.test.tsx
+++ b/src/pages/PdfAuditResultsPage.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach, type Mocked } from 'vitest';
-import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, cleanup, act } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import userEvent from '@testing-library/user-event';
@@ -677,6 +677,112 @@ describe('PdfAuditResultsPage', () => {
       await waitFor(() => {
         const scoreElement = screen.getByText('45');
         expect(scoreElement).toHaveClass('text-red-600');
+      });
+    });
+  });
+
+  describe('Auto-tag status sync', () => {
+    const jobId = 'job-123';
+    const auditUrl = `/pdf/job/${jobId}/audit/result`;
+    const statusUrl = `/pdf/${jobId}/auto-tag/status`;
+    const aiUrl = `/pdf/${jobId}/ai-analysis`;
+    const emptyAiResponse = { data: { data: { suggestions: [], analyzed: 0, total: 0, status: 'complete' } } };
+
+    it('fetches auto-tag status exactly once per job (regression: applyAutoTagStatus must not re-trigger its own effect)', async () => {
+      const mockResult = createMockAuditResult();
+
+      mockApi.get.mockImplementation((url: string) => {
+        if (url === auditUrl) return Promise.resolve({ data: { data: mockResult } });
+        if (url === statusUrl) return Promise.resolve({ data: { data: { status: 'complete', taggerSource: 'adobe' } } });
+        if (url === aiUrl) return Promise.resolve(emptyAiResponse);
+        return Promise.resolve({ data: { data: {} } });
+      });
+
+      renderWithRouter(jobId);
+
+      await waitFor(() => {
+        expect(screen.getByText('test-document.pdf')).toBeInTheDocument();
+      });
+
+      // applyAutoTagStatus writes a new auditResult object into state on a
+      // terminal status, and the effect that fetches auto-tag status lists
+      // auditResult as a dependency — without the ref guard this refires
+      // forever. Give any runaway loop room to spin before asserting.
+      await waitFor(() => {
+        expect(mockApi.get.mock.calls.some(([url]) => url === statusUrl)).toBe(true);
+      });
+      await new Promise(resolve => setTimeout(resolve, 300));
+
+      const statusCalls = mockApi.get.mock.calls.filter(([url]) => url === statusUrl);
+      expect(statusCalls).toHaveLength(1);
+    });
+
+    it('shows the tagger-source badge once the auto-tag status resolves', async () => {
+      const mockResult = createMockAuditResult();
+
+      mockApi.get.mockImplementation((url: string) => {
+        if (url === auditUrl) return Promise.resolve({ data: { data: mockResult } });
+        if (url === statusUrl) return Promise.resolve({ data: { data: { status: 'complete', taggerSource: 'seam-c' } } });
+        if (url === aiUrl) return Promise.resolve(emptyAiResponse);
+        return Promise.resolve({ data: { data: {} } });
+      });
+
+      renderWithRouter(jobId);
+
+      await waitFor(() => {
+        expect(screen.getByText(/Auto-tagged: Seam-C \(YOLO\)/)).toBeInTheDocument();
+      });
+    });
+
+    it('retry still polls the status endpoint and updates the header badge on completion', async () => {
+      const mockResult = createMockAuditResult({
+        autoTagStatus: 'failed',
+        autoTagError: 'Adobe API timeout',
+        taggerSource: null,
+      });
+
+      let statusCallCount = 0;
+      mockApi.get.mockImplementation((url: string) => {
+        if (url === auditUrl) return Promise.resolve({ data: { data: mockResult } });
+        if (url === statusUrl) {
+          statusCallCount += 1;
+          if (statusCallCount === 1) {
+            return Promise.resolve({ data: { data: { status: 'failed', error: 'Adobe API timeout' } } });
+          }
+          if (statusCallCount === 2) {
+            return Promise.resolve({ data: { data: { status: 'processing' } } });
+          }
+          return Promise.resolve({ data: { data: { status: 'complete', taggerSource: 'adobe' } } });
+        }
+        if (url === aiUrl) return Promise.resolve(emptyAiResponse);
+        return Promise.resolve({ data: { data: {} } });
+      });
+      mockApi.post.mockResolvedValue({ data: { data: {} } });
+
+      renderWithRouter(jobId);
+
+      await waitFor(() => {
+        expect(screen.getByText('Auto-tag failed')).toBeInTheDocument();
+      });
+
+      const retryButton = await screen.findByRole('button', { name: /^retry$/i });
+
+      vi.useFakeTimers();
+      try {
+        await act(async () => {
+          fireEvent.click(retryButton);
+          // Retry POST kicks off; the poll interval (5s) runs until terminal.
+          await vi.advanceTimersByTimeAsync(5000); // -> 'processing'
+          await vi.advanceTimersByTimeAsync(5000); // -> 'complete'
+        });
+
+        expect(statusCallCount).toBeGreaterThanOrEqual(3);
+      } finally {
+        vi.useRealTimers();
+      }
+
+      await waitFor(() => {
+        expect(screen.getByText(/Auto-tagged: Adobe AutoTag/)).toBeInTheDocument();
       });
     });
   });

--- a/src/pages/PdfAuditResultsPage.tsx
+++ b/src/pages/PdfAuditResultsPage.tsx
@@ -155,6 +155,7 @@ export const PdfAuditResultsPage: React.FC = () => {
   } | null>(null);
   const aiPollingRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const autoTagPollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const autoTagFetchedJobRef = useRef<string | null>(null);
 
   // Auto-tag status state
   const [autoTagInfo, setAutoTagInfo] = useState<{
@@ -529,7 +530,8 @@ export const PdfAuditResultsPage: React.FC = () => {
 
   // Fetch auto-tag status after audit result loads
   useEffect(() => {
-    if (!jobId || !auditResult) return;
+    if (!jobId || !auditResult || autoTagFetchedJobRef.current === jobId) return;
+    autoTagFetchedJobRef.current = jobId;
     api.get(`/pdf/${encodeURIComponent(jobId)}/auto-tag/status`)
       .then(res => {
         if (!isMountedRef.current) return;
@@ -537,7 +539,9 @@ export const PdfAuditResultsPage: React.FC = () => {
         setAutoTagInfo(info);
         applyAutoTagStatus(info);
       })
-      .catch(() => {});
+      .catch(() => {
+        autoTagFetchedJobRef.current = null; // allow retry if the fetch itself failed
+      });
   }, [jobId, auditResult, applyAutoTagStatus]);
 
   const handleRetryAutoTag = async () => {


### PR DESCRIPTION
## Summary
Hotfix — actively affecting staging right now (reported on job `Y_eqWwrDRGVRAJiw7JOqR`, likely others).

PR #289 added `applyAutoTagStatus`, which writes a fresh `auditResult` object into state on every terminal auto-tag outcome. The "fetch auto-tag status" effect lists `auditResult` as a dependency, so each fetch retriggered the effect, hammering `GET /pdf/:jobId/auto-tag/status` (and, since it happens to run alongside, `GET /pdf/:jobId/ai-analysis`) indefinitely.

Fix: a ref guard (`autoTagFetchedJobRef`) so the fetch only runs once per `jobId`, resetting on fetch failure so a retry is still possible. `handleRetryAutoTag`'s own 5s polling interval is untouched.

## Verification
Not just trusted the diff — added regression tests in `PdfAuditResultsPage.test.tsx` and confirmed both directions:
- **Without** the ref guard (temporarily stashed the source fix, kept the test): the new test reproduces **173 calls** to `/auto-tag/status` in a 300ms window — the actual "hammering" behavior described in the bug.
- **With** the fix: exactly 1 call.
- Also added a fake-timer test confirming `handleRetryAutoTag`'s 5s poll still fires correctly on retry and the header badge updates to the terminal result — that path is unmodified by this fix.

I don't have interactive browser/staging access in this environment, so I could not do the literal DevTools → Network manual check against job `Y_eqWwrDRGVRAJiw7JOqR` — the automated regression test above is the verification for this PR.

## Test plan
- [x] `npm run type-check`
- [x] `npm run lint`
- [x] `npx vitest run src/pages/PdfAuditResultsPage.test.tsx` (19 passed, 10 pre-existing skips, 0 failed)
- [x] Confirmed new tests fail without the fix and pass with it

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved auto-tag status updates by preventing duplicate status requests for the same job.
  * Added automatic retry support when a status request fails.
  * Preserved successful status results while processing the current job.
  * Improved display of the tagger source badge.

* **Tests**
  * Added coverage for status polling, retry behavior, successful completion, and tagger-source display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->