### PR TITLE
fix(pdf): reflect actual auto-tagger in the Auto Tag stats card

### DIFF
--- a/src/components/pdf/PdfStatsCards.tsx
+++ b/src/components/pdf/PdfStatsCards.tsx
@@ -52,6 +52,7 @@ function isMatterhorn(issue: AugIssue): boolean {
 
 export interface AutoTagInfo {
   status?: string;
+  taggerSource?: 'seam-c' | 'adobe' | null;
   hasTaggingReport?: boolean;
   hasWordExport?: boolean;
   elementCounts?: Record<string, number> | null;
@@ -271,7 +272,9 @@ export function PdfStatsCards({
 
   const autoTagSummary = atStatus === 'complete' ? (
     <>
-      <span className="text-xs font-medium text-green-700">✓ Adobe</span>
+      <span className="text-xs font-medium text-green-700">
+        ✓ {autoTagInfo?.taggerSource === 'seam-c' ? 'Seam-C (YOLO)' : 'Adobe'}
+      </span>
       {elems && (
         <>
           <SummaryMetric n={elems.figures ?? 0} label="Fig" />
@@ -321,7 +324,7 @@ export function PdfStatsCards({
       {atStatus === 'processing' && (
         <div className="flex items-center gap-2 text-xs text-blue-700">
           <Loader2 className="h-3.5 w-3.5 animate-spin" />
-          Auto-tagging with Adobe…
+          Auto-tagging…
         </div>
       )}
       {(autoTagInfo?.hasTaggingReport || autoTagInfo?.hasWordExport) && (


### PR DESCRIPTION
## Summary
The "Auto Tag" stats card on the PDF audit results page always showed "✓ Adobe" on completion and "Auto-tagging with Adobe…" while processing, regardless of which tagger actually ran. The header badge (from #288/#289) already used `taggerSource` correctly — this card was never updated to match.

- Added `taggerSource` to the `AutoTagInfo` interface.
- Completion label now shows "Seam-C (YOLO)" or "Adobe" based on `taggerSource`.
- Processing-state text genericized to "Auto-tagging…" — Seam-C runs first on the initial attempt and `taggerSource` isn't known until completion, so naming a specific tagger while in progress would be misleading.

Note: Seam-C's `elementCounts` currently comes back `null` (its result shape doesn't compute the Fig/Tab/Head/Para breakdown Adobe does), so a Seam-C-tagged doc will correctly show "✓ Seam-C (YOLO)" without element metrics next to it. That's expected given current data, not a regression from this change — left as-is per the task scope.

## Test plan
- [x] `npm run type-check`
- [x] `npm run lint`
- [x] `npx vitest run src/pages/PdfAuditResultsPage.test.tsx` (19 passed, 10 pre-existing skips)
- [ ] Upload an untagged PDF (Seam-C tags it), confirm the Auto Tag card says "✓ Seam-C (YOLO)"
- [ ] Trigger a manual retry (Adobe-only), confirm "Auto-tagging…" while running and "✓ Adobe" once complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)