### PR TITLE
feat(pdf): show tagged-category stats for both auto-taggers

### DIFF
--- a/src/components/pdf/PdfStatsCards.tsx
+++ b/src/components/pdf/PdfStatsCards.tsx
@@ -38,6 +38,34 @@ const MATTERHORN_PREFIXES = [
   'PDF-LOW-CONTRAST', 'PDF-UNTAGGED', 'PDF-NO-LANGUAGE',
 ];
 
+// ─── Auto-tag element count labels (Adobe's shape + Seam-C's 11 canonical zone types) ─
+
+const ELEMENT_LABELS: Record<string, { short: string; full: string }> = {
+  // Adobe's shape
+  figures: { short: 'Fig', full: 'Figures' },
+  tables: { short: 'Tab', full: 'Tables' },
+  headings: { short: 'Head', full: 'Headings' },
+  paragraphs: { short: 'Para', full: 'Paragraphs' },
+  // Seam-C's 11 canonical zone types
+  paragraph: { short: 'Para', full: 'Paragraphs' },
+  'section-header': { short: 'Head', full: 'Headings' },
+  table: { short: 'Tab', full: 'Tables' },
+  figure: { short: 'Fig', full: 'Figures' },
+  caption: { short: 'Cap', full: 'Captions' },
+  footnote: { short: 'Fn', full: 'Footnotes' },
+  header: { short: 'PgHd', full: 'Page Headers' },
+  footer: { short: 'PgFt', full: 'Page Footers' },
+  'list-item': { short: 'List', full: 'List Items' },
+  toci: { short: 'TOC', full: 'TOC Entries' },
+  formula: { short: 'Form', full: 'Formulas' },
+};
+
+function elementLabel(key: string, variant: 'short' | 'full'): string {
+  const entry = ELEMENT_LABELS[key];
+  if (entry) return entry[variant];
+  return key.replace(/[-_]/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
 type AugIssue = PdfAuditIssue & { category?: string; code?: string };
 
 function isMatterhorn(issue: AugIssue): boolean {
@@ -261,6 +289,9 @@ export function PdfStatsCards({
 
   const atStatus = autoTagInfo?.status;
   const elems = autoTagInfo?.elementCounts;
+  const elemEntries = elems
+    ? Object.entries(elems).filter(([, n]) => n > 0).sort(([, a], [, b]) => b - a)
+    : [];
 
   const autoTagIcon = atStatus === 'complete'
     ? <CheckCircle className="h-4 w-4 text-green-600" />
@@ -275,14 +306,9 @@ export function PdfStatsCards({
       <span className="text-xs font-medium text-green-700">
         ✓ {autoTagInfo?.taggerSource === 'seam-c' ? 'Seam-C (YOLO)' : 'Adobe'}
       </span>
-      {elems && (
-        <>
-          <SummaryMetric n={elems.figures ?? 0} label="Fig" />
-          <SummaryMetric n={elems.tables ?? 0} label="Tab" />
-          <SummaryMetric n={elems.headings ?? 0} label="Head" />
-          <SummaryMetric n={elems.paragraphs ?? 0} label="Para" />
-        </>
-      )}
+      {elemEntries.slice(0, 4).map(([key, n]) => (
+        <SummaryMetric key={key} n={n} label={elementLabel(key, 'short')} />
+      ))}
     </>
   ) : atStatus === 'failed' ? (
     <span className="text-xs text-amber-700 font-medium">Auto-tagging failed</span>
@@ -294,12 +320,11 @@ export function PdfStatsCards({
 
   const autoTagDetail = (
     <>
-      {atStatus === 'complete' && elems && (
+      {atStatus === 'complete' && elemEntries.length > 0 && (
         <div className="space-y-1">
-          <DetailRow label="Figures" value={elems.figures ?? 0} />
-          <DetailRow label="Tables" value={elems.tables ?? 0} />
-          <DetailRow label="Headings" value={elems.headings ?? 0} />
-          <DetailRow label="Paragraphs" value={elems.paragraphs ?? 0} />
+          {elemEntries.map(([key, n]) => (
+            <DetailRow key={key} label={elementLabel(key, 'full')} value={n} />
+          ))}
         </div>
       )}
       {autoTagInfo?.adobeFlags && autoTagInfo.adobeFlags.length > 0 && (


### PR DESCRIPTION
## Summary
Backend PR #453 (ninja-backend, merged & deployed to staging) makes Seam-C populate `elementCounts` for real — previously always `null`. It's keyed by the detector's 11 canonical zone types (`paragraph`, `section-header`, `table`, `figure`, `caption`, `footnote`, `header`, `footer`, `list-item`, `toci`, `formula`), a different, larger vocabulary than Adobe's fixed `{figures, tables, headings, paragraphs}` shape.

The Auto Tag stats card previously hardcoded Adobe's 4 keys. It now renders whatever keys are actually present:
- A label map covers both vocabularies, with a title-cased fallback for anything unmapped.
- The compact summary row shows the top 4 categories by count (capped so it doesn't overflow — Seam-C can have up to 11 non-zero categories).
- The expanded detail view shows the full breakdown, uncapped.

Stacked on #291 (header badge "Adobe"/"Seam-C" fix, already merged) — this is the matching fix for the stats card, which was never updated to match.

## Test plan
- [x] `npm run type-check`
- [x] `npm run lint`
- [x] `npx vitest run src/pages/PdfAuditResultsPage.test.tsx` (19 passed, 10 pre-existing skips)
- [ ] Upload an untagged PDF (Seam-C path), confirm compact row shows up to 4 categories and expanded view shows the full breakdown
- [ ] Re-verify an Adobe-tagged doc still shows its original 4 metrics correctly (regression check — same code path now handles both shapes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Auto-tag summaries now display all detected nonzero element types.
  * Added support for Adobe and Seam-C element labels.
  * Element types are sorted by count for easier review.
  * Unknown element types now receive a readable fallback label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->