### PR TITLE
feat(pdf): add bulk Apply All Approved action for AI suggestions

### DIFF
--- a/src/components/remediation/ApplyAllSuggestionsPanel.test.tsx
+++ b/src/components/remediation/ApplyAllSuggestionsPanel.test.tsx
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ApplyAllSuggestionsPanel } from './ApplyAllSuggestionsPanel';
+import { applyAllAiSuggestions } from '@/services/api/pdfAiAnalysis.service';
+
+vi.mock('@/services/api/pdfAiAnalysis.service');
+
+function renderPanel(props?: Partial<React.ComponentProps<typeof ApplyAllSuggestionsPanel>>) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const onApplied = vi.fn();
+  const onClose = vi.fn();
+  const utils = render(
+    <QueryClientProvider client={queryClient}>
+      <ApplyAllSuggestionsPanel
+        jobId="job-123"
+        eligibleCount={3}
+        pendingEligibleCount={0}
+        onApplied={onApplied}
+        onClose={onClose}
+        {...props}
+      />
+    </QueryClientProvider>
+  );
+  return { ...utils, onApplied, onClose };
+}
+
+describe('ApplyAllSuggestionsPanel', () => {
+  const mockApplyAll = vi.mocked(applyAllAiSuggestions);
+
+  beforeEach(() => {
+    mockApplyAll.mockReset();
+  });
+
+  it('shows the eligible count and no pending toggle when nothing is pending', () => {
+    renderPanel({ eligibleCount: 3, pendingEligibleCount: 0 });
+
+    expect(screen.getByText(/Apply 3 approved suggestions to the PDF/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Apply All \(3\)/ })).toBeInTheDocument();
+    expect(screen.queryByRole('checkbox')).not.toBeInTheDocument();
+  });
+
+  it('shows an unchecked include-pending toggle when there are pending-eligible suggestions', () => {
+    renderPanel({ eligibleCount: 3, pendingEligibleCount: 2 });
+
+    const checkbox = screen.getByRole('checkbox', { name: /Also include 2 suggestions awaiting review/ });
+    expect(checkbox).toHaveAttribute('aria-checked', 'false');
+    expect(screen.getByRole('button', { name: /Apply All \(3\)/ })).toBeInTheDocument();
+  });
+
+  it('applies approved-only by default, without includePending', async () => {
+    mockApplyAll.mockResolvedValue({ applied: 3, failed: 0 });
+    const { onApplied } = renderPanel({ eligibleCount: 3, pendingEligibleCount: 2 });
+
+    fireEvent.click(screen.getByRole('button', { name: /Apply All \(3\)/ }));
+
+    await waitFor(() => {
+      expect(mockApplyAll).toHaveBeenCalledWith('job-123', false);
+    });
+    // Refetch/poll trigger fires immediately on success, before results render.
+    await waitFor(() => expect(onApplied).toHaveBeenCalledTimes(1));
+  });
+
+  it('includes pending suggestions only when the toggle is checked', async () => {
+    mockApplyAll.mockResolvedValue({ applied: 5, failed: 0 });
+    renderPanel({ eligibleCount: 3, pendingEligibleCount: 2 });
+
+    fireEvent.click(screen.getByRole('checkbox', { name: /Also include 2 suggestions awaiting review/ }));
+    expect(screen.getByRole('button', { name: /Apply All \(5\)/ })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /Apply All \(5\)/ }));
+
+    await waitFor(() => {
+      expect(mockApplyAll).toHaveBeenCalledWith('job-123', true);
+    });
+  });
+
+  it('shows aggregate results with per-issue failure reasons, not a reconstructed issue list', async () => {
+    mockApplyAll.mockResolvedValue({
+      applied: 2,
+      failed: 1,
+      errors: [{ issueId: 'issue-abcdefgh', suggestionType: 'alt-text', reason: 'PDF page locked' }],
+    });
+    renderPanel({ eligibleCount: 3, pendingEligibleCount: 0 });
+
+    fireEvent.click(screen.getByRole('button', { name: /Apply All \(3\)/ }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Successfully applied 2 suggestions')).toBeInTheDocument();
+    });
+    expect(screen.getByText('1 suggestion failed')).toBeInTheDocument();
+    expect(screen.getByText(/alt-text — issue-ab/)).toBeInTheDocument();
+    expect(screen.getByText('PDF page locked')).toBeInTheDocument();
+  });
+
+  it('cancelling before applying closes the panel without calling the API', () => {
+    const { onClose } = renderPanel();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(mockApplyAll).not.toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/remediation/ApplyAllSuggestionsPanel.tsx
+++ b/src/components/remediation/ApplyAllSuggestionsPanel.tsx
@@ -1,0 +1,227 @@
+import { useState, useEffect, useRef } from 'react';
+import { useMutation } from '@tanstack/react-query';
+import { Zap, CheckCircle, XCircle, Loader2 } from 'lucide-react';
+import { Checkbox } from '@/components/ui/Checkbox';
+import { applyAllAiSuggestions, ApplyAllAiSuggestionsResult } from '@/services/api/pdfAiAnalysis.service';
+
+interface ApplyAllSuggestionsPanelProps {
+  jobId: string;
+  /** Count of approved, apply-to-pdf-eligible suggestions — the safe default scope. */
+  eligibleCount: number;
+  /** Count of still-pending (not yet reviewed) apply-to-pdf-eligible suggestions. */
+  pendingEligibleCount: number;
+  /**
+   * Fires once immediately after a successful apply-all response, before the
+   * results screen is shown. The response only carries aggregate counts, so
+   * the caller should refetch the full suggestion list here rather than have
+   * this panel try to reconstruct per-issue state.
+   */
+  onApplied: () => void;
+  /** Dismiss the panel — via Cancel before applying, or Done/auto-close after. */
+  onClose: () => void;
+}
+
+function ResultsView({
+  results,
+  onClose,
+}: {
+  results: ApplyAllAiSuggestionsResult;
+  onClose: () => void;
+}) {
+  const failedCount = results.failed;
+  const errors = results.errors ?? [];
+
+  const initialCountdown = failedCount > 0 ? 10 : 3;
+  const [countdown, setCountdown] = useState(initialCountdown);
+  const [isPaused, setIsPaused] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  useEffect(() => {
+    if (isPaused) return;
+
+    timerRef.current = setInterval(() => {
+      setCountdown((prev) => {
+        if (prev <= 1) {
+          if (timerRef.current) clearInterval(timerRef.current);
+          onClose();
+          return 0;
+        }
+        return prev - 1;
+      });
+    }, 1000);
+
+    return () => {
+      if (timerRef.current) clearInterval(timerRef.current);
+    };
+  }, [onClose, isPaused]);
+
+  const handlePauseTimer = () => {
+    setIsPaused(true);
+    if (timerRef.current) {
+      clearInterval(timerRef.current);
+      timerRef.current = null;
+    }
+  };
+
+  return (
+    <div className="p-6">
+      <h3 className="text-xl font-bold mb-4">Apply All Results</h3>
+
+      <div className="space-y-4 mb-6">
+        {results.applied > 0 && (
+          <div className="flex items-center gap-2 p-4 bg-green-50 border border-green-200 rounded-lg">
+            <CheckCircle size={24} className="text-green-600" />
+            <div className="flex-1">
+              <div className="font-semibold text-green-800">
+                Successfully applied {results.applied} {results.applied === 1 ? 'suggestion' : 'suggestions'}
+              </div>
+              {!isPaused && (
+                <div className="text-sm text-green-700 mt-1">
+                  Closing in {countdown} second{countdown !== 1 ? 's' : ''}...
+                </div>
+              )}
+            </div>
+          </div>
+        )}
+
+        {failedCount > 0 && (
+          <div className="bg-red-50 border border-red-200 rounded-lg p-4">
+            <div className="flex items-center gap-2 mb-3">
+              <XCircle size={20} className="text-red-600" />
+              <span className="font-semibold text-red-800">
+                {failedCount} {failedCount === 1 ? 'suggestion' : 'suggestions'} failed
+              </span>
+            </div>
+            {errors.length > 0 && (
+              <ul className="text-sm text-red-700 space-y-2 ml-7">
+                {errors.map((err, idx) => (
+                  <li key={`${err.issueId}-${idx}`} className="border-l-2 border-red-300 pl-3">
+                    <div className="font-medium">{err.suggestionType} — {err.issueId.substring(0, 8)}...</div>
+                    <div className="text-xs text-red-600">{err.reason}</div>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        )}
+      </div>
+
+      <div className="flex gap-2">
+        {!isPaused && (
+          <button
+            onClick={handlePauseTimer}
+            className="flex-1 px-4 py-3 border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50 font-medium"
+          >
+            Cancel Auto-close
+          </button>
+        )}
+        <button
+          onClick={onClose}
+          className={`${isPaused ? 'w-full' : 'flex-1'} px-4 py-3 bg-blue-500 text-white rounded-lg hover:bg-blue-600 font-semibold`}
+        >
+          Done
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export function ApplyAllSuggestionsPanel({
+  jobId,
+  eligibleCount,
+  pendingEligibleCount,
+  onApplied,
+  onClose,
+}: ApplyAllSuggestionsPanelProps) {
+  const [includePending, setIncludePending] = useState(false);
+
+  const applyAllMutation = useMutation({
+    mutationFn: () => applyAllAiSuggestions(jobId, includePending),
+    onSuccess: () => {
+      // Aggregate counts only — refetch the real suggestion list rather than
+      // guessing which issues succeeded from this response.
+      onApplied();
+    },
+  });
+
+  if (applyAllMutation.data) {
+    return <ResultsView results={applyAllMutation.data} onClose={onClose} />;
+  }
+
+  const totalToApply = eligibleCount + (includePending ? pendingEligibleCount : 0);
+
+  return (
+    <div className="p-6">
+      <div className="flex items-center gap-3 mb-4">
+        <div className="p-2 bg-green-100 rounded">
+          <Zap className="text-green-600" size={24} aria-hidden="true" />
+        </div>
+        <div>
+          <h3 className="text-lg font-semibold">Apply All Approved</h3>
+          <p className="text-sm text-gray-600">
+            Apply {eligibleCount} approved {eligibleCount === 1 ? 'suggestion' : 'suggestions'} to the PDF
+          </p>
+        </div>
+      </div>
+
+      <div className="bg-green-50 border border-green-200 rounded p-3 mb-4">
+        <p className="text-sm text-green-800">
+          All {eligibleCount} approved {eligibleCount === 1 ? 'fix' : 'fixes'} will be applied automatically.
+          This also kicks off a post-fix validation audit to confirm what was resolved.
+        </p>
+      </div>
+
+      {pendingEligibleCount > 0 && (
+        <label className="flex items-start gap-2 mb-6 cursor-pointer select-none">
+          <span className="mt-0.5">
+            <Checkbox
+              checked={includePending}
+              onChange={setIncludePending}
+              aria-label={`Also include ${pendingEligibleCount} suggestions awaiting review`}
+            />
+          </span>
+          <span className="text-xs text-gray-500">
+            Also include {pendingEligibleCount} {pendingEligibleCount === 1 ? 'suggestion' : 'suggestions'} awaiting review
+            <span className="block text-gray-400">Skips the pending-review step for those suggestions.</span>
+          </span>
+        </label>
+      )}
+
+      <div className="flex gap-3">
+        <button
+          onClick={() => applyAllMutation.mutate()}
+          disabled={applyAllMutation.isPending || totalToApply === 0}
+          className="flex-1 flex items-center justify-center gap-2 px-4 py-3 bg-green-500 text-white rounded-lg hover:bg-green-600 disabled:opacity-50 disabled:cursor-not-allowed font-semibold"
+        >
+          {applyAllMutation.isPending ? (
+            <>
+              <Loader2 className="animate-spin" size={20} aria-hidden="true" />
+              Applying {totalToApply} {totalToApply === 1 ? 'fix' : 'fixes'}...
+            </>
+          ) : (
+            <>
+              <Zap size={20} aria-hidden="true" />
+              Apply All ({totalToApply})
+            </>
+          )}
+        </button>
+
+        <button
+          onClick={onClose}
+          disabled={applyAllMutation.isPending}
+          className="px-4 py-2 border border-gray-300 rounded-lg hover:bg-gray-50 disabled:opacity-50"
+        >
+          Cancel
+        </button>
+      </div>
+
+      {applyAllMutation.isError && (
+        <div className="mt-4 bg-red-50 border border-red-200 rounded p-3">
+          <p className="text-sm text-red-800">
+            Failed to apply suggestions: {(applyAllMutation.error as Error)?.message || 'Unknown error'}
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/remediation/index.ts
+++ b/src/components/remediation/index.ts
@@ -15,6 +15,7 @@ export { CodePreview } from './CodePreview';
 export { RemediationTaskCard } from './RemediationTaskCard';
 export { RemediationSessionView } from './RemediationSessionView';
 export { BatchQuickFixPanel } from './BatchQuickFixPanel';
+export { ApplyAllSuggestionsPanel } from './ApplyAllSuggestionsPanel';
 export { IssueCard, AutoFixSummary } from './IssueCard';
 export { AuditCoverageDisplay } from './AuditCoverageDisplay';
 export { IssuesList } from './IssuesList';

--- a/src/pages/PdfAuditResultsPage.test.tsx
+++ b/src/pages/PdfAuditResultsPage.test.tsx
@@ -786,4 +786,76 @@ describe('PdfAuditResultsPage', () => {
       });
     });
   });
+
+  describe('Apply All Approved bulk action', () => {
+    const jobId = 'job-123';
+    const auditUrl = `/pdf/job/${jobId}/audit/result`;
+    const statusUrl = `/pdf/${jobId}/auto-tag/status`;
+    const aiUrl = `/pdf/${jobId}/ai-analysis`;
+
+    const mockAiResponse = (suggestions: Array<{ issueId: string; applyMode: string; status: string }>) => ({
+      data: {
+        data: {
+          suggestions: suggestions.map((s, i) => ({
+            id: `sugg-${i}`,
+            jobId,
+            issueId: s.issueId,
+            suggestionType: 'alt-text',
+            value: 'A description',
+            guidance: null,
+            confidence: 0.9,
+            rationale: 'because',
+            model: 'gemini',
+            applyMode: s.applyMode,
+            status: s.status,
+            createdAt: '2024-01-15T10:00:00Z',
+            updatedAt: '2024-01-15T10:00:00Z',
+          })),
+          analyzed: suggestions.length,
+          total: suggestions.length,
+          status: 'complete',
+        },
+      },
+    });
+
+    it('only counts approved, apply-to-pdf suggestions toward the bulk-apply button', async () => {
+      const mockResult = createMockAuditResult();
+
+      mockApi.get.mockImplementation((url: string) => {
+        if (url === auditUrl) return Promise.resolve({ data: { data: mockResult } });
+        if (url === statusUrl) return Promise.resolve({ data: { data: { status: 'complete', taggerSource: 'adobe' } } });
+        if (url === aiUrl) return Promise.resolve(mockAiResponse([
+          { issueId: '1', applyMode: 'apply-to-pdf', status: 'approved' },
+          { issueId: '2', applyMode: 'apply-to-pdf', status: 'approved' },
+          { issueId: '3', applyMode: 'apply-to-pdf', status: 'pending' },
+          { issueId: '4', applyMode: 'guidance-only', status: 'approved' },
+        ]));
+        return Promise.resolve({ data: { data: {} } });
+      });
+
+      renderWithRouter(jobId);
+
+      expect(await screen.findByRole('button', { name: /Apply All Approved \(2\)/ })).toBeInTheDocument();
+    });
+
+    it('hides the bulk-apply button when there are no approved apply-to-pdf suggestions', async () => {
+      const mockResult = createMockAuditResult();
+
+      mockApi.get.mockImplementation((url: string) => {
+        if (url === auditUrl) return Promise.resolve({ data: { data: mockResult } });
+        if (url === statusUrl) return Promise.resolve({ data: { data: { status: 'complete', taggerSource: 'adobe' } } });
+        if (url === aiUrl) return Promise.resolve(mockAiResponse([
+          { issueId: '1', applyMode: 'apply-to-pdf', status: 'pending' },
+        ]));
+        return Promise.resolve({ data: { data: {} } });
+      });
+
+      renderWithRouter(jobId);
+
+      await waitFor(() => {
+        expect(screen.getByText('test-document.pdf')).toBeInTheDocument();
+      });
+      expect(screen.queryByRole('button', { name: /Apply All Approved/ })).not.toBeInTheDocument();
+    });
+  });
 });

--- a/src/pages/PdfAuditResultsPage.tsx
+++ b/src/pages/PdfAuditResultsPage.tsx
@@ -23,19 +23,21 @@
 
 import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
-import { FileText, Loader2, Download, Share2, RotateCw, Filter, X, ChevronDown, ListChecks, Maximize2, Minimize2 } from 'lucide-react';
+import { FileText, Loader2, Download, Share2, RotateCw, Filter, X, ChevronDown, ListChecks, Maximize2, Minimize2, Zap } from 'lucide-react';
 import toast from 'react-hot-toast';
 import { Card, CardContent } from '@/components/ui/Card';
 import { Alert } from '@/components/ui/Alert';
 import { Badge } from '@/components/ui/Badge';
 import { Button } from '@/components/ui/Button';
 import { Breadcrumbs } from '@/components/ui/Breadcrumbs';
+import { Dialog, DialogContent } from '@/components/ui/Dialog';
 import { MatterhornSummary } from '@/components/pdf/MatterhornSummary';
 import { PacReportModal } from '@/components/pdf/PacReportModal';
 import { PdfPageNavigator } from '@/components/pdf/PdfPageNavigator';
 import { PdfPreviewPanel } from '@/components/pdf/PdfPreviewPanel';
 import { PdfStatsCards } from '@/components/pdf/PdfStatsCards';
 import { IssueCard, AiAnalysis } from '@/components/remediation/IssueCard';
+import { ApplyAllSuggestionsPanel } from '@/components/remediation/ApplyAllSuggestionsPanel';
 import { api } from '@/services/api';
 
 /**
@@ -169,6 +171,20 @@ export const PdfAuditResultsPage: React.FC = () => {
   } | null>(null);
   const [isRetryingAutoTag, setIsRetryingAutoTag] = useState(false);
   const [showPacReport, setShowPacReport] = useState(false);
+  const [showApplyAllPanel, setShowApplyAllPanel] = useState(false);
+
+  // Counts driving the "Apply All Approved" bulk action — only apply-to-pdf
+  // suggestions are eligible; guidance-only/auto-resolve ones have nothing to apply.
+  const eligibleForApplyAll = useMemo(
+    () => Array.from(aiSuggestions.values())
+      .filter(s => s.applyMode === 'apply-to-pdf' && s.status === 'approved').length,
+    [aiSuggestions]
+  );
+  const pendingEligible = useMemo(
+    () => Array.from(aiSuggestions.values())
+      .filter(s => s.applyMode === 'apply-to-pdf' && s.status === 'pending').length,
+    [aiSuggestions]
+  );
 
   // Fetch audit result
   const fetchAuditResult = useCallback(async () => {
@@ -583,6 +599,42 @@ export const PdfAuditResultsPage: React.FC = () => {
     }
   };
 
+  // Apply-all kicks off an automatic post-fix validation audit server-side.
+  // Reflect that immediately so the existing "Validating…" state (Generate ACR
+  // button, PdfStatsCards post-fix validation card) shows right away, then poll
+  // until the backend reports a terminal outcome.
+  const pollPostRemediationStatus = useCallback(() => {
+    if (!jobId) return;
+    if (autoTagPollRef.current) clearInterval(autoTagPollRef.current);
+    setAutoTagInfo(prev => prev ? { ...prev, postRemediationStatus: 'pending' } : prev);
+    autoTagPollRef.current = setInterval(async () => {
+      try {
+        const res = await api.get(`/pdf/${encodeURIComponent(jobId)}/auto-tag/status`);
+        const info = res.data.data;
+        if (isMountedRef.current) setAutoTagInfo(info);
+        if (info?.postRemediationStatus !== 'pending') {
+          if (autoTagPollRef.current) {
+            clearInterval(autoTagPollRef.current);
+            autoTagPollRef.current = null;
+          }
+        }
+      } catch {
+        if (autoTagPollRef.current) {
+          clearInterval(autoTagPollRef.current);
+          autoTagPollRef.current = null;
+        }
+      }
+    }, 5000);
+  }, [jobId]);
+
+  // After a successful bulk apply, refetch suggestions from the server instead
+  // of patching aiSuggestions locally — apply-all's response only carries
+  // aggregate counts, not which issues succeeded.
+  const handleApplyAllSuccess = useCallback(() => {
+    fetchAiSuggestions();
+    pollPostRemediationStatus();
+  }, [fetchAiSuggestions, pollPostRemediationStatus]);
+
   const handleDownloadReport = (_format: 'pdf' | 'docx' | 'json' = 'json') => {
     if (!auditResult || !jobId) return;
     const blob = new Blob([JSON.stringify(auditResult, null, 2)], { type: 'application/json' });
@@ -976,6 +1028,16 @@ export const PdfAuditResultsPage: React.FC = () => {
                 >
                   {isFullscreen ? <Minimize2 className="h-4 w-4" /> : <Maximize2 className="h-4 w-4" />}
                 </button>
+              {eligibleForApplyAll > 0 && (
+                <Button
+                  variant="primary"
+                  size="sm"
+                  onClick={() => setShowApplyAllPanel(true)}
+                >
+                  <Zap className="h-4 w-4 mr-1" />
+                  Apply All Approved ({eligibleForApplyAll})
+                </Button>
+              )}
               <Button
                 variant="outline"
                 size="sm"
@@ -1167,6 +1229,18 @@ export const PdfAuditResultsPage: React.FC = () => {
         </div>
         </div> {/* inner flex row */}
       </div>
+
+      <Dialog open={showApplyAllPanel} onOpenChange={setShowApplyAllPanel}>
+        <DialogContent className="max-w-lg">
+          <ApplyAllSuggestionsPanel
+            jobId={jobId!}
+            eligibleCount={eligibleForApplyAll}
+            pendingEligibleCount={pendingEligible}
+            onApplied={handleApplyAllSuccess}
+            onClose={() => setShowApplyAllPanel(false)}
+          />
+        </DialogContent>
+      </Dialog>
 
       <PacReportModal
         isOpen={showPacReport}

--- a/src/services/api/pdfAiAnalysis.service.ts
+++ b/src/services/api/pdfAiAnalysis.service.ts
@@ -1,0 +1,22 @@
+import { api } from '@/services/api';
+
+export interface ApplyAllAiSuggestionsResult {
+  applied: number;
+  failed: number;
+  errors?: Array<{ issueId: string; suggestionType: string; reason: string }>;
+}
+
+/**
+ * Applies all AI suggestions in bulk. Defaults to approved-only, matching the
+ * backend's default and keeping the human review step (pending → approved)
+ * meaningful — passing includePending bypasses that review entirely.
+ */
+export async function applyAllAiSuggestions(
+  jobId: string,
+  includePending = false
+): Promise<ApplyAllAiSuggestionsResult> {
+  const res = await api.post<{ data: ApplyAllAiSuggestionsResult }>(
+    `/pdf/${encodeURIComponent(jobId)}/ai-analysis/apply-all${includePending ? '?includePending=true' : ''}`
+  );
+  return res.data.data;
+}


### PR DESCRIPTION
## Summary
- New "Apply All Approved (N)" bulk action in the PDF audit Issues panel header, calling `POST /pdf/:jobId/ai-analysis/apply-all`
- Defaults to approved-only suggestions (safe default); including still-pending suggestions is a separate, unchecked-by-default opt-in since it bypasses the human review step
- On success, refetches the full suggestion list from the server instead of reconstructing per-issue state from the aggregate `{applied, failed, errors}` response (avoids reintroducing the issueId-keying bug class fixed on the single-apply path)
- Kicks off the existing post-fix validation indicator (`postRemediationStatus`/`postRemediationAudit` in `PdfStatsCards`) since apply-all triggers automatic re-verification server-side

## Test plan
- [x] `npm run type-check` passes
- [x] `npm run lint` passes
- [x] New unit tests for `ApplyAllSuggestionsPanel` (confirm/apply/results/checkbox/cancel) — 6 passing
- [x] New integration tests for button visibility/count gating on `PdfAuditResultsPage` — 2 passing
- [ ] Manual: on a job with several approved AI suggestions, click Apply All Approved, confirm the applied count matches, confirm the Issues panel reflects new applied statuses, confirm pending suggestions are untouched unless "include pending" is explicitly checked

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an “Apply All Approved” action for eligible PDF remediation suggestions.
  - Optionally include pending suggestions when applying changes in bulk.
  - Added progress, error, cancellation, and completion results with applied and failed item details.
  - Automatically refreshes suggestions and validation status after bulk remediation.
  - Added a closing countdown for completed results, which can be canceled.

- **Bug Fixes**
  - The bulk-apply action is hidden when no eligible approved suggestions are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->