### PR TITLE
feat(comparison-study): add Ninja-vs-pdfxt validation study workflow

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -92,6 +92,10 @@ import CorpusSummaryPage from '@/pages/calibration/CorpusSummaryPage';
 import AnnotatorGuideHelpPage from '@/pages/help/AnnotatorGuidePage';
 import AdminCorpusPage from '@/pages/admin/AdminCorpusPage';
 import AdminUsersPage from '@/pages/admin/AdminUsersPage';
+import ComparisonStudyConsolePage from '@/pages/comparison-study/ComparisonStudyConsolePage';
+import ComparisonTrialWorkspacePage from '@/pages/comparison-study/ComparisonTrialWorkspacePage';
+import ComparisonTrialReportPage from '@/pages/comparison-study/ComparisonTrialReportPage';
+import ComparisonAggregateReportPage from '@/pages/comparison-study/ComparisonAggregateReportPage';
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
@@ -276,6 +280,12 @@ function AppRoutes() {
           <Route path="/calibration/comparison-report/:runId" element={<ComparisonReportPage />} />
           <Route path="/calibration/annotation-guide/:runId" element={<AnnotationGuidePage />} />
           <Route path="/calibration/aggregate-report" element={<AggregateComparisonPage />} />
+
+          {/* Comparison Study Routes (Ninja vs pdfxt validation) */}
+          <Route path="/comparison-study" element={<ComparisonStudyConsolePage />} />
+          <Route path="/comparison-study/trials/:id" element={<ComparisonTrialWorkspacePage />} />
+          <Route path="/comparison-study/trials/:id/report" element={<ComparisonTrialReportPage />} />
+          <Route path="/comparison-study/aggregate-report" element={<ComparisonAggregateReportPage />} />
 
           {/* In-app help */}
           <Route path="/help/annotator-guide" element={<AnnotatorGuideHelpPage />} />

--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -28,6 +28,7 @@ import {
   HelpCircle,
   ChevronLeft,
   ChevronRight,
+  GitCompare,
 } from 'lucide-react';
 
 type NavItem = {
@@ -106,6 +107,7 @@ export function MainLayout() {
         { to: '/admin/corpus', icon: Database, label: 'Corpus Management', activePrefix: '/admin/corpus' },
         { to: '/admin/users', icon: Users, label: 'User Management', activePrefix: '/admin/users' },
         { to: '/bootstrap', icon: Shield, label: 'Bootstrap Console', activePrefix: '/bootstrap' },
+        { to: '/comparison-study', icon: GitCompare, label: 'Comparison Study', activePrefix: '/comparison-study' },
       ],
     },
     {

--- a/src/components/remediation/ApplyAllSuggestionsPanel.tsx
+++ b/src/components/remediation/ApplyAllSuggestionsPanel.tsx
@@ -16,7 +16,7 @@ interface ApplyAllSuggestionsPanelProps {
    * the caller should refetch the full suggestion list here rather than have
    * this panel try to reconstruct per-issue state.
    */
-  onApplied: () => void;
+  onApplied: (result: ApplyAllAiSuggestionsResult) => void;
   /** Dismiss the panel — via Cancel before applying, or Done/auto-close after. */
   onClose: () => void;
 }
@@ -137,10 +137,10 @@ export function ApplyAllSuggestionsPanel({
 
   const applyAllMutation = useMutation({
     mutationFn: () => applyAllAiSuggestions(jobId, includePending),
-    onSuccess: () => {
+    onSuccess: (result) => {
       // Aggregate counts only — refetch the real suggestion list rather than
       // guessing which issues succeeded from this response.
-      onApplied();
+      onApplied(result);
     },
   });
 

--- a/src/components/remediation/IssueCard.test.tsx
+++ b/src/components/remediation/IssueCard.test.tsx
@@ -1,8 +1,11 @@
-import { describe, it, expect, vi } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, type Mocked } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { IssueCard } from './IssueCard';
+import { IssueCard, type AiAnalysis } from './IssueCard';
+import { api } from '@/services/api';
 import type { PdfAuditIssue } from '@/types/pdf.types';
+
+vi.mock('@/services/api');
 
 function renderWithQuery(ui: React.ReactElement) {
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
@@ -244,6 +247,89 @@ describe('IssueCard', () => {
 
       expect(screen.getByText('TEST-001')).toBeInTheDocument();
       expect(screen.getByText('Test issue')).toBeInTheDocument();
+    });
+  });
+
+  describe('Comparison Study remediation-timer wiring', () => {
+    const mockApi = api as Mocked<typeof api>;
+    const mockAiSuggestion: AiAnalysis = {
+      id: 'ai-1',
+      jobId: 'job-1',
+      issueId: 'pdf-issue-1',
+      suggestionType: 'alt-text',
+      value: 'A description',
+      guidance: null,
+      confidence: 0.92,
+      rationale: 'because',
+      model: 'gemini',
+      applyMode: 'apply-to-pdf',
+      status: 'pending',
+      createdAt: '2024-01-15T10:00:00Z',
+      updatedAt: '2024-01-15T10:00:00Z',
+    };
+
+    beforeEach(() => {
+      mockApi.post.mockReset();
+      mockApi.patch.mockReset();
+    });
+
+    it('calls recordApplied after a successful Apply', async () => {
+      mockApi.post.mockResolvedValue({ data: { data: { ...mockAiSuggestion, status: 'applied' } } });
+      const recordApplied = vi.fn();
+      renderWithQuery(
+        <IssueCard issue={mockPdfIssue} jobId="job-1" aiSuggestion={mockAiSuggestion} recordApplied={recordApplied} />
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: 'Apply' }));
+
+      await waitFor(() => expect(recordApplied).toHaveBeenCalledTimes(1));
+    });
+
+    it('calls recordSuggestionDecision("rejected") after a successful Dismiss', async () => {
+      mockApi.patch.mockResolvedValue({ data: { data: { ...mockAiSuggestion, status: 'rejected' } } });
+      const recordSuggestionDecision = vi.fn();
+      renderWithQuery(
+        <IssueCard
+          issue={mockPdfIssue}
+          jobId="job-1"
+          aiSuggestion={mockAiSuggestion}
+          recordSuggestionDecision={recordSuggestionDecision}
+        />
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: 'Dismiss' }));
+
+      await waitFor(() => expect(recordSuggestionDecision).toHaveBeenCalledWith('rejected'));
+    });
+
+    it('does not record a decision when the resulting status is neither approved nor rejected', async () => {
+      // Guards the "check the actual status, don't assume" requirement — this
+      // mutation may be reused for other transitions, so a response that isn't
+      // a clean approve/reject must not be misrecorded as either.
+      mockApi.patch.mockResolvedValue({ data: { data: { ...mockAiSuggestion, status: 'pending' } } });
+      const recordSuggestionDecision = vi.fn();
+      renderWithQuery(
+        <IssueCard
+          issue={mockPdfIssue}
+          jobId="job-1"
+          aiSuggestion={mockAiSuggestion}
+          recordSuggestionDecision={recordSuggestionDecision}
+        />
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: 'Dismiss' }));
+
+      await waitFor(() => expect(mockApi.patch).toHaveBeenCalled());
+      expect(recordSuggestionDecision).not.toHaveBeenCalled();
+    });
+
+    it('does not throw when recorder props are omitted (IssueCard is also used outside Comparison Study)', async () => {
+      mockApi.post.mockResolvedValue({ data: { data: { ...mockAiSuggestion, status: 'applied' } } });
+      renderWithQuery(<IssueCard issue={mockPdfIssue} jobId="job-1" aiSuggestion={mockAiSuggestion} />);
+
+      fireEvent.click(screen.getByRole('button', { name: 'Apply' }));
+
+      await waitFor(() => expect(mockApi.post).toHaveBeenCalled());
     });
   });
 });

--- a/src/components/remediation/IssueCard.tsx
+++ b/src/components/remediation/IssueCard.tsx
@@ -63,6 +63,9 @@ interface IssueCardProps {
   aiSuggestion?: AiAnalysis;
   onAiSuggestionChange?: (updated: AiAnalysis) => void;
   issueNumber?: number;
+  /** Comparison Study remediation-timer hooks — optional-chained since IssueCard is also used outside that flow. */
+  recordApplied?: (count?: number) => void;
+  recordSuggestionDecision?: (decision: 'accepted' | 'rejected') => void;
 }
 
 export function IssueCard({
@@ -76,6 +79,8 @@ export function IssueCard({
   aiSuggestion,
   onAiSuggestionChange,
   issueNumber,
+  recordApplied,
+  recordSuggestionDecision,
 }: IssueCardProps) {
   const isPdf = isPdfIssue(issue);
   const [explanationOpen, setExplanationOpen] = useState(false);
@@ -93,6 +98,10 @@ export function IssueCard({
     },
     onSuccess: (updated) => {
       onAiSuggestionChange?.(updated);
+      // Check the actual resulting status rather than assume it matches the
+      // requested one — this mutation may be reused for other transitions later.
+      if (updated.status === 'approved') recordSuggestionDecision?.('accepted');
+      else if (updated.status === 'rejected') recordSuggestionDecision?.('rejected');
       queryClient.invalidateQueries({ queryKey: ['ai-analysis', jobId] });
     },
     onError: (err: unknown) => {
@@ -113,6 +122,7 @@ export function IssueCard({
     },
     onSuccess: (updated) => {
       onAiSuggestionChange?.(updated);
+      recordApplied?.();
       // Clear the local edit override so the textarea shows the server-normalized
       // value (render prefers editedValue over aiSuggestion.value).
       setEditedValue(null);

--- a/src/hooks/__tests__/useRemediationTimer.test.ts
+++ b/src/hooks/__tests__/useRemediationTimer.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { useRemediationTimer } from '../useRemediationTimer';
+import { remediationSessionService } from '@/services/remediation-session.service';
+
+vi.mock('@/services/remediation-session.service', () => ({
+  remediationSessionService: {
+    startSession: vi.fn(),
+    endSession: vi.fn(),
+  },
+}));
+
+const mockService = vi.mocked(remediationSessionService);
+
+describe('useRemediationTimer', () => {
+  beforeEach(() => {
+    mockService.startSession.mockReset();
+    mockService.endSession.mockReset();
+    mockService.startSession.mockResolvedValue({ sessionId: 'session-1' });
+    mockService.endSession.mockResolvedValue({ sessionId: 'session-1' });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('does nothing when jobId is falsy — no session start, no listeners', async () => {
+    const addSpy = vi.spyOn(document, 'addEventListener');
+    const { unmount } = renderHook(() => useRemediationTimer(undefined));
+
+    // Give any accidental async start a chance to fire.
+    await new Promise((r) => setTimeout(r, 0));
+    expect(mockService.startSession).not.toHaveBeenCalled();
+    expect(addSpy).not.toHaveBeenCalledWith('visibilitychange', expect.anything());
+
+    unmount();
+    expect(mockService.endSession).not.toHaveBeenCalled();
+    addSpy.mockRestore();
+  });
+
+  it('starts a backend session on mount when jobId is provided', async () => {
+    renderHook(() => useRemediationTimer('job-123'));
+
+    await waitFor(() => {
+      expect(mockService.startSession).toHaveBeenCalledWith('job-123');
+    });
+  });
+
+  it('sends the full counter set on stop/unmount', async () => {
+    const { result, unmount } = renderHook(() => useRemediationTimer('job-123'));
+
+    await waitFor(() => {
+      expect(mockService.startSession).toHaveBeenCalled();
+    });
+
+    act(() => {
+      result.current.recordApplied();
+      result.current.recordApplied(2);
+      result.current.recordSuggestionDecision('accepted');
+      result.current.recordSuggestionDecision('rejected');
+      result.current.recordSuggestionDecision('rejected');
+    });
+
+    unmount();
+
+    expect(mockService.endSession).toHaveBeenCalledTimes(1);
+    const [jobId, sessionId, body] = mockService.endSession.mock.calls[0];
+    expect(jobId).toBe('job-123');
+    expect(sessionId).toBe('session-1');
+    expect(body).toMatchObject({
+      issuesApplied: 3,
+      suggestionsAccepted: 1,
+      suggestionsRejected: 2,
+      bulkApplyUsed: false,
+    });
+    expect(typeof body.activeMs).toBe('number');
+    expect(typeof body.idleMs).toBe('number');
+  });
+
+  it('recordBulkApply flags bulkApplyUsed and adds to issuesApplied', async () => {
+    const { result, unmount } = renderHook(() => useRemediationTimer('job-123'));
+
+    await waitFor(() => {
+      expect(mockService.startSession).toHaveBeenCalled();
+    });
+
+    act(() => {
+      result.current.recordApplied();
+      result.current.recordBulkApply(4);
+    });
+
+    unmount();
+
+    const [, , body] = mockService.endSession.mock.calls[0];
+    expect(body).toMatchObject({
+      issuesApplied: 5,
+      bulkApplyUsed: true,
+    });
+  });
+
+  it('stop() is idempotent — only ends the session once', async () => {
+    const { result, unmount } = renderHook(() => useRemediationTimer('job-123'));
+
+    await waitFor(() => {
+      expect(mockService.startSession).toHaveBeenCalled();
+    });
+
+    act(() => {
+      result.current.stop();
+      result.current.stop();
+    });
+    unmount();
+
+    expect(mockService.endSession).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/hooks/useComparisonStudy.ts
+++ b/src/hooks/useComparisonStudy.ts
@@ -1,0 +1,93 @@
+import { useQuery, useInfiniteQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { comparisonStudyService, uploadComparisonPdf } from '@/services/comparisonStudy.service';
+import type { ComparisonTrialContentType } from '@/types/comparisonStudy.types';
+
+const TRIALS_KEY = ['comparison-study', 'trials'] as const;
+
+const KEYS = {
+  trials: (params?: { status?: string; contentType?: string }) => [...TRIALS_KEY, params] as const,
+  trial: (id: string) => ['comparison-study', 'trial', id] as const,
+  report: (id: string) => ['comparison-study', 'report', id] as const,
+  aggregate: () => ['comparison-study', 'aggregate-report'] as const,
+};
+
+const PAGE_SIZE = 20;
+
+export function useComparisonTrialsInfinite(params?: { status?: string; contentType?: string }) {
+  return useInfiniteQuery({
+    queryKey: KEYS.trials(params),
+    queryFn: ({ pageParam }) =>
+      comparisonStudyService.listTrials({ ...params, limit: PAGE_SIZE, cursor: pageParam }),
+    initialPageParam: undefined as string | undefined,
+    getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
+  });
+}
+
+export function useComparisonTrial(id: string | undefined) {
+  return useQuery({
+    queryKey: KEYS.trial(id ?? ''),
+    queryFn: () => comparisonStudyService.getTrial(id!),
+    enabled: !!id,
+  });
+}
+
+export function useTrialReport(id: string | undefined) {
+  return useQuery({
+    queryKey: KEYS.report(id ?? ''),
+    queryFn: () => comparisonStudyService.getTrialReport(id!),
+    enabled: !!id,
+  });
+}
+
+export function useAggregateReport() {
+  return useQuery({
+    queryKey: KEYS.aggregate(),
+    queryFn: () => comparisonStudyService.getAggregateReport(),
+  });
+}
+
+export function useRegisterTrial() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ file, contentType }: { file: File; contentType: ComparisonTrialContentType }) => {
+      const s3Key = await uploadComparisonPdf(file);
+      return comparisonStudyService.registerTrial({
+        sourceFileName: file.name,
+        sourceS3Key: s3Key,
+        contentType,
+      });
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: TRIALS_KEY });
+    },
+  });
+}
+
+export function useLogPdfxtData(id: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (data: {
+      pdfxtS3Key?: string;
+      pdfxtTimeMs?: number;
+      pdfxtPageCount?: number;
+      pdfxtCostUsd?: number;
+    }) => comparisonStudyService.logPdfxtData(id, data),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: KEYS.trial(id) });
+      qc.invalidateQueries({ queryKey: TRIALS_KEY });
+    },
+  });
+}
+
+export function useValidateTrial(id: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: () => comparisonStudyService.validateTrial(id),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: KEYS.trial(id) });
+      qc.invalidateQueries({ queryKey: KEYS.report(id) });
+      qc.invalidateQueries({ queryKey: TRIALS_KEY });
+      qc.invalidateQueries({ queryKey: KEYS.aggregate() });
+    },
+  });
+}

--- a/src/hooks/useRemediationTimer.ts
+++ b/src/hooks/useRemediationTimer.ts
@@ -1,0 +1,206 @@
+import { useEffect, useRef, useCallback, useState } from 'react';
+import { remediationSessionService } from '@/services/remediation-session.service';
+
+interface SessionSegment {
+  openedAt: string;
+  closedAt: string;
+  activeMs: number;
+  idleMs: number;
+}
+
+interface TimerState {
+  activeMs: number;
+  idleMs: number;
+  sessionLog: SessionSegment[];
+  stopped: boolean;
+  issuesApplied: number;
+  suggestionsAccepted: number;
+  suggestionsRejected: number;
+  bulkApplyUsed: boolean;
+}
+
+const IDLE_THRESHOLD_MS = 2 * 60 * 1000;
+
+/**
+ * Tracks remediation session time for the Comparison Study workflow — mirrors
+ * useAnnotationTimer's pattern (activity listeners, tab-visibility pausing,
+ * segment-based ms accumulation) against a remediation session instead of an
+ * annotation run.
+ *
+ * On mount: starts a backend session via POST .../remediation-session/start.
+ * On unmount/stop: ends the session via POST .../remediation-session/:id/end.
+ * Idle detection: pauses after 2 minutes of no activity.
+ * Visibility tracking: pauses when tab is hidden.
+ *
+ * Pass a falsy jobId to no-op entirely — used to keep the idle-listener and
+ * session overhead off every regular remediation visit, only paying for it
+ * when the operator arrived via a Comparison Study trial.
+ */
+export function useRemediationTimer(jobId: string | undefined) {
+  const stateRef = useRef<TimerState>({
+    activeMs: 0,
+    idleMs: 0,
+    sessionLog: [],
+    stopped: false,
+    issuesApplied: 0,
+    suggestionsAccepted: 0,
+    suggestionsRejected: 0,
+    bulkApplyUsed: false,
+  });
+
+  const sessionIdRef = useRef<string | null>(null);
+  const segmentStartRef = useRef<number | null>(null);
+  const segmentOpenedAtRef = useRef<string | null>(null);
+  const idleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [isIdle, setIsIdle] = useState(false);
+  const isIdleRef = useRef(false);
+
+  const startSegment = useCallback(() => {
+    if (segmentStartRef.current !== null) return;
+    segmentStartRef.current = Date.now();
+    segmentOpenedAtRef.current = new Date().toISOString();
+  }, []);
+
+  const closeSegment = useCallback(() => {
+    if (segmentStartRef.current === null) return;
+    const now = Date.now();
+    const segActiveMs = now - segmentStartRef.current;
+    const openedAt = segmentOpenedAtRef.current!;
+    const closedAt = new Date().toISOString();
+    const segIdleMs = new Date(closedAt).getTime() - new Date(openedAt).getTime() - segActiveMs;
+
+    stateRef.current.activeMs += segActiveMs;
+    stateRef.current.idleMs += Math.max(0, segIdleMs);
+    stateRef.current.sessionLog.push({
+      openedAt,
+      closedAt,
+      activeMs: segActiveMs,
+      idleMs: Math.max(0, segIdleMs),
+    });
+
+    segmentStartRef.current = null;
+    segmentOpenedAtRef.current = null;
+  }, []);
+
+  const resetIdleTimer = useCallback(() => {
+    if (stateRef.current.stopped) return;
+
+    if (idleTimerRef.current) clearTimeout(idleTimerRef.current);
+
+    if (isIdleRef.current) {
+      isIdleRef.current = false;
+      setIsIdle(false);
+      if (!document.hidden) startSegment();
+    }
+
+    idleTimerRef.current = setTimeout(() => {
+      if (!stateRef.current.stopped && !document.hidden) {
+        closeSegment();
+        isIdleRef.current = true;
+        setIsIdle(true);
+      }
+    }, IDLE_THRESHOLD_MS);
+  }, [startSegment, closeSegment]);
+
+  const handleVisibilityChange = useCallback(() => {
+    if (stateRef.current.stopped) return;
+    if (document.hidden) {
+      closeSegment();
+      if (idleTimerRef.current) clearTimeout(idleTimerRef.current);
+    } else {
+      if (!isIdleRef.current) startSegment();
+      resetIdleTimer();
+    }
+  }, [closeSegment, startSegment, resetIdleTimer]);
+
+  const stop = useCallback(() => {
+    if (stateRef.current.stopped) return;
+    closeSegment();
+    stateRef.current.stopped = true;
+    if (idleTimerRef.current) clearTimeout(idleTimerRef.current);
+
+    // End session on backend (fire-and-forget)
+    const sid = sessionIdRef.current;
+    if (sid && jobId) {
+      const s = stateRef.current;
+      remediationSessionService
+        .endSession(jobId, sid, {
+          activeMs: s.activeMs,
+          idleMs: s.idleMs,
+          issuesApplied: s.issuesApplied,
+          suggestionsAccepted: s.suggestionsAccepted,
+          suggestionsRejected: s.suggestionsRejected,
+          bulkApplyUsed: s.bulkApplyUsed,
+          sessionLog: s.sessionLog,
+        })
+        .catch(() => {
+          // non-blocking — metrics never break the remediation flow
+        });
+    }
+  }, [closeSegment, jobId]);
+
+  const recordApplied = useCallback((count = 1) => {
+    if (count <= 0) return;
+    stateRef.current.issuesApplied += count;
+  }, []);
+
+  const recordSuggestionDecision = useCallback((decision: 'accepted' | 'rejected') => {
+    if (decision === 'accepted') stateRef.current.suggestionsAccepted++;
+    else stateRef.current.suggestionsRejected++;
+  }, []);
+
+  /** Batch-increment issuesApplied and flag bulkApplyUsed for a bulk "Apply All" action. */
+  const recordBulkApply = useCallback((count: number) => {
+    if (count <= 0) return;
+    stateRef.current.bulkApplyUsed = true;
+    stateRef.current.issuesApplied += count;
+  }, []);
+
+  // Mount / unmount
+  useEffect(() => {
+    if (!jobId) return;
+    let mounted = true;
+
+    (async () => {
+      // Start backend session
+      try {
+        const result = await remediationSessionService.startSession(jobId);
+        if (mounted && result?.sessionId) {
+          sessionIdRef.current = result.sessionId;
+        }
+      } catch {
+        // non-blocking
+      }
+
+      if (!mounted) return;
+
+      // Start first segment if tab is visible
+      if (!document.hidden) startSegment();
+      resetIdleTimer();
+    })();
+
+    // Attach event listeners
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+    const activityEvents = ['mousemove', 'keydown', 'scroll', 'click'] as const;
+    activityEvents.forEach((ev) => document.addEventListener(ev, resetIdleTimer, { passive: true }));
+
+    return () => {
+      mounted = false;
+      stop();
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+      activityEvents.forEach((ev) => document.removeEventListener(ev, resetIdleTimer));
+      if (idleTimerRef.current) clearTimeout(idleTimerRef.current);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [jobId]);
+
+  return {
+    activeMs: stateRef.current.activeMs,
+    idleMs: stateRef.current.idleMs,
+    isIdle,
+    recordApplied,
+    recordSuggestionDecision,
+    recordBulkApply,
+    stop,
+  };
+}

--- a/src/pages/PdfAuditResultsPage.tsx
+++ b/src/pages/PdfAuditResultsPage.tsx
@@ -22,7 +22,7 @@
  */
 
 import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate, useSearchParams } from 'react-router-dom';
 import { FileText, Loader2, Download, Share2, RotateCw, Filter, X, ChevronDown, ListChecks, Maximize2, Minimize2, Zap } from 'lucide-react';
 import toast from 'react-hot-toast';
 import { Card, CardContent } from '@/components/ui/Card';
@@ -38,6 +38,8 @@ import { PdfPreviewPanel } from '@/components/pdf/PdfPreviewPanel';
 import { PdfStatsCards } from '@/components/pdf/PdfStatsCards';
 import { IssueCard, AiAnalysis } from '@/components/remediation/IssueCard';
 import { ApplyAllSuggestionsPanel } from '@/components/remediation/ApplyAllSuggestionsPanel';
+import { useRemediationTimer } from '@/hooks/useRemediationTimer';
+import type { ApplyAllAiSuggestionsResult } from '@/services/api/pdfAiAnalysis.service';
 import { api } from '@/services/api';
 
 /**
@@ -124,6 +126,15 @@ const POLLING_INTERVAL_MS = 5000; // Poll every 5 seconds
 export const PdfAuditResultsPage: React.FC = () => {
   const { jobId } = useParams<{ jobId: string }>();
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+
+  // Only present when the operator arrived via a Comparison Study trial —
+  // gates the remediation timer so regular remediation visits don't pay the
+  // idle-listener/session overhead they're not part of.
+  const comparisonTrialId = searchParams.get('comparisonTrialId');
+  const { recordApplied, recordSuggestionDecision, recordBulkApply } = useRemediationTimer(
+    comparisonTrialId ? jobId : undefined
+  );
 
   // Track component mount status to prevent setState on unmounted component
   const isMountedRef = useRef(true);
@@ -630,10 +641,11 @@ export const PdfAuditResultsPage: React.FC = () => {
   // After a successful bulk apply, refetch suggestions from the server instead
   // of patching aiSuggestions locally — apply-all's response only carries
   // aggregate counts, not which issues succeeded.
-  const handleApplyAllSuccess = useCallback(() => {
+  const handleApplyAllSuccess = useCallback((result: ApplyAllAiSuggestionsResult) => {
     fetchAiSuggestions();
     pollPostRemediationStatus();
-  }, [fetchAiSuggestions, pollPostRemediationStatus]);
+    recordBulkApply(result.applied);
+  }, [fetchAiSuggestions, pollPostRemediationStatus, recordBulkApply]);
 
   const handleDownloadReport = (_format: 'pdf' | 'docx' | 'json' = 'json') => {
     if (!auditResult || !jobId) return;
@@ -1214,6 +1226,8 @@ export const PdfAuditResultsPage: React.FC = () => {
                     aiSuggestion={aiSuggestions.get(issue.id)}
                     issueNumber={issueNumberMap.get(issue.id)}
                     onClick={() => handleIssueSelect(issue)}
+                    recordApplied={recordApplied}
+                    recordSuggestionDecision={recordSuggestionDecision}
                     onAiSuggestionChange={(updated) => {
                       setAiSuggestions((prev) => {
                         const next = new Map(prev);

--- a/src/pages/comparison-study/ComparisonAggregateReportPage.test.tsx
+++ b/src/pages/comparison-study/ComparisonAggregateReportPage.test.tsx
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import ComparisonAggregateReportPage from './ComparisonAggregateReportPage';
+import { comparisonStudyService } from '@/services/comparisonStudy.service';
+import type { AggregateReport } from '@/types/comparisonStudy.types';
+
+vi.mock('@/services/comparisonStudy.service');
+
+const mockService = vi.mocked(comparisonStudyService);
+
+function renderPage() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={['/comparison-study/aggregate-report']}>
+        <Routes>
+          <Route path="/comparison-study/aggregate-report" element={<ComparisonAggregateReportPage />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+describe('ComparisonAggregateReportPage', () => {
+  beforeEach(() => {
+    mockService.getAggregateReport.mockReset();
+  });
+
+  it('renders the validated-count line, time savings tiles, and speedup with real data', async () => {
+    const report: AggregateReport = {
+      trialCount: 10,
+      validatedCount: 6,
+      avgNinjaActiveMs: 90000,
+      avgPdfxtTimeMs: 300000,
+      estimatedSpeedup: 3.3,
+      avgNinjaPacFailures: 1.5,
+      avgPdfxtPacFailures: 4.2,
+      avgNinjaCostUsd: 1.1,
+      avgPdfxtCostUsd: 3.3,
+    };
+    mockService.getAggregateReport.mockResolvedValue(report);
+
+    renderPage();
+
+    expect(await screen.findByText('6 of 10 trials validated')).toBeInTheDocument();
+    expect(screen.getByText('3.3x')).toBeInTheDocument();
+    expect(screen.getByText('90.0s')).toBeInTheDocument();
+    expect(screen.getByText('300.0s')).toBeInTheDocument();
+  });
+
+  it('does not crash when no trials have been validated yet (every average is null)', async () => {
+    const report: AggregateReport = {
+      trialCount: 3,
+      validatedCount: 0,
+      avgNinjaActiveMs: null,
+      avgPdfxtTimeMs: null,
+      estimatedSpeedup: null,
+      avgNinjaPacFailures: null,
+      avgPdfxtPacFailures: null,
+      avgNinjaCostUsd: null,
+      avgPdfxtCostUsd: null,
+    };
+    mockService.getAggregateReport.mockResolvedValue(report);
+
+    renderPage();
+
+    expect(await screen.findByText('0 of 3 trials validated')).toBeInTheDocument();
+    expect(screen.getAllByText('--').length).toBeGreaterThan(0);
+  });
+
+  it('shows a fallback state instead of crashing when the request fails', async () => {
+    mockService.getAggregateReport.mockRejectedValue(new Error('500'));
+
+    renderPage();
+
+    expect(await screen.findByText('No aggregate data available yet.')).toBeInTheDocument();
+  });
+});

--- a/src/pages/comparison-study/ComparisonAggregateReportPage.tsx
+++ b/src/pages/comparison-study/ComparisonAggregateReportPage.tsx
@@ -1,0 +1,99 @@
+import { Link } from 'react-router-dom';
+import { Spinner } from '@/components/ui/Spinner';
+import { useAggregateReport } from '@/hooks/useComparisonStudy';
+
+function fmtMs(ms: number | null): string {
+  if (ms == null) return '--';
+  return `${(ms / 1000).toFixed(1)}s`;
+}
+function fmtUsd(v: number | null): string {
+  if (v == null) return '--';
+  return `$${v.toFixed(2)}`;
+}
+function fmtNum(v: number | null): string {
+  if (v == null) return '--';
+  return v.toFixed(2);
+}
+
+export default function ComparisonAggregateReportPage() {
+  const { data, isLoading, error } = useAggregateReport();
+
+  if (isLoading) return <div className="flex justify-center py-16"><Spinner size="lg" /></div>;
+
+  if (error || !data) {
+    return (
+      <div className="max-w-5xl mx-auto p-6">
+        <Link to="/comparison-study" className="text-sm text-gray-500 hover:text-gray-700">&larr; Back</Link>
+        <div className="text-center py-12 text-gray-400">No aggregate data available yet.</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-5xl mx-auto space-y-6 p-6">
+      <div className="flex items-center gap-3">
+        <Link to="/comparison-study" className="text-sm text-gray-500 hover:text-gray-700">&larr; Back</Link>
+        <h1 className="text-xl font-semibold">Comparison Study — Aggregate Report</h1>
+      </div>
+
+      <p className="text-sm text-gray-500">
+        {data.validatedCount} of {data.trialCount} trials validated
+      </p>
+
+      {/* Time Savings Estimate — same 3-box pattern as the blind-annotation speedup
+          tile, relabeled pdfxt-time -> Ninja-time -> speedup. */}
+      <div className="bg-white rounded-lg shadow p-6">
+        <h3 className="text-sm font-semibold mb-4">Time Savings Estimate</h3>
+        <div className="flex items-center gap-4 text-sm">
+          <div className="bg-gray-50 rounded-lg p-4 text-center flex-1">
+            <p className="text-lg font-bold text-gray-700">{fmtMs(data.avgPdfxtTimeMs)}</p>
+            <p className="text-xs text-gray-500">Avg pdfxt time</p>
+          </div>
+          <span className="text-2xl text-gray-400">&rarr;</span>
+          <div className="bg-green-50 rounded-lg p-4 text-center flex-1">
+            <p className="text-lg font-bold text-green-700">{fmtMs(data.avgNinjaActiveMs)}</p>
+            <p className="text-xs text-gray-500">Avg Ninja time</p>
+          </div>
+          <span className="text-2xl text-gray-400">=</span>
+          <div className="bg-blue-50 rounded-lg p-4 text-center flex-1">
+            <p className="text-lg font-bold text-blue-700">
+              {data.estimatedSpeedup != null ? `${data.estimatedSpeedup.toFixed(1)}x` : '--'}
+            </p>
+            <p className="text-xs text-gray-500">Speedup</p>
+          </div>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 gap-4">
+        <div className="bg-white rounded-lg shadow p-4">
+          <p className="text-xs font-medium text-gray-500 uppercase tracking-wide mb-3">Avg Cost</p>
+          <div className="flex items-center justify-between gap-4">
+            <div className="text-center flex-1">
+              <p className="text-2xl font-bold tabular-nums text-teal-700">{fmtUsd(data.avgNinjaCostUsd)}</p>
+              <p className="text-xs text-gray-400 mt-1">Ninja</p>
+            </div>
+            <span className="text-gray-300">vs</span>
+            <div className="text-center flex-1">
+              <p className="text-2xl font-bold tabular-nums text-gray-600">{fmtUsd(data.avgPdfxtCostUsd)}</p>
+              <p className="text-xs text-gray-400 mt-1">pdfxt</p>
+            </div>
+          </div>
+        </div>
+        <div className="bg-white rounded-lg shadow p-4">
+          <p className="text-xs font-medium text-gray-500 uppercase tracking-wide mb-3">Avg PAC Failures</p>
+          <div className="flex items-center justify-between gap-4">
+            <div className="text-center flex-1">
+              <p className="text-2xl font-bold tabular-nums text-teal-700">{fmtNum(data.avgNinjaPacFailures)}</p>
+              <p className="text-xs text-gray-400 mt-1">Ninja</p>
+            </div>
+            <span className="text-gray-300">vs</span>
+            <div className="text-center flex-1">
+              <p className="text-2xl font-bold tabular-nums text-gray-600">{fmtNum(data.avgPdfxtPacFailures)}</p>
+              <p className="text-xs text-gray-400 mt-1">pdfxt</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/comparison-study/ComparisonStudyConsolePage.test.tsx
+++ b/src/pages/comparison-study/ComparisonStudyConsolePage.test.tsx
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import ComparisonStudyConsolePage from './ComparisonStudyConsolePage';
+import { comparisonStudyService, uploadComparisonPdf } from '@/services/comparisonStudy.service';
+import type { ComparisonTrial } from '@/types/comparisonStudy.types';
+
+vi.mock('@/services/comparisonStudy.service');
+
+const mockService = vi.mocked(comparisonStudyService);
+const mockUpload = vi.mocked(uploadComparisonPdf);
+
+const mockTrial = (overrides?: Partial<ComparisonTrial>): ComparisonTrial => ({
+  id: 'trial-1',
+  sourceFileName: 'sample.pdf',
+  sourceS3Path: 's3://bucket/sample.pdf',
+  contentType: 'text-dominant',
+  operatorId: 'op-1',
+  ninjaJobId: 'job-1',
+  ninjaActiveMs: null,
+  ninjaGpuCostUsd: null,
+  ninjaPacResult: null,
+  pdfxtS3Path: null,
+  pdfxtTimeMs: null,
+  pdfxtPageCount: null,
+  pdfxtCostUsd: null,
+  pdfxtPacResult: null,
+  status: 'registered',
+  createdAt: '2026-08-01T10:00:00Z',
+  updatedAt: '2026-08-01T10:00:00Z',
+  ...overrides,
+});
+
+function renderPage() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={['/comparison-study']}>
+        <Routes>
+          <Route path="/comparison-study" element={<ComparisonStudyConsolePage />} />
+          <Route path="/comparison-study/trials/:id" element={<div>Workspace page</div>} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+describe('ComparisonStudyConsolePage', () => {
+  beforeEach(() => {
+    mockService.listTrials.mockReset();
+    mockService.registerTrial.mockReset();
+    mockUpload.mockReset();
+  });
+
+  it('renders the trial list with status badges', async () => {
+    mockService.listTrials.mockResolvedValue({
+      trials: [mockTrial(), mockTrial({ id: 'trial-2', sourceFileName: 'other.pdf', status: 'validated' })],
+      nextCursor: null,
+    });
+
+    renderPage();
+
+    expect(await screen.findByText('sample.pdf')).toBeInTheDocument();
+    expect(screen.getByText('other.pdf')).toBeInTheDocument();
+    expect(screen.getByText('Registered')).toBeInTheDocument();
+    expect(screen.getByText('Validated')).toBeInTheDocument();
+  });
+
+  it('shows an empty state when there are no trials', async () => {
+    mockService.listTrials.mockResolvedValue({ trials: [], nextCursor: null });
+
+    renderPage();
+
+    expect(await screen.findByText('No trials registered yet')).toBeInTheDocument();
+  });
+
+  it('uploads via the presigned-URL flow then registers and navigates to the trial workspace', async () => {
+    mockService.listTrials.mockResolvedValue({ trials: [], nextCursor: null });
+    mockUpload.mockResolvedValue('uploads/new.pdf');
+    mockService.registerTrial.mockResolvedValue(mockTrial({ id: 'trial-new', sourceFileName: 'new.pdf' }));
+
+    renderPage();
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Register Trial' }));
+
+    const dialog = screen.getByRole('dialog');
+    const file = new File(['%PDF-1.4'], 'new.pdf', { type: 'application/pdf' });
+    const fileInput = dialog.querySelector('input[type="file"]') as HTMLInputElement;
+    fireEvent.change(fileInput, { target: { files: [file] } });
+
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Register Trial' }));
+
+    await waitFor(() => {
+      expect(mockUpload).toHaveBeenCalledWith(file);
+    });
+    expect(mockService.registerTrial).toHaveBeenCalledWith({
+      sourceFileName: 'new.pdf',
+      sourceS3Key: 'uploads/new.pdf',
+      contentType: 'text-dominant',
+    });
+    expect(await screen.findByText('Workspace page')).toBeInTheDocument();
+  });
+});

--- a/src/pages/comparison-study/ComparisonStudyConsolePage.tsx
+++ b/src/pages/comparison-study/ComparisonStudyConsolePage.tsx
@@ -1,0 +1,225 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Loader2 } from 'lucide-react';
+import { Dialog, DialogContent } from '@/components/ui/Dialog';
+import { useComparisonTrialsInfinite, useRegisterTrial } from '@/hooks/useComparisonStudy';
+import type { ComparisonTrialContentType } from '@/types/comparisonStudy.types';
+
+const CONTENT_TYPE_OPTIONS: { value: ComparisonTrialContentType; label: string }[] = [
+  { value: 'text-dominant', label: 'Text Dominant' },
+  { value: 'table-heavy', label: 'Table Heavy' },
+  { value: 'figure-heavy', label: 'Figure Heavy' },
+  { value: 'mixed', label: 'Mixed' },
+];
+
+const STATUS_CONFIG: Record<string, { label: string; bg: string; text: string }> = {
+  registered: { label: 'Registered', bg: 'bg-gray-100', text: 'text-gray-600' },
+  pdfxt_logged: { label: 'pdfxt Logged', bg: 'bg-[#FFF8E8]', text: 'text-[#C8860A]' },
+  validated: { label: 'Validated', bg: 'bg-[#E8F5EE]', text: 'text-[#1A7A3C]' },
+};
+
+function StatusBadge({ status }: { status: string }) {
+  const config = STATUS_CONFIG[status] ?? { label: status, bg: 'bg-gray-100', text: 'text-gray-600' };
+  return (
+    <span className={`text-xs font-semibold px-2 py-0.5 rounded-full ${config.bg} ${config.text}`}>
+      {config.label}
+    </span>
+  );
+}
+
+function fmtDate(d: string): string {
+  return new Date(d).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+}
+
+function RegisterTrialForm({ onClose }: { onClose: () => void }) {
+  const [file, setFile] = useState<File | null>(null);
+  const [contentType, setContentType] = useState<ComparisonTrialContentType>('text-dominant');
+  const registerMutation = useRegisterTrial();
+  const navigate = useNavigate();
+
+  const handleSubmit = () => {
+    if (!file) return;
+    registerMutation.mutate(
+      { file, contentType },
+      {
+        onSuccess: (trial) => {
+          onClose();
+          navigate(`/comparison-study/trials/${trial.id}`);
+        },
+      }
+    );
+  };
+
+  return (
+    <div className="p-6">
+      <h3 className="text-lg font-semibold mb-4">Register Trial</h3>
+      <div className="space-y-4">
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">Source PDF</label>
+          <input
+            type="file"
+            accept="application/pdf"
+            onChange={(e) => setFile(e.target.files?.[0] ?? null)}
+            className="block w-full text-sm text-gray-600 file:mr-3 file:py-1.5 file:px-3 file:rounded file:border file:border-gray-300 file:text-sm file:font-medium file:bg-white hover:file:bg-gray-50"
+          />
+          <p className="mt-1 text-xs text-gray-400">Can be a large PDF — uploaded directly to S3.</p>
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">Content Type</label>
+          <select
+            value={contentType}
+            onChange={(e) => setContentType(e.target.value as ComparisonTrialContentType)}
+            className="w-full px-3 py-2 text-sm border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-primary-500"
+          >
+            {CONTENT_TYPE_OPTIONS.map((opt) => (
+              <option key={opt.value} value={opt.value}>{opt.label}</option>
+            ))}
+          </select>
+        </div>
+        {registerMutation.isError && (
+          <p className="text-sm text-red-600">
+            {registerMutation.error instanceof Error ? registerMutation.error.message : 'Failed to register trial'}
+          </p>
+        )}
+      </div>
+      <div className="flex gap-3 mt-6">
+        <button
+          onClick={handleSubmit}
+          disabled={!file || registerMutation.isPending}
+          className="flex-1 flex items-center justify-center gap-2 px-4 py-2.5 bg-teal-600 text-white rounded-lg hover:bg-teal-700 disabled:opacity-50 disabled:cursor-not-allowed font-semibold text-sm"
+        >
+          {registerMutation.isPending ? (
+            <>
+              <Loader2 className="animate-spin h-4 w-4" />
+              Uploading &amp; registering…
+            </>
+          ) : (
+            'Register Trial'
+          )}
+        </button>
+        <button
+          onClick={onClose}
+          disabled={registerMutation.isPending}
+          className="px-4 py-2 border border-gray-300 rounded-lg hover:bg-gray-50 disabled:opacity-50 text-sm"
+        >
+          Cancel
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export default function ComparisonStudyConsolePage() {
+  const [showRegister, setShowRegister] = useState(false);
+  const navigate = useNavigate();
+  const { data, isLoading, isError, hasNextPage, fetchNextPage, isFetchingNextPage } =
+    useComparisonTrialsInfinite();
+
+  const trials = data?.pages.flatMap((p) => p.trials) ?? [];
+
+  return (
+    <div className="max-w-7xl mx-auto p-6">
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">Comparison Study</h1>
+          <p className="mt-1 text-sm text-gray-500">
+            Validation trials comparing Ninja remediation against pdfxt on fresh PDFs
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            onClick={() => navigate('/comparison-study/aggregate-report')}
+            className="px-4 py-2 text-sm font-medium rounded border border-gray-300 text-gray-700 hover:bg-gray-50"
+          >
+            Aggregate Report
+          </button>
+          <button
+            onClick={() => setShowRegister(true)}
+            className="px-4 py-2 text-sm font-medium rounded bg-teal-600 text-white hover:bg-teal-700"
+          >
+            Register Trial
+          </button>
+        </div>
+      </div>
+
+      {isError && (
+        <div className="text-center py-12">
+          <p className="text-sm text-red-600">Failed to load trials</p>
+        </div>
+      )}
+
+      {!isError && (
+        <div className="overflow-x-auto rounded-lg border border-gray-200">
+          <table className="min-w-full divide-y divide-gray-200">
+            <thead className="bg-gray-50">
+              <tr>
+                <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Filename</th>
+                <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Content Type</th>
+                <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
+                <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Created</th>
+              </tr>
+            </thead>
+            <tbody className="bg-white divide-y divide-gray-200">
+              {isLoading ? (
+                Array.from({ length: 5 }, (_, i) => (
+                  <tr key={i}>
+                    {Array.from({ length: 4 }, (_, j) => (
+                      <td key={j} className="px-6 py-4">
+                        <div className="h-4 bg-gray-200 rounded animate-pulse" />
+                      </td>
+                    ))}
+                  </tr>
+                ))
+              ) : trials.length === 0 ? (
+                <tr>
+                  <td colSpan={4} className="px-6 py-12 text-center text-sm text-gray-400">
+                    No trials registered yet
+                  </td>
+                </tr>
+              ) : (
+                trials.map((trial) => (
+                  <tr
+                    key={trial.id}
+                    onClick={() => navigate(`/comparison-study/trials/${trial.id}`)}
+                    className="cursor-pointer hover:bg-gray-50"
+                  >
+                    <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900 truncate max-w-xs">
+                      {trial.sourceFileName}
+                    </td>
+                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                      {CONTENT_TYPE_OPTIONS.find((o) => o.value === trial.contentType)?.label ?? trial.contentType}
+                    </td>
+                    <td className="px-6 py-4 whitespace-nowrap">
+                      <StatusBadge status={trial.status} />
+                    </td>
+                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                      {fmtDate(trial.createdAt)}
+                    </td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {hasNextPage && (
+        <div className="flex justify-center py-4">
+          <button
+            onClick={() => fetchNextPage()}
+            disabled={isFetchingNextPage}
+            className="px-4 py-2 text-sm font-medium rounded border border-gray-300 text-gray-700 hover:bg-gray-50 disabled:opacity-50"
+          >
+            {isFetchingNextPage ? 'Loading…' : 'Load more'}
+          </button>
+        </div>
+      )}
+
+      <Dialog open={showRegister} onOpenChange={setShowRegister}>
+        <DialogContent className="max-w-md">
+          <RegisterTrialForm onClose={() => setShowRegister(false)} />
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/src/pages/comparison-study/ComparisonTrialReportPage.test.tsx
+++ b/src/pages/comparison-study/ComparisonTrialReportPage.test.tsx
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import ComparisonTrialReportPage from './ComparisonTrialReportPage';
+import { comparisonStudyService } from '@/services/comparisonStudy.service';
+import type { TrialReport } from '@/types/comparisonStudy.types';
+
+vi.mock('@/services/comparisonStudy.service');
+
+const mockService = vi.mocked(comparisonStudyService);
+
+function renderPage() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={['/comparison-study/trials/trial-1/report']}>
+        <Routes>
+          <Route path="/comparison-study/trials/:id/report" element={<ComparisonTrialReportPage />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+describe('ComparisonTrialReportPage', () => {
+  beforeEach(() => {
+    mockService.getTrialReport.mockReset();
+  });
+
+  it('renders all four metric tiles with real data', async () => {
+    const report: TrialReport = {
+      trialId: 'trial-1',
+      sourceFileName: 'sample.pdf',
+      contentType: 'text-dominant',
+      pageCount: 42,
+      ninja: { activeMs: 90000, costUsd: 1.23, pacFailureCount: 2, pagesPerHour: 28 },
+      pdfxt: { timeMs: 300000, costUsd: 4.56, pacFailureCount: 5, pagesPerHour: 8.4 },
+    };
+    mockService.getTrialReport.mockResolvedValue(report);
+
+    renderPage();
+
+    expect(await screen.findByText(/Trial Report — sample.pdf/)).toBeInTheDocument();
+    expect(screen.getByText('90.0s')).toBeInTheDocument();
+    expect(screen.getByText('300.0s')).toBeInTheDocument();
+    expect(screen.getByText('$1.23')).toBeInTheDocument();
+    expect(screen.getByText('$4.56')).toBeInTheDocument();
+  });
+
+  it('does not crash when every numeric field is null (report generated before validation)', async () => {
+    const report: TrialReport = {
+      trialId: 'trial-1',
+      sourceFileName: 'sample.pdf',
+      contentType: 'text-dominant',
+      pageCount: null,
+      ninja: { activeMs: null, costUsd: null, pacFailureCount: null, pagesPerHour: null },
+      pdfxt: { timeMs: null, costUsd: null, pacFailureCount: null, pagesPerHour: null },
+    };
+    mockService.getTrialReport.mockResolvedValue(report);
+
+    renderPage();
+
+    expect(await screen.findByText(/Trial Report — sample.pdf/)).toBeInTheDocument();
+    expect(screen.getByText(/page count unknown/)).toBeInTheDocument();
+    expect(screen.getAllByText('--').length).toBeGreaterThan(0);
+  });
+
+  it('shows a fallback state instead of crashing when no report exists yet', async () => {
+    mockService.getTrialReport.mockRejectedValue(new Error('404'));
+
+    renderPage();
+
+    expect(await screen.findByText(/No report available yet/)).toBeInTheDocument();
+  });
+});

--- a/src/pages/comparison-study/ComparisonTrialReportPage.tsx
+++ b/src/pages/comparison-study/ComparisonTrialReportPage.tsx
@@ -1,0 +1,92 @@
+import { Link, useParams } from 'react-router-dom';
+import { Spinner } from '@/components/ui/Spinner';
+import { useTrialReport } from '@/hooks/useComparisonStudy';
+
+function fmtMs(ms: number | null | undefined): string {
+  if (ms == null) return '--';
+  return `${(ms / 1000).toFixed(1)}s`;
+}
+
+function fmtUsd(v: number | null | undefined): string {
+  if (v == null) return '--';
+  return `$${v.toFixed(2)}`;
+}
+
+function fmtNum(v: number | null | undefined, digits = 0): string {
+  if (v == null) return '--';
+  return v.toFixed(digits);
+}
+
+function MetricTile({
+  label,
+  ninjaValue,
+  pdfxtValue,
+}: {
+  label: string;
+  ninjaValue: string;
+  pdfxtValue: string;
+}) {
+  return (
+    <div className="bg-white rounded-lg shadow p-4">
+      <p className="text-xs font-medium text-gray-500 uppercase tracking-wide mb-3">{label}</p>
+      <div className="flex items-center justify-between gap-4">
+        <div className="text-center flex-1">
+          <p className="text-2xl font-bold tabular-nums text-teal-700">{ninjaValue}</p>
+          <p className="text-xs text-gray-400 mt-1">Ninja</p>
+        </div>
+        <span className="text-gray-300">vs</span>
+        <div className="text-center flex-1">
+          <p className="text-2xl font-bold tabular-nums text-gray-600">{pdfxtValue}</p>
+          <p className="text-xs text-gray-400 mt-1">pdfxt</p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function ComparisonTrialReportPage() {
+  const { id } = useParams<{ id: string }>();
+  const { data, isLoading, error } = useTrialReport(id);
+
+  if (isLoading) {
+    return <div className="flex justify-center py-16"><Spinner size="lg" /></div>;
+  }
+
+  if (error || !data) {
+    return (
+      <div className="max-w-5xl mx-auto p-6">
+        <Link to="/comparison-study" className="text-sm text-gray-500 hover:text-gray-700">&larr; Back</Link>
+        <div className="text-center py-12 text-gray-400">
+          No report available yet — run validation on this trial first.
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-5xl mx-auto space-y-6 p-6">
+      <div className="flex items-center gap-3">
+        <Link to={`/comparison-study/trials/${id}`} className="text-sm text-gray-500 hover:text-gray-700">&larr; Back to Trial</Link>
+        <h1 className="text-xl font-semibold">Trial Report — {data.sourceFileName}</h1>
+      </div>
+      <p className="text-sm text-gray-500">
+        {data.contentType} &middot; {data.pageCount != null ? `${data.pageCount} pages` : 'page count unknown'}
+      </p>
+
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
+        <MetricTile label="Time" ninjaValue={fmtMs(data.ninja.activeMs)} pdfxtValue={fmtMs(data.pdfxt.timeMs)} />
+        <MetricTile label="Cost" ninjaValue={fmtUsd(data.ninja.costUsd)} pdfxtValue={fmtUsd(data.pdfxt.costUsd)} />
+        <MetricTile
+          label="PAC Failures"
+          ninjaValue={fmtNum(data.ninja.pacFailureCount)}
+          pdfxtValue={fmtNum(data.pdfxt.pacFailureCount)}
+        />
+        <MetricTile
+          label="Pages / Hour"
+          ninjaValue={fmtNum(data.ninja.pagesPerHour, 1)}
+          pdfxtValue={fmtNum(data.pdfxt.pagesPerHour, 1)}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/pages/comparison-study/ComparisonTrialWorkspacePage.test.tsx
+++ b/src/pages/comparison-study/ComparisonTrialWorkspacePage.test.tsx
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import ComparisonTrialWorkspacePage from './ComparisonTrialWorkspacePage';
+import { comparisonStudyService } from '@/services/comparisonStudy.service';
+import type { ComparisonTrialWithJob } from '@/types/comparisonStudy.types';
+
+vi.mock('@/services/comparisonStudy.service');
+
+const mockService = vi.mocked(comparisonStudyService);
+
+const mockTrial = (overrides?: Partial<ComparisonTrialWithJob>): ComparisonTrialWithJob => ({
+  id: 'trial-1',
+  sourceFileName: 'sample.pdf',
+  sourceS3Path: 's3://bucket/sample.pdf',
+  contentType: 'text-dominant',
+  operatorId: 'op-1',
+  ninjaJobId: null,
+  ninjaActiveMs: null,
+  ninjaGpuCostUsd: null,
+  ninjaPacResult: null,
+  pdfxtS3Path: null,
+  pdfxtTimeMs: null,
+  pdfxtPageCount: null,
+  pdfxtCostUsd: null,
+  pdfxtPacResult: null,
+  status: 'registered',
+  createdAt: '2026-08-01T10:00:00Z',
+  updatedAt: '2026-08-01T10:00:00Z',
+  job: null,
+  ...overrides,
+});
+
+function renderPage() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={['/comparison-study/trials/trial-1']}>
+        <Routes>
+          <Route path="/comparison-study/trials/:id" element={<ComparisonTrialWorkspacePage />} />
+          <Route path="/pdf/audit/:jobId" element={<div>Audit page</div>} />
+          <Route path="/comparison-study/trials/:id/report" element={<div>Report page</div>} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+describe('ComparisonTrialWorkspacePage', () => {
+  beforeEach(() => {
+    mockService.getTrial.mockReset();
+    mockService.logPdfxtData.mockReset();
+    mockService.validateTrial.mockReset();
+    mockService.getUploadUrl.mockReset();
+    global.fetch = vi.fn();
+  });
+
+  it('disables Start Ninja Remediation until ninjaJobId is set', async () => {
+    mockService.getTrial.mockResolvedValue(mockTrial({ ninjaJobId: null }));
+
+    renderPage();
+
+    const button = await screen.findByRole('button', { name: 'Start Ninja Remediation' });
+    expect(button).toBeDisabled();
+  });
+
+  it('navigates to the audit page with the comparisonTrialId query param once ninjaJobId is set', async () => {
+    mockService.getTrial.mockResolvedValue(mockTrial({ ninjaJobId: 'job-42' }));
+
+    renderPage();
+
+    const button = await screen.findByRole('button', { name: 'Start Ninja Remediation' });
+    expect(button).not.toBeDisabled();
+    fireEvent.click(button);
+
+    expect(await screen.findByText('Audit page')).toBeInTheDocument();
+  });
+
+  it('disables Run Validation while pdfxt data has not been logged yet', async () => {
+    mockService.getTrial.mockResolvedValue(mockTrial({ status: 'registered' }));
+
+    renderPage();
+
+    const button = await screen.findByRole('button', { name: 'Run Validation' });
+    expect(button).toBeDisabled();
+  });
+
+  it('saves pdfxt data (parsing mm:ss into ms) without a file, then enables validation once logged', async () => {
+    mockService.getTrial.mockResolvedValue(mockTrial({ status: 'registered' }));
+    mockService.logPdfxtData.mockResolvedValue(mockTrial({ status: 'pdfxt_logged', pdfxtTimeMs: 272000 }));
+
+    renderPage();
+
+    await screen.findByRole('button', { name: 'Run Validation' });
+
+    fireEvent.change(screen.getByPlaceholderText('e.g. 4:32 or 272'), { target: { value: '4:32' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save pdfxt Data' }));
+
+    await waitFor(() => {
+      expect(mockService.logPdfxtData).toHaveBeenCalledWith('trial-1', { pdfxtTimeMs: 272000 });
+    });
+    expect(mockService.getUploadUrl).not.toHaveBeenCalled();
+  });
+
+  it('shows the report link once a trial is validated', async () => {
+    mockService.getTrial.mockResolvedValue(mockTrial({ status: 'validated' }));
+
+    renderPage();
+
+    fireEvent.click(await screen.findByRole('link', { name: /View Report/ }));
+
+    expect(await screen.findByText('Report page')).toBeInTheDocument();
+  });
+
+  it('shows a not-found state for a missing trial without crashing', async () => {
+    mockService.getTrial.mockRejectedValue(new Error('404'));
+
+    renderPage();
+
+    expect(await screen.findByText('Trial not found.')).toBeInTheDocument();
+  });
+});

--- a/src/pages/comparison-study/ComparisonTrialWorkspacePage.tsx
+++ b/src/pages/comparison-study/ComparisonTrialWorkspacePage.tsx
@@ -1,0 +1,217 @@
+import { useState } from 'react';
+import { useParams, useNavigate, Link } from 'react-router-dom';
+import { Loader2 } from 'lucide-react';
+import { Spinner } from '@/components/ui/Spinner';
+import { useComparisonTrial, useLogPdfxtData, useValidateTrial } from '@/hooks/useComparisonStudy';
+import { comparisonStudyService } from '@/services/comparisonStudy.service';
+
+const CONTENT_TYPE_LABELS: Record<string, string> = {
+  'text-dominant': 'Text Dominant',
+  'table-heavy': 'Table Heavy',
+  'figure-heavy': 'Figure Heavy',
+  mixed: 'Mixed',
+};
+
+/** Accepts "mm:ss", "h:mm:ss", or a plain number of seconds (a raw stopwatch reading). */
+function parseTimeToMs(input: string): number | null {
+  const trimmed = input.trim();
+  if (!trimmed) return null;
+  if (trimmed.includes(':')) {
+    const parts = trimmed.split(':').map(Number);
+    if (parts.some((n) => Number.isNaN(n))) return null;
+    if (parts.length === 2) return Math.round((parts[0] * 60 + parts[1]) * 1000);
+    if (parts.length === 3) return Math.round((parts[0] * 3600 + parts[1] * 60 + parts[2]) * 1000);
+    return null;
+  }
+  const n = Number(trimmed);
+  return Number.isNaN(n) ? null : Math.round(n * 1000);
+}
+
+export default function ComparisonTrialWorkspacePage() {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const { data: trial, isLoading } = useComparisonTrial(id);
+  const logPdfxt = useLogPdfxtData(id!);
+  const validateTrial = useValidateTrial(id!);
+
+  const [pdfxtTime, setPdfxtTime] = useState('');
+  const [pdfxtPageCount, setPdfxtPageCount] = useState('');
+  const [pdfxtCost, setPdfxtCost] = useState('');
+  const [pdfxtFile, setPdfxtFile] = useState<File | null>(null);
+  const [isUploadingPdfxt, setIsUploadingPdfxt] = useState(false);
+  const [pdfxtError, setPdfxtError] = useState<string | null>(null);
+
+  if (isLoading) {
+    return <div className="flex justify-center py-16"><Spinner size="lg" /></div>;
+  }
+
+  if (!trial) {
+    return (
+      <div className="max-w-4xl mx-auto p-6">
+        <Link to="/comparison-study" className="text-sm text-gray-500 hover:text-gray-700">&larr; Back</Link>
+        <div className="text-center py-12 text-gray-400">Trial not found.</div>
+      </div>
+    );
+  }
+
+  const handleSavePdfxtData = async () => {
+    setPdfxtError(null);
+    const timeMs = parseTimeToMs(pdfxtTime);
+    if (pdfxtTime.trim() && timeMs === null) {
+      setPdfxtError('Could not parse time — use mm:ss or a plain number of seconds.');
+      return;
+    }
+    const pageCount = pdfxtPageCount.trim() ? Number(pdfxtPageCount) : undefined;
+    const costUsd = pdfxtCost.trim() ? Number(pdfxtCost) : undefined;
+
+    try {
+      let pdfxtS3Key: string | undefined;
+      if (pdfxtFile) {
+        setIsUploadingPdfxt(true);
+        const { uploadUrl, s3Key } = await comparisonStudyService.getUploadUrl(
+          pdfxtFile.name,
+          pdfxtFile.type || 'application/pdf'
+        );
+        const s3Res = await fetch(uploadUrl, {
+          method: 'PUT',
+          headers: { 'Content-Type': pdfxtFile.type || 'application/pdf' },
+          body: pdfxtFile,
+        });
+        if (!s3Res.ok) throw new Error(`S3 upload failed: ${s3Res.status}`);
+        pdfxtS3Key = s3Key;
+      }
+
+      logPdfxt.mutate(
+        {
+          ...(pdfxtS3Key ? { pdfxtS3Key } : {}),
+          ...(timeMs !== null ? { pdfxtTimeMs: timeMs } : {}),
+          ...(pageCount !== undefined && !Number.isNaN(pageCount) ? { pdfxtPageCount: pageCount } : {}),
+          ...(costUsd !== undefined && !Number.isNaN(costUsd) ? { pdfxtCostUsd: costUsd } : {}),
+        },
+        {
+          onError: () => setPdfxtError('Failed to save pdfxt data — please retry.'),
+        }
+      );
+    } catch (err) {
+      setPdfxtError(err instanceof Error ? err.message : 'Upload failed');
+    } finally {
+      setIsUploadingPdfxt(false);
+    }
+  };
+
+  return (
+    <div className="max-w-4xl mx-auto space-y-6 p-6">
+      <Link to="/comparison-study" className="text-sm text-gray-500 hover:text-gray-700">&larr; Back to Comparison Study</Link>
+
+      <div className="bg-white rounded-lg shadow p-6">
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <h1 className="text-xl font-semibold text-gray-900">{trial.sourceFileName}</h1>
+            <p className="text-sm text-gray-500 mt-1">
+              {CONTENT_TYPE_LABELS[trial.contentType] ?? trial.contentType} &middot; Status:{' '}
+              <span className="font-medium">{trial.status}</span>
+              {trial.job && (
+                <>
+                  {' '}&middot; Ninja job: <span className="font-medium">{trial.job.status}</span>
+                </>
+              )}
+            </p>
+          </div>
+          <button
+            onClick={() => navigate(`/pdf/audit/${trial.ninjaJobId}?comparisonTrialId=${trial.id}`)}
+            disabled={!trial.ninjaJobId}
+            title={!trial.ninjaJobId ? 'Ninja audit job has not been created yet' : undefined}
+            className="shrink-0 px-4 py-2 text-sm font-medium rounded bg-teal-600 text-white hover:bg-teal-700 disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            Start Ninja Remediation
+          </button>
+        </div>
+      </div>
+
+      <div className="bg-white rounded-lg shadow p-6">
+        <h3 className="text-sm font-semibold mb-4">pdfxt Data Entry</h3>
+        <div className="grid grid-cols-2 gap-4 mb-4">
+          <div>
+            <label className="block text-xs font-medium text-gray-600 mb-1">Time (mm:ss or seconds)</label>
+            <input
+              type="text"
+              value={pdfxtTime}
+              onChange={(e) => setPdfxtTime(e.target.value)}
+              placeholder="e.g. 4:32 or 272"
+              className="w-full px-3 py-2 text-sm border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-primary-500"
+            />
+          </div>
+          <div>
+            <label className="block text-xs font-medium text-gray-600 mb-1">Page Count</label>
+            <input
+              type="number"
+              min={1}
+              value={pdfxtPageCount}
+              onChange={(e) => setPdfxtPageCount(e.target.value)}
+              className="w-full px-3 py-2 text-sm border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-primary-500"
+            />
+          </div>
+          <div>
+            <label className="block text-xs font-medium text-gray-600 mb-1">Cost (USD)</label>
+            <input
+              type="number"
+              min={0}
+              step="0.01"
+              value={pdfxtCost}
+              onChange={(e) => setPdfxtCost(e.target.value)}
+              className="w-full px-3 py-2 text-sm border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-primary-500"
+            />
+          </div>
+          <div>
+            <label className="block text-xs font-medium text-gray-600 mb-1">pdfxt Output PDF</label>
+            <input
+              type="file"
+              accept="application/pdf"
+              onChange={(e) => setPdfxtFile(e.target.files?.[0] ?? null)}
+              className="block w-full text-sm text-gray-600 file:mr-3 file:py-1 file:px-2 file:rounded file:border file:border-gray-300 file:text-xs file:bg-white hover:file:bg-gray-50"
+            />
+          </div>
+        </div>
+        {pdfxtError && <p className="text-sm text-red-600 mb-3">{pdfxtError}</p>}
+        <button
+          onClick={handleSavePdfxtData}
+          disabled={isUploadingPdfxt || logPdfxt.isPending}
+          className="px-4 py-2 text-sm font-medium rounded bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50 flex items-center gap-2"
+        >
+          {(isUploadingPdfxt || logPdfxt.isPending) && <Loader2 className="animate-spin h-4 w-4" />}
+          Save pdfxt Data
+        </button>
+        {logPdfxt.isSuccess && <p className="text-sm text-green-700 mt-2">Saved.</p>}
+      </div>
+
+      <div className="bg-white rounded-lg shadow p-6">
+        <h3 className="text-sm font-semibold mb-4">Validation</h3>
+        <p className="text-sm text-gray-500 mb-4">
+          Runs veraPDF against both the Ninja-remediated and pdfxt outputs — can take a few seconds.
+        </p>
+        <div className="flex items-center gap-3">
+          <button
+            onClick={() => validateTrial.mutate()}
+            disabled={validateTrial.isPending || trial.status === 'registered'}
+            title={trial.status === 'registered' ? 'Log pdfxt data first' : undefined}
+            className="px-4 py-2 text-sm font-medium rounded bg-purple-600 text-white hover:bg-purple-700 disabled:opacity-50 flex items-center gap-2"
+          >
+            {validateTrial.isPending && <Loader2 className="animate-spin h-4 w-4" />}
+            Run Validation
+          </button>
+          {trial.status === 'validated' && (
+            <Link
+              to={`/comparison-study/trials/${trial.id}/report`}
+              className="text-sm font-medium text-teal-700 hover:text-teal-900 hover:underline"
+            >
+              View Report &rarr;
+            </Link>
+          )}
+        </div>
+        {validateTrial.isError && (
+          <p className="text-sm text-red-600 mt-3">Validation failed — please retry.</p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/services/comparisonStudy.service.test.ts
+++ b/src/services/comparisonStudy.service.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach, type Mocked } from 'vitest';
+import { comparisonStudyService, uploadComparisonPdf } from './comparisonStudy.service';
+import { api } from './api';
+
+vi.mock('./api');
+
+describe('uploadComparisonPdf', () => {
+  const mockApi = api as Mocked<typeof api>;
+
+  beforeEach(() => {
+    mockApi.post.mockReset();
+    global.fetch = vi.fn();
+  });
+
+  it('gets a presigned URL, PUTs the file to S3, and returns the s3Key', async () => {
+    mockApi.post.mockResolvedValue({
+      data: { data: { uploadUrl: 'https://s3.example.com/presigned', s3Key: 'uploads/a.pdf', expiresAt: '2026-08-01T11:00:00Z' } },
+    });
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({ ok: true });
+
+    const file = new File(['%PDF-1.4'], 'a.pdf', { type: 'application/pdf' });
+    const s3Key = await uploadComparisonPdf(file);
+
+    expect(mockApi.post).toHaveBeenCalledWith('/admin/comparison-study/upload-url', {
+      filename: 'a.pdf',
+      contentType: 'application/pdf',
+    });
+    expect(global.fetch).toHaveBeenCalledWith('https://s3.example.com/presigned', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/pdf' },
+      body: file,
+    });
+    expect(s3Key).toBe('uploads/a.pdf');
+  });
+
+  it('throws when the S3 PUT fails', async () => {
+    mockApi.post.mockResolvedValue({
+      data: { data: { uploadUrl: 'https://s3.example.com/presigned', s3Key: 'uploads/a.pdf', expiresAt: '2026-08-01T11:00:00Z' } },
+    });
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({ ok: false, status: 403 });
+
+    const file = new File(['%PDF-1.4'], 'a.pdf', { type: 'application/pdf' });
+    await expect(uploadComparisonPdf(file)).rejects.toThrow('S3 upload failed: 403');
+  });
+});
+
+describe('comparisonStudyService', () => {
+  const mockApi = api as Mocked<typeof api>;
+
+  beforeEach(() => {
+    mockApi.get.mockReset();
+    mockApi.post.mockReset();
+    mockApi.patch.mockReset();
+  });
+
+  it('logPdfxtData PATCHes the /pdfxt sub-route, not the bare trial route', async () => {
+    mockApi.patch.mockResolvedValue({ data: { data: { id: 'trial-1', status: 'pdfxt_logged' } } });
+
+    await comparisonStudyService.logPdfxtData('trial-1', { pdfxtTimeMs: 5000 });
+
+    expect(mockApi.patch).toHaveBeenCalledWith('/admin/comparison-study/trials/trial-1/pdfxt', { pdfxtTimeMs: 5000 });
+  });
+
+  it('registerTrial POSTs to /admin/comparison-study/trials', async () => {
+    mockApi.post.mockResolvedValue({ data: { data: { id: 'trial-1' } } });
+
+    await comparisonStudyService.registerTrial({
+      sourceFileName: 'a.pdf',
+      sourceS3Key: 'uploads/a.pdf',
+      contentType: 'mixed',
+    });
+
+    expect(mockApi.post).toHaveBeenCalledWith('/admin/comparison-study/trials', {
+      sourceFileName: 'a.pdf',
+      sourceS3Key: 'uploads/a.pdf',
+      contentType: 'mixed',
+    });
+  });
+});

--- a/src/services/comparisonStudy.service.ts
+++ b/src/services/comparisonStudy.service.ts
@@ -1,0 +1,84 @@
+import { api } from './api';
+import type {
+  ComparisonTrial,
+  ComparisonTrialWithJob,
+  ComparisonTrialContentType,
+  TrialReport,
+  AggregateReport,
+} from '@/types/comparisonStudy.types';
+
+// Routes are mounted under /admin, not bare /comparison-study.
+const BASE = '/admin/comparison-study';
+
+export interface ComparisonTrialListResponse {
+  trials: ComparisonTrial[];
+  nextCursor: string | null;
+}
+
+export const comparisonStudyService = {
+  getUploadUrl: (
+    filename: string,
+    contentType = 'application/pdf'
+  ): Promise<{ uploadUrl: string; s3Key: string; expiresAt: string }> =>
+    api.post(`${BASE}/upload-url`, { filename, contentType }).then((r) => r.data.data),
+
+  registerTrial: (data: {
+    sourceFileName: string;
+    sourceS3Key: string;
+    contentType: ComparisonTrialContentType;
+  }): Promise<ComparisonTrial> =>
+    api.post(`${BASE}/trials`, data).then((r) => r.data.data),
+
+  listTrials: (params?: {
+    limit?: number;
+    cursor?: string;
+    status?: string;
+    contentType?: string;
+  }): Promise<ComparisonTrialListResponse> =>
+    api.get(`${BASE}/trials`, { params }).then((r) => r.data.data),
+
+  getTrial: (id: string): Promise<ComparisonTrialWithJob> =>
+    api.get(`${BASE}/trials/${encodeURIComponent(id)}`).then((r) => r.data.data),
+
+  // PATCH .../trials/:id/pdfxt — not bare .../trials/:id.
+  logPdfxtData: (
+    id: string,
+    data: {
+      pdfxtS3Key?: string;
+      pdfxtTimeMs?: number;
+      pdfxtPageCount?: number;
+      pdfxtCostUsd?: number;
+    }
+  ): Promise<ComparisonTrial> =>
+    api.patch(`${BASE}/trials/${encodeURIComponent(id)}/pdfxt`, data).then((r) => r.data.data),
+
+  validateTrial: (id: string): Promise<ComparisonTrial> =>
+    api.post(`${BASE}/trials/${encodeURIComponent(id)}/validate`).then((r) => r.data.data),
+
+  getTrialReport: (id: string): Promise<TrialReport> =>
+    api.get(`${BASE}/trials/${encodeURIComponent(id)}/report`).then((r) => r.data.data),
+
+  getAggregateReport: (): Promise<AggregateReport> =>
+    api.get(`${BASE}/aggregate-report`).then((r) => r.data.data),
+};
+
+/**
+ * Upload a PDF via presigned S3 URL — same pattern as corpus tagged-PDF
+ * uploads, deliberately bypassing the CloudFront WAF's multipart/form-data
+ * block by PUTting directly to S3 instead of routing through our API.
+ */
+export async function uploadComparisonPdf(file: File): Promise<string> {
+  const { uploadUrl, s3Key } = await comparisonStudyService.getUploadUrl(
+    file.name,
+    file.type || 'application/pdf'
+  );
+  const s3Res = await fetch(uploadUrl, {
+    method: 'PUT',
+    headers: { 'Content-Type': file.type || 'application/pdf' },
+    body: file,
+  });
+  if (!s3Res.ok) {
+    throw new Error(`S3 upload failed: ${s3Res.status}`);
+  }
+  return s3Key;
+}

--- a/src/services/remediation-session.service.ts
+++ b/src/services/remediation-session.service.ts
@@ -1,0 +1,28 @@
+import { api } from './api';
+
+export const remediationSessionService = {
+  startSession: (jobId: string): Promise<{ sessionId: string }> =>
+    api
+      .post(`/pdf/${encodeURIComponent(jobId)}/remediation-session/start`)
+      .then((r) => r.data.data),
+
+  endSession: (
+    jobId: string,
+    sessionId: string,
+    data: {
+      activeMs: number;
+      idleMs: number;
+      issuesApplied: number;
+      suggestionsAccepted: number;
+      suggestionsRejected: number;
+      bulkApplyUsed: boolean;
+      sessionLog?: unknown;
+    }
+  ): Promise<{ sessionId: string }> =>
+    api
+      .post(
+        `/pdf/${encodeURIComponent(jobId)}/remediation-session/${encodeURIComponent(sessionId)}/end`,
+        data
+      )
+      .then((r) => r.data.data),
+};

--- a/src/types/comparisonStudy.types.ts
+++ b/src/types/comparisonStudy.types.ts
@@ -1,0 +1,69 @@
+export type ComparisonTrialContentType = 'text-dominant' | 'table-heavy' | 'figure-heavy' | 'mixed';
+
+/** Status values actually set by the backend — 'ninja_complete' and 'reported' are schema-aspirational, no code path sets them. */
+export type ComparisonTrialStatus = 'registered' | 'pdfxt_logged' | 'validated';
+
+export interface VeraPdfFailure {
+  ruleId: string;
+  description: string;
+  pageNumber?: number;
+  context?: string;
+}
+
+export interface ComparisonTrial {
+  id: string;
+  sourceFileName: string;
+  sourceS3Path: string;
+  contentType: ComparisonTrialContentType;
+  operatorId: string;
+
+  ninjaJobId: string | null;
+  ninjaActiveMs: number | null;
+  ninjaGpuCostUsd: number | null;
+  ninjaPacResult: VeraPdfFailure[] | null;
+
+  pdfxtS3Path: string | null;
+  pdfxtTimeMs: number | null;
+  pdfxtPageCount: number | null;
+  pdfxtCostUsd: number | null;
+  pdfxtPacResult: VeraPdfFailure[] | null;
+
+  status: ComparisonTrialStatus;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ComparisonTrialWithJob extends ComparisonTrial {
+  job: { id: string; status: string; output: unknown } | null;
+}
+
+export interface TrialReport {
+  trialId: string;
+  sourceFileName: string;
+  contentType: string;
+  pageCount: number | null;
+  ninja: {
+    activeMs: number | null;
+    costUsd: number | null;
+    pacFailureCount: number | null;
+    pagesPerHour: number | null;
+  };
+  pdfxt: {
+    timeMs: number | null;
+    costUsd: number | null;
+    pacFailureCount: number | null;
+    pagesPerHour: number | null;
+  };
+}
+
+export interface AggregateReport {
+  trialCount: number;
+  validatedCount: number;
+  avgNinjaActiveMs: number | null;
+  avgPdfxtTimeMs: number | null;
+  estimatedSpeedup: number | null;
+  avgNinjaPacFailures: number | null;
+  avgPdfxtPacFailures: number | null;
+  avgNinjaCostUsd: number | null;
+  avgPdfxtCostUsd: number | null;
+}


### PR DESCRIPTION
## Summary
- **Part 1** — `useRemediationTimer` hook mirroring `useAnnotationTimer`'s activity/idle/visibility-based segment tracking, against a remediation session (`POST /pdf/:jobId/remediation-session/start` / `.../end`) instead of an annotation run.
- **Part 2** — Wired into `PdfAuditResultsPage`/`IssueCard`/`ApplyAllSuggestionsPanel`, gated behind a `comparisonTrialId` query param so regular remediation visits don't pay the idle-listener/session overhead.
- **Part 3** — Four new pages under `/comparison-study` (console, trial workspace, trial report, aggregate report) with a new `comparisonStudy` service + React Query hooks layer, and a "Comparison Study" nav entry next to Bootstrap Console.

Verified the exact API contract directly against the merged `ninja-backend` source (commit `9262f6d`) rather than the original task prompt, which had two inaccuracies: comparison-study routes are mounted under `/admin/comparison-study`, not bare `/comparison-study`, and the pdfxt data-entry route is `PATCH /trials/:id/pdfxt`, not `PATCH /trials/:id`.

## Test plan
- [x] `npm run type-check` passes
- [x] `npm run lint` passes
- [x] `useRemediationTimer` unit tests (session lifecycle, counters, idempotent stop) — 5 passing
- [x] `IssueCard` recorder-wiring tests, including a guard against misrecording an unexpected resulting status — 4 new (31 total) passing
- [x] `comparisonStudy.service` tests (presigned-upload flow, correct route paths) — 4 passing
- [x] Console/workspace/report/aggregate-report page tests, including explicit null-field crash coverage — 18 passing
- [ ] Manual: register a trial with a real PDF, start Ninja remediation via the trial workspace and confirm the session start/end calls fire with correct counters, log pdfxt data + a second PDF, run validation (including with veraPDF unavailable locally), confirm both report pages render real data

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an admin comparison-study console for registering PDF trials, tracking validation, and viewing trial or aggregate reports.
  * Added side-by-side Ninja and PDFXT performance metrics, including time, cost, PAC failures, and throughput.
  * Added PDF upload, metadata entry, validation, and report navigation workflows.
  * Added remediation-session timing and activity tracking, including bulk applications and suggestion decisions.
  * Added a Comparison Study entry to Admin navigation.

* **Tests**
  * Added coverage for comparison-study workflows, reporting states, uploads, validation, and remediation tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->