### PR TITLE
fix(pdf): add missing Approve action so Apply All Approved is reachable (#295)

### DIFF
--- a/src/components/remediation/IssueCard.test.tsx
+++ b/src/components/remediation/IssueCard.test.tsx
@@ -332,4 +332,75 @@ describe('IssueCard', () => {
       await waitFor(() => expect(mockApi.post).toHaveBeenCalled());
     });
   });
+
+  describe('Approve action (issue #295 — Apply All Approved was unreachable)', () => {
+    const mockApi = api as Mocked<typeof api>;
+    const mockAiSuggestion: AiAnalysis = {
+      id: 'ai-1',
+      jobId: 'job-1',
+      issueId: 'pdf-issue-1',
+      suggestionType: 'alt-text',
+      value: 'A description',
+      guidance: null,
+      confidence: 0.92,
+      rationale: 'because',
+      model: 'gemini',
+      applyMode: 'apply-to-pdf',
+      status: 'pending',
+      createdAt: '2024-01-15T10:00:00Z',
+      updatedAt: '2024-01-15T10:00:00Z',
+    };
+
+    beforeEach(() => {
+      mockApi.post.mockReset();
+      mockApi.patch.mockReset();
+    });
+
+    it('shows Approve, Apply, and Dismiss for a pending apply-to-pdf suggestion', () => {
+      renderWithQuery(<IssueCard issue={mockPdfIssue} jobId="job-1" aiSuggestion={mockAiSuggestion} />);
+
+      expect(screen.getByRole('button', { name: 'Approve' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Apply' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Dismiss' })).toBeInTheDocument();
+    });
+
+    it('clicking Approve PATCHes status: approved', async () => {
+      mockApi.patch.mockResolvedValue({ data: { data: { ...mockAiSuggestion, status: 'approved' } } });
+      renderWithQuery(<IssueCard issue={mockPdfIssue} jobId="job-1" aiSuggestion={mockAiSuggestion} />);
+
+      fireEvent.click(screen.getByRole('button', { name: 'Approve' }));
+
+      await waitFor(() => {
+        expect(mockApi.patch).toHaveBeenCalledWith('/pdf/job-1/ai-analysis/pdf-issue-1', { status: 'approved' });
+      });
+    });
+
+    it('records an "accepted" suggestion decision after approving', async () => {
+      mockApi.patch.mockResolvedValue({ data: { data: { ...mockAiSuggestion, status: 'approved' } } });
+      const recordSuggestionDecision = vi.fn();
+      renderWithQuery(
+        <IssueCard
+          issue={mockPdfIssue}
+          jobId="job-1"
+          aiSuggestion={mockAiSuggestion}
+          recordSuggestionDecision={recordSuggestionDecision}
+        />
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: 'Approve' }));
+
+      await waitFor(() => expect(recordSuggestionDecision).toHaveBeenCalledWith('accepted'));
+    });
+
+    it('shows an Approved indicator with Apply/Dismiss still available, and no Approve button, once approved', () => {
+      renderWithQuery(
+        <IssueCard issue={mockPdfIssue} jobId="job-1" aiSuggestion={{ ...mockAiSuggestion, status: 'approved' }} />
+      );
+
+      expect(screen.getByText('Approved')).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'Approve' })).not.toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Apply' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Dismiss' })).toBeInTheDocument();
+    });
+  });
 });

--- a/src/components/remediation/IssueCard.tsx
+++ b/src/components/remediation/IssueCard.tsx
@@ -398,6 +398,20 @@ export function IssueCard({
                   <span className="text-gray-500 italic">Dismissed</span>
                 ) : (
                   <div className="flex items-center gap-1.5">
+                    {aiSuggestion.status === 'approved' ? (
+                      <span className="flex items-center gap-1 text-green-700 font-medium">
+                        <CheckCircle size={12} /> Approved
+                      </span>
+                    ) : (
+                      <button
+                        type="button"
+                        className="px-2 py-0.5 bg-white text-green-700 border border-green-300 rounded hover:bg-green-50 transition-colors disabled:opacity-50"
+                        disabled={!jobId || applyMutation.isPending || updateStatusMutation.isPending}
+                        onClick={() => updateStatusMutation.mutate('approved')}
+                      >
+                        Approve
+                      </button>
+                    )}
                     <button
                       type="button"
                       className="px-2 py-0.5 bg-purple-600 text-white rounded hover:bg-purple-700 transition-colors disabled:opacity-50"


### PR DESCRIPTION
## Summary
- Fixes #295: the "Apply All Approved" bulk-apply button (from #293) required `status: 'approved'` + `applyMode: 'apply-to-pdf'`, but nothing in the app ever produced that combination — every apply-to-pdf suggestion was either `pending` or `applied`.
- `IssueCard.tsx` had Apply/Dismiss for pending apply-to-pdf suggestions but no Approve, even though the backend's `PATCH /pdf/:jobId/ai-analysis/:issueId` already fully supports `status: 'approved'` (Dismiss already calls this same endpoint with `'rejected'`).
- Pending apply-to-pdf suggestions now show **Approve / Apply / Dismiss**. Apply still works immediately without requiring Approve first. Once approved, an "Approved" indicator replaces the Approve button while Apply/Dismiss remain available.
- No changes to `PdfAuditResultsPage.tsx` or `ApplyAllSuggestionsPanel.tsx` — their eligibility-count and bulk-apply logic were already correct, just unreachable.

## Test plan
- [x] `npm run type-check` passes
- [x] `npm run lint` passes
- [x] `IssueCard.test.tsx` — new "Approve action" suite: pending suggestion shows all three actions, Approve PATCHes `status: 'approved'`, records an "accepted" suggestion decision, and the approved state shows the indicator + Apply/Dismiss with no Approve button (4 new tests, 35 total, all passing)
- [x] Re-ran `ApplyAllSuggestionsPanel.test.tsx` and `PdfAuditResultsPage.test.tsx` — untouched, still 100% passing (confirms nothing downstream broke)
- [ ] Manual: open a job with pending apply-to-pdf suggestions, click Approve, confirm "Apply All Approved (1)" appears in the toolbar and the panel's default scope shows "Apply 1 approved suggestion"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an **Approve** action for pending PDF AI suggestions.
  - Approved suggestions now display an **Approved** status while retaining Apply and Dismiss options.
  - Approval decisions are recorded and the suggestion status updates immediately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->