### PR TITLE
feat(comparison-study): add Delete Trial action to the trial workspace

### DIFF
--- a/src/hooks/useComparisonStudy.ts
+++ b/src/hooks/useComparisonStudy.ts
@@ -91,3 +91,13 @@ export function useValidateTrial(id: string) {
     },
   });
 }
+
+export function useDeleteTrial(id: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: () => comparisonStudyService.deleteTrial(id),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: TRIALS_KEY });
+    },
+  });
+}

--- a/src/pages/comparison-study/ComparisonTrialWorkspacePage.test.tsx
+++ b/src/pages/comparison-study/ComparisonTrialWorkspacePage.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
 import { MemoryRouter, Routes, Route } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import ComparisonTrialWorkspacePage from './ComparisonTrialWorkspacePage';
@@ -41,6 +41,7 @@ function renderPage() {
           <Route path="/comparison-study/trials/:id" element={<ComparisonTrialWorkspacePage />} />
           <Route path="/pdf/audit/:jobId" element={<div>Audit page</div>} />
           <Route path="/comparison-study/trials/:id/report" element={<div>Report page</div>} />
+          <Route path="/comparison-study" element={<div>Console page</div>} />
         </Routes>
       </MemoryRouter>
     </QueryClientProvider>
@@ -53,6 +54,7 @@ describe('ComparisonTrialWorkspacePage', () => {
     mockService.logPdfxtData.mockReset();
     mockService.validateTrial.mockReset();
     mockService.getUploadUrl.mockReset();
+    mockService.deleteTrial.mockReset();
     global.fetch = vi.fn();
   });
 
@@ -119,5 +121,64 @@ describe('ComparisonTrialWorkspacePage', () => {
     renderPage();
 
     expect(await screen.findByText('Trial not found.')).toBeInTheDocument();
+  });
+
+  describe('Delete Trial', () => {
+    it('opens a confirmation dialog without calling the delete mutation', async () => {
+      mockService.getTrial.mockResolvedValue(mockTrial());
+
+      renderPage();
+
+      fireEvent.click(await screen.findByRole('button', { name: 'Delete Trial' }));
+
+      expect(await screen.findByText(/permanently removes the trial from Comparison Study/)).toBeInTheDocument();
+      expect(mockService.deleteTrial).not.toHaveBeenCalled();
+    });
+
+    it('canceling closes the dialog without calling the delete mutation', async () => {
+      mockService.getTrial.mockResolvedValue(mockTrial());
+
+      renderPage();
+
+      fireEvent.click(await screen.findByRole('button', { name: 'Delete Trial' }));
+      await screen.findByText(/permanently removes the trial from Comparison Study/);
+
+      fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+      await waitFor(() => {
+        expect(screen.queryByText(/permanently removes the trial from Comparison Study/)).not.toBeInTheDocument();
+      });
+      expect(mockService.deleteTrial).not.toHaveBeenCalled();
+    });
+
+    it('confirming calls the delete mutation and navigates to /comparison-study on success', async () => {
+      mockService.getTrial.mockResolvedValue(mockTrial());
+      mockService.deleteTrial.mockResolvedValue({ id: 'trial-1' });
+
+      renderPage();
+
+      fireEvent.click(await screen.findByRole('button', { name: 'Delete Trial' }));
+      const dialog = await screen.findByRole('dialog');
+      fireEvent.click(within(dialog).getByRole('button', { name: 'Delete Trial' }));
+
+      await waitFor(() => {
+        expect(mockService.deleteTrial).toHaveBeenCalledWith('trial-1');
+      });
+      expect(await screen.findByText('Console page')).toBeInTheDocument();
+    });
+
+    it('shows an inline error and keeps the dialog open on failure', async () => {
+      mockService.getTrial.mockResolvedValue(mockTrial());
+      mockService.deleteTrial.mockRejectedValue(new Error('500'));
+
+      renderPage();
+
+      fireEvent.click(await screen.findByRole('button', { name: 'Delete Trial' }));
+      const dialog = await screen.findByRole('dialog');
+      fireEvent.click(within(dialog).getByRole('button', { name: 'Delete Trial' }));
+
+      expect(await screen.findByText('Failed to delete trial — please retry.')).toBeInTheDocument();
+      expect(screen.getByText(/permanently removes the trial from Comparison Study/)).toBeInTheDocument();
+    });
   });
 });

--- a/src/pages/comparison-study/ComparisonTrialWorkspacePage.tsx
+++ b/src/pages/comparison-study/ComparisonTrialWorkspacePage.tsx
@@ -2,7 +2,8 @@ import { useState } from 'react';
 import { useParams, useNavigate, Link } from 'react-router-dom';
 import { Loader2 } from 'lucide-react';
 import { Spinner } from '@/components/ui/Spinner';
-import { useComparisonTrial, useLogPdfxtData, useValidateTrial } from '@/hooks/useComparisonStudy';
+import { Dialog, DialogContent } from '@/components/ui/Dialog';
+import { useComparisonTrial, useLogPdfxtData, useValidateTrial, useDeleteTrial } from '@/hooks/useComparisonStudy';
 import { comparisonStudyService } from '@/services/comparisonStudy.service';
 
 const CONTENT_TYPE_LABELS: Record<string, string> = {
@@ -27,12 +28,52 @@ function parseTimeToMs(input: string): number | null {
   return Number.isNaN(n) ? null : Math.round(n * 1000);
 }
 
+function DeleteTrialDialog({
+  onConfirm,
+  onCancel,
+  isPending,
+  error,
+}: {
+  onConfirm: () => void;
+  onCancel: () => void;
+  isPending: boolean;
+  error: string | null;
+}) {
+  return (
+    <div className="p-6">
+      <h3 className="text-lg font-semibold mb-3 text-gray-900">Delete Trial</h3>
+      <p className="text-sm text-gray-600 mb-4">
+        This permanently removes the trial from Comparison Study. The underlying Ninja job and its data are not affected.
+      </p>
+      {error && <p className="text-sm text-red-600 mb-4">{error}</p>}
+      <div className="flex gap-3">
+        <button
+          onClick={onConfirm}
+          disabled={isPending}
+          className="flex-1 flex items-center justify-center gap-2 px-4 py-2.5 bg-red-600 text-white rounded-lg hover:bg-red-700 disabled:opacity-50 disabled:cursor-not-allowed font-semibold text-sm"
+        >
+          {isPending && <Loader2 className="animate-spin h-4 w-4" />}
+          Delete Trial
+        </button>
+        <button
+          onClick={onCancel}
+          disabled={isPending}
+          className="px-4 py-2 border border-gray-300 rounded-lg hover:bg-gray-50 disabled:opacity-50 text-sm"
+        >
+          Cancel
+        </button>
+      </div>
+    </div>
+  );
+}
+
 export default function ComparisonTrialWorkspacePage() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
   const { data: trial, isLoading } = useComparisonTrial(id);
   const logPdfxt = useLogPdfxtData(id!);
   const validateTrial = useValidateTrial(id!);
+  const deleteTrial = useDeleteTrial(id!);
 
   const [pdfxtTime, setPdfxtTime] = useState('');
   const [pdfxtPageCount, setPdfxtPageCount] = useState('');
@@ -40,6 +81,8 @@ export default function ComparisonTrialWorkspacePage() {
   const [pdfxtFile, setPdfxtFile] = useState<File | null>(null);
   const [isUploadingPdfxt, setIsUploadingPdfxt] = useState(false);
   const [pdfxtError, setPdfxtError] = useState<string | null>(null);
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
 
   if (isLoading) {
     return <div className="flex justify-center py-16"><Spinner size="lg" /></div>;
@@ -99,9 +142,32 @@ export default function ComparisonTrialWorkspacePage() {
     }
   };
 
+  const handleDeleteTrial = () => {
+    setDeleteError(null);
+    deleteTrial.mutate(undefined, {
+      onSuccess: () => {
+        navigate('/comparison-study');
+      },
+      onError: () => {
+        setDeleteError('Failed to delete trial — please retry.');
+      },
+    });
+  };
+
   return (
     <div className="max-w-4xl mx-auto space-y-6 p-6">
-      <Link to="/comparison-study" className="text-sm text-gray-500 hover:text-gray-700">&larr; Back to Comparison Study</Link>
+      <div className="flex items-center justify-between">
+        <Link to="/comparison-study" className="text-sm text-gray-500 hover:text-gray-700">&larr; Back to Comparison Study</Link>
+        <button
+          onClick={() => {
+            setDeleteError(null);
+            setShowDeleteConfirm(true);
+          }}
+          className="text-xs text-red-600 hover:text-red-800 hover:underline"
+        >
+          Delete Trial
+        </button>
+      </div>
 
       <div className="bg-white rounded-lg shadow p-6">
         <div className="flex items-start justify-between gap-4">
@@ -212,6 +278,17 @@ export default function ComparisonTrialWorkspacePage() {
           <p className="text-sm text-red-600 mt-3">Validation failed — please retry.</p>
         )}
       </div>
+
+      <Dialog open={showDeleteConfirm} onOpenChange={setShowDeleteConfirm}>
+        <DialogContent className="max-w-md">
+          <DeleteTrialDialog
+            onConfirm={handleDeleteTrial}
+            onCancel={() => setShowDeleteConfirm(false)}
+            isPending={deleteTrial.isPending}
+            error={deleteError}
+          />
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/src/services/comparisonStudy.service.ts
+++ b/src/services/comparisonStudy.service.ts
@@ -60,6 +60,9 @@ export const comparisonStudyService = {
 
   getAggregateReport: (): Promise<AggregateReport> =>
     api.get(`${BASE}/aggregate-report`).then((r) => r.data.data),
+
+  deleteTrial: (id: string): Promise<{ id: string }> =>
+    api.delete(`${BASE}/trials/${encodeURIComponent(id)}`).then((r) => r.data.data),
 };
 
 /**


### PR DESCRIPTION
## Summary
- Wires up `DELETE /api/v1/admin/comparison-study/trials/:id` (verified directly against merged `ninja-backend` PR #456, commit `c506186`, before implementing) so an operator can clean up a dry-run trial that must never count toward the real aggregate report.
- Deleting only removes the `ComparisonTrial` row — the underlying Ninja job and its data are unaffected.
- `comparisonStudy.service.ts`: `deleteTrial(id)`. `useComparisonStudy.ts`: `useDeleteTrial(id)`, mirroring `useValidateTrial`'s shape.
- `ComparisonTrialWorkspacePage.tsx`: a small "Delete Trial" text-link next to the "← Back to Comparison Study" link — deliberately away from the primary action buttons so it isn't easy to click by accident. Opens a destructive-styled confirmation dialog (reusing the `Dialog`/`DialogContent` system already used for Register Trial on the console page). On confirm: deletes and navigates to `/comparison-study`. On failure: shows an inline error and keeps the dialog open for retry.

## Test plan
- [x] `npm run type-check` passes
- [x] `npm run lint` passes
- [x] `ComparisonTrialWorkspacePage.test.tsx` — new "Delete Trial" suite: opens confirmation without calling the mutation, Cancel closes without calling it, Confirm calls the mutation and navigates to `/comparison-study` on success, and an error keeps the dialog open with an inline message (4 new tests, 10 total, all passing)
- [x] Full comparison-study suite re-run (service + all 4 pages) — 23 tests passing, nothing downstream broke
- [ ] Manual: register a throwaway trial, open its workspace, delete it, confirm it no longer appears in the trial list

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to delete trials from the comparison workspace.
  * Added a confirmation dialog before deletion.
  * Successfully deleted trials return to the comparison study.
  * Deletion errors are displayed while keeping the confirmation dialog open.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->