### PR TITLE
fix(pdf): show accurate, non-alarming status for already-tagged skips

### DIFF
--- a/src/components/pdf/PdfStatsCards.test.tsx
+++ b/src/components/pdf/PdfStatsCards.test.tsx
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { PdfStatsCards, type AutoTagInfo } from './PdfStatsCards';
+import type { PdfAuditResult } from '@/types/pdf.types';
+
+const mockAuditResult = { issues: [] } as unknown as PdfAuditResult;
+
+function renderCard(autoTagInfo: AutoTagInfo | null) {
+  return render(
+    <PdfStatsCards
+      autoTagInfo={autoTagInfo}
+      auditResult={mockAuditResult}
+      aiSuggestions={new Map()}
+      aiStats={null}
+      matterhornIssueCount={0}
+      isAnalyzingAi={false}
+      aiProgress={null}
+      onViewAutoTagReport={vi.fn()}
+      onRetryAutoTag={vi.fn()}
+      isRetryingAutoTag={false}
+      jobId="job-1"
+    />
+  );
+}
+
+function collapseAutoTagCard() {
+  fireEvent.click(screen.getByRole('button', { name: /Auto Tag/ }));
+}
+
+describe('PdfStatsCards — Auto Tag card status display', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('shows an informational, non-alarming message with no Retry button for already-tagged skips', () => {
+    renderCard({ status: 'skipped', skipReason: 'already-tagged' });
+
+    expect(screen.getByText('Document already tagged — audited existing structure')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Retry' })).not.toBeInTheDocument();
+    expect(screen.queryByText('Auto-tagging failed')).not.toBeInTheDocument();
+
+    collapseAutoTagCard();
+    expect(screen.getByText('Document already tagged')).toBeInTheDocument();
+  });
+
+  it('keeps the no-tagger-configured skip low-key with no Retry button', () => {
+    renderCard({ status: 'skipped', skipReason: 'no-tagger-configured' });
+
+    expect(screen.getByText('No tagger available')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Retry' })).not.toBeInTheDocument();
+    expect(screen.queryByText('Auto-tagging failed')).not.toBeInTheDocument();
+  });
+
+  it('still shows the failed state with a Retry button for a real failure', () => {
+    renderCard({ status: 'failed', error: 'Adobe API timeout' });
+
+    // The Auto Tag card is expanded by default, so the detail section
+    // (with Retry) is already visible without collapsing first.
+    expect(screen.getByText('Auto-tagging failed')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Retry' })).toBeInTheDocument();
+  });
+
+  it('still shows the complete state unaffected', () => {
+    renderCard({ status: 'complete', taggerSource: 'seam-c', elementCounts: { figure: 2 } });
+
+    collapseAutoTagCard();
+    expect(screen.getByText(/Seam-C \(YOLO\)/)).toBeInTheDocument();
+  });
+});

--- a/src/components/pdf/PdfStatsCards.tsx
+++ b/src/components/pdf/PdfStatsCards.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useMemo } from 'react';
 import {
   ChevronDown, ChevronUp, CheckCircle, AlertTriangle,
-  Loader2, Sparkles, Tag,
+  Loader2, Sparkles, Tag, Info,
 } from 'lucide-react';
 import { cn } from '@/utils/cn';
 import { api } from '@/services/api';
@@ -80,6 +80,8 @@ function isMatterhorn(issue: AugIssue): boolean {
 
 export interface AutoTagInfo {
   status?: string;
+  error?: string;
+  skipReason?: 'already-tagged' | 'no-tagger-configured';
   taggerSource?: 'seam-c' | 'adobe' | null;
   hasTaggingReport?: boolean;
   hasWordExport?: boolean;
@@ -299,7 +301,9 @@ export function PdfStatsCards({
       ? <AlertTriangle className="h-4 w-4 text-amber-500" />
       : atStatus === 'processing'
         ? <Loader2 className="h-4 w-4 text-blue-500 animate-spin" />
-        : <Tag className="h-4 w-4 text-gray-400" />;
+        : atStatus === 'skipped' && autoTagInfo?.skipReason === 'already-tagged'
+          ? <Info className="h-4 w-4 text-blue-500" />
+          : <Tag className="h-4 w-4 text-gray-400" />;
 
   const autoTagSummary = atStatus === 'complete' ? (
     <>
@@ -314,6 +318,10 @@ export function PdfStatsCards({
     <span className="text-xs text-amber-700 font-medium">Auto-tagging failed</span>
   ) : atStatus === 'processing' ? (
     <span className="text-xs text-blue-700">Auto-tagging in progress…</span>
+  ) : atStatus === 'skipped' && autoTagInfo?.skipReason === 'already-tagged' ? (
+    <span className="text-xs text-gray-600 font-medium">Document already tagged</span>
+  ) : atStatus === 'skipped' && autoTagInfo?.skipReason === 'no-tagger-configured' ? (
+    <span className="text-xs text-gray-400">No tagger available</span>
   ) : (
     <span className="text-xs text-gray-400">No auto-tag data</span>
   );
@@ -345,6 +353,15 @@ export function PdfStatsCards({
             {isRetryingAutoTag ? 'Retrying…' : 'Retry'}
           </button>
         </div>
+      )}
+      {atStatus === 'skipped' && autoTagInfo?.skipReason === 'already-tagged' && (
+        <div className="flex items-center gap-2 text-xs text-gray-600">
+          <Info className="h-3.5 w-3.5 flex-shrink-0" />
+          Document already tagged — audited existing structure
+        </div>
+      )}
+      {atStatus === 'skipped' && autoTagInfo?.skipReason === 'no-tagger-configured' && (
+        <span className="text-xs text-gray-400">No tagger available</span>
       )}
       {atStatus === 'processing' && (
         <div className="flex items-center gap-2 text-xs text-blue-700">

--- a/src/pages/PdfAuditResultsPage.test.tsx
+++ b/src/pages/PdfAuditResultsPage.test.tsx
@@ -734,6 +734,43 @@ describe('PdfAuditResultsPage', () => {
       });
     });
 
+    it('shows a neutral "Already tagged" badge — not the alarming failed badge — when auto-tag is skipped because the document already had structure', async () => {
+      const mockResult = createMockAuditResult();
+
+      mockApi.get.mockImplementation((url: string) => {
+        if (url === auditUrl) return Promise.resolve({ data: { data: mockResult } });
+        if (url === statusUrl) return Promise.resolve({ data: { data: { status: 'skipped', skipReason: 'already-tagged' } } });
+        if (url === aiUrl) return Promise.resolve(emptyAiResponse);
+        return Promise.resolve({ data: { data: {} } });
+      });
+
+      renderWithRouter(jobId);
+
+      await waitFor(() => {
+        expect(screen.getByText('Already tagged')).toBeInTheDocument();
+      });
+      expect(screen.queryByText('Auto-tag failed')).not.toBeInTheDocument();
+    });
+
+    it('shows no header badge for a no-tagger-configured skip (kept low-key)', async () => {
+      const mockResult = createMockAuditResult();
+
+      mockApi.get.mockImplementation((url: string) => {
+        if (url === auditUrl) return Promise.resolve({ data: { data: mockResult } });
+        if (url === statusUrl) return Promise.resolve({ data: { data: { status: 'skipped', skipReason: 'no-tagger-configured' } } });
+        if (url === aiUrl) return Promise.resolve(emptyAiResponse);
+        return Promise.resolve({ data: { data: {} } });
+      });
+
+      renderWithRouter(jobId);
+
+      await waitFor(() => {
+        expect(screen.getByText('test-document.pdf')).toBeInTheDocument();
+      });
+      expect(screen.queryByText('Auto-tag failed')).not.toBeInTheDocument();
+      expect(screen.queryByText('Already tagged')).not.toBeInTheDocument();
+    });
+
     it('retry still polls the status endpoint and updates the header badge on completion', async () => {
       const mockResult = createMockAuditResult({
         autoTagStatus: 'failed',

--- a/src/pages/PdfAuditResultsPage.tsx
+++ b/src/pages/PdfAuditResultsPage.tsx
@@ -545,6 +545,7 @@ export const PdfAuditResultsPage: React.FC = () => {
     status?: string;
     taggerSource?: string | null;
     error?: string | null;
+    skipReason?: string | null;
   } | undefined) => {
     if (!info || info.status === 'processing') return;
     setAuditResult(prev => prev ? {
@@ -552,6 +553,7 @@ export const PdfAuditResultsPage: React.FC = () => {
       autoTagStatus: (info.status as PdfAuditResult['autoTagStatus']) ?? prev.autoTagStatus,
       taggerSource: (info.taggerSource as PdfAuditResult['taggerSource']) ?? prev.taggerSource,
       autoTagError: info.error ?? prev.autoTagError,
+      autoTagSkipReason: (info.skipReason as PdfAuditResult['autoTagSkipReason']) ?? prev.autoTagSkipReason,
     } : prev);
   }, []);
 
@@ -826,6 +828,11 @@ export const PdfAuditResultsPage: React.FC = () => {
                     {auditResult.autoTagStatus === 'complete' && auditResult.taggerSource && (
                       <Badge variant="info" className="ml-2">
                         Auto-tagged: {auditResult.taggerSource === 'seam-c' ? 'Seam-C (YOLO)' : 'Adobe AutoTag'}
+                      </Badge>
+                    )}
+                    {auditResult.autoTagStatus === 'skipped' && auditResult.autoTagSkipReason === 'already-tagged' && (
+                      <Badge variant="info" className="ml-2">
+                        Already tagged
                       </Badge>
                     )}
                     {auditResult.autoTagStatus === 'failed' && (

--- a/src/types/pdf.types.ts
+++ b/src/types/pdf.types.ts
@@ -159,6 +159,8 @@ export interface PdfAuditResult {
   autoTagStatus?: 'complete' | 'failed' | 'skipped' | null;
   /** Error message if autoTagStatus is 'failed' */
   autoTagError?: string | null;
+  /** Why tagging was skipped, when autoTagStatus is 'skipped' */
+  autoTagSkipReason?: 'already-tagged' | 'no-tagger-configured' | null;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Backend PR #460 now reports `autoTagStatus: 'skipped'` with `autoTagSkipReason` (`'already-tagged'` | `'no-tagger-configured'`) instead of `'failed'` when Seam-C correctly refuses to re-tag a document that already has real structure. Previously this was indistinguishable from a genuine failure — "Auto-tagging failed" with a Retry button that would fail identically forever, since the underlying condition is deterministic.
- `PdfStatsCards.tsx`: neutral `Info` icon + "Document already tagged — audited existing structure" message, no Retry button, for the already-tagged skip. Low-key "No tagger available" for the no-tagger-configured skip (a config state, not actionable). The genuine-failure path (amber triangle + Retry) is unchanged.
- `PdfAuditResultsPage.tsx`: threads `autoTagSkipReason` through `applyAutoTagStatus` into `auditResult`, adds a neutral "Already tagged" header badge for that case, and intentionally shows no badge for no-tagger-configured, matching the stats card's low-key treatment.

## Test plan
- [x] `npm run type-check` passes
- [x] `npm run lint` passes
- [x] New `PdfStatsCards.test.tsx` — already-tagged skip shows the informational message with no Retry button (both collapsed summary and expanded detail), no-tagger-configured stays low-key, and the genuine-failure/complete states are unaffected (4 tests, all passing)
- [x] New tests in `PdfAuditResultsPage.test.tsx` — neutral "Already tagged" badge for the already-tagged skip (not the alarming failed badge), no header badge at all for no-tagger-configured (2 new tests, 27 total passing)
- [ ] Manual: verify against the real trial that surfaced this bug — `Math_Olszewski_PDF.pdf`, job `VyZ8mPMzzZE-hgbP9KVGz`, trial `cmt4f38sb00011jnwbmada5g1` — currently sitting in staging's Comparison Study console in the exact `skipped`/`already-tagged` state this fix targets

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer auto-tag status messaging for already-tagged documents and cases where no tagger is configured.
  * Added an “Already tagged” badge to audit results when applicable.
  * Preserved audit results while distinguishing skipped auto-tagging from failures.

* **Bug Fixes**
  * Prevented already-tagged or unconfigured documents from being incorrectly presented as auto-tag failures.
  * Retained retry messaging for genuine auto-tagging failures.

* **Tests**
  * Added coverage for skipped, failed, and completed auto-tagging states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->