### PR TITLE
feat(pdf): add manual trigger for color-contrast auto-fix re-analysis

### DIFF
--- a/src/components/pdf/PdfStatsCards.test.tsx
+++ b/src/components/pdf/PdfStatsCards.test.tsx
@@ -67,3 +67,76 @@ describe('PdfStatsCards — Auto Tag card status display', () => {
     expect(screen.getByText(/Seam-C \(YOLO\)/)).toBeInTheDocument();
   });
 });
+
+describe('PdfStatsCards — AI Analysis card color-contrast re-analysis link', () => {
+  const emptyAiStats = {
+    gemini: { totalTokens: 0, estimatedCostUsd: 0 },
+    claude: { totalTokens: 0, estimatedCostUsd: 0 },
+    totalTokens: 0,
+    totalCostUsd: 0,
+  };
+
+  function renderAiCard(overrides?: {
+    isAnalyzingAi?: boolean;
+    onRerunWithColorContrastFix?: () => void;
+    isRerunningColorContrastFix?: boolean;
+  }) {
+    return render(
+      <PdfStatsCards
+        autoTagInfo={null}
+        auditResult={mockAuditResult}
+        aiSuggestions={new Map()}
+        aiStats={emptyAiStats}
+        matterhornIssueCount={0}
+        isAnalyzingAi={overrides?.isAnalyzingAi ?? false}
+        aiProgress={null}
+        onViewAutoTagReport={vi.fn()}
+        onRetryAutoTag={vi.fn()}
+        isRetryingAutoTag={false}
+        onRerunWithColorContrastFix={overrides?.onRerunWithColorContrastFix}
+        isRerunningColorContrastFix={overrides?.isRerunningColorContrastFix}
+        jobId="job-1"
+      />
+    );
+  }
+
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('shows the link and calls the handler on click', () => {
+    const onRerun = vi.fn();
+    renderAiCard({ onRerunWithColorContrastFix: onRerun });
+
+    const link = screen.getByRole('button', { name: 'Re-run AI analysis with color-contrast auto-fix' });
+    fireEvent.click(link);
+
+    expect(onRerun).toHaveBeenCalledTimes(1);
+  });
+
+  it('is absent when no handler is passed (backwards compatible with other callers)', () => {
+    renderAiCard();
+
+    expect(
+      screen.queryByRole('button', { name: 'Re-run AI analysis with color-contrast auto-fix' })
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows a disabled spinner state while re-running', () => {
+    renderAiCard({ onRerunWithColorContrastFix: vi.fn(), isRerunningColorContrastFix: true });
+
+    const link = screen.getByRole('button', { name: /Re-running with color-contrast auto-fix/ });
+    expect(link).toBeDisabled();
+    expect(
+      screen.queryByText('Re-run AI analysis with color-contrast auto-fix')
+    ).not.toBeInTheDocument();
+  });
+
+  it('is hidden while AI analysis is already in progress', () => {
+    renderAiCard({ onRerunWithColorContrastFix: vi.fn(), isAnalyzingAi: true });
+
+    expect(
+      screen.queryByRole('button', { name: /color-contrast auto-fix/ })
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/components/pdf/PdfStatsCards.tsx
+++ b/src/components/pdf/PdfStatsCards.tsx
@@ -120,6 +120,8 @@ export interface PdfStatsCardsProps {
   onViewAutoTagReport: () => void;
   onRetryAutoTag: () => void;
   isRetryingAutoTag: boolean;
+  onRerunWithColorContrastFix?: () => void;
+  isRerunningColorContrastFix?: boolean;
   jobId: string;
 }
 
@@ -215,6 +217,8 @@ export function PdfStatsCards({
   onViewAutoTagReport,
   onRetryAutoTag,
   isRetryingAutoTag,
+  onRerunWithColorContrastFix,
+  isRerunningColorContrastFix,
   jobId,
 }: PdfStatsCardsProps) {
   const [expanded, setExpanded] = useState<CardState>(() => readStorage());
@@ -578,6 +582,22 @@ export function PdfStatsCards({
               />
             </div>
           </div>
+        </div>
+      )}
+      {onRerunWithColorContrastFix && (
+        <div className="pt-2 border-t border-gray-200">
+          <button
+            type="button"
+            onClick={onRerunWithColorContrastFix}
+            disabled={isRerunningColorContrastFix}
+            className="text-xs font-medium text-purple-700 hover:text-purple-900 disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-1"
+          >
+            {isRerunningColorContrastFix ? (
+              <><Loader2 className="h-3 w-3 animate-spin" />Re-running with color-contrast auto-fix…</>
+            ) : (
+              'Re-run AI analysis with color-contrast auto-fix'
+            )}
+          </button>
         </div>
       )}
     </>

--- a/src/pages/PdfAuditResultsPage.test.tsx
+++ b/src/pages/PdfAuditResultsPage.test.tsx
@@ -895,4 +895,129 @@ describe('PdfAuditResultsPage', () => {
       expect(screen.queryByRole('button', { name: /Apply All Approved/ })).not.toBeInTheDocument();
     });
   });
+
+  describe('Color-contrast re-analysis', () => {
+    const jobId = 'job-123';
+    const auditUrl = `/pdf/job/${jobId}/audit/result`;
+    const statusUrl = `/pdf/${jobId}/auto-tag/status`;
+    const aiUrl = `/pdf/${jobId}/ai-analysis`;
+    const completeAiResponse = {
+      data: {
+        data: {
+          suggestions: [],
+          analyzed: 0,
+          total: 0,
+          status: 'complete',
+          stats: {
+            gemini: { totalTokens: 100, estimatedCostUsd: 0.01 },
+            claude: { totalTokens: 0, estimatedCostUsd: 0 },
+            totalTokens: 100,
+            totalCostUsd: 0.01,
+          },
+        },
+      },
+    };
+
+    function mockCommonGets() {
+      const mockResult = createMockAuditResult();
+      mockApi.get.mockImplementation((url: string) => {
+        if (url === auditUrl) return Promise.resolve({ data: { data: mockResult } });
+        if (url === statusUrl) return Promise.resolve({ data: { data: { status: 'complete', taggerSource: 'adobe' } } });
+        if (url === aiUrl) return Promise.resolve(completeAiResponse);
+        return Promise.resolve({ data: { data: {} } });
+      });
+    }
+
+    beforeEach(() => {
+      // PdfStatsCards persists each card's expand/collapse state to
+      // localStorage — clear it so an earlier test's collapse doesn't hide
+      // the AI Analysis detail section (and this button) here.
+      localStorage.clear();
+    });
+
+    it('POSTs the colorContrastMode override and resumes polling for updated suggestions', async () => {
+      mockCommonGets();
+      mockApi.post.mockResolvedValue({ data: { data: { status: 'processing', total: 5, message: 'started' } } });
+
+      renderWithRouter(jobId);
+
+      const rerunLink = await screen.findByRole('button', { name: 'Re-run AI analysis with color-contrast auto-fix' });
+      const aiCallsBefore = mockApi.get.mock.calls.filter(([url]) => url === aiUrl).length;
+
+      // Engage fake timers BEFORE the click so the setInterval the handler
+      // schedules on success is a fake one — otherwise it becomes a real
+      // background interval that outlives this test and pollutes later ones.
+      vi.useFakeTimers();
+      try {
+        await act(async () => {
+          fireEvent.click(rerunLink);
+          await vi.advanceTimersByTimeAsync(3000);
+        });
+      } finally {
+        vi.useRealTimers();
+      }
+
+      expect(mockApi.post).toHaveBeenCalledWith(aiUrl, { overrides: { colorContrastMode: 'apply-to-pdf' } });
+      const aiCallsAfter = mockApi.get.mock.calls.filter(([url]) => url === aiUrl).length;
+      expect(aiCallsAfter).toBeGreaterThan(aiCallsBefore);
+    });
+
+    it('disables the link while the trigger request is in flight, then hands off to the Analyzing state on success', async () => {
+      mockCommonGets();
+      let resolvePost!: (value: unknown) => void;
+      mockApi.post.mockImplementation(() => new Promise((resolve) => { resolvePost = resolve; }));
+
+      renderWithRouter(jobId);
+
+      const rerunLink = await screen.findByRole('button', { name: 'Re-run AI analysis with color-contrast auto-fix' });
+
+      // Fake timers for the same reason as above — resolving below schedules
+      // a polling setInterval that must not leak into later tests as a real one.
+      vi.useFakeTimers();
+      try {
+        await act(async () => {
+          fireEvent.click(rerunLink);
+        });
+
+        // Can't use waitFor while fake timers are active (its polling relies
+        // on real setTimeout) — act() has already flushed the synchronous
+        // setIsRerunningColorContrastFix(true) update, so assert directly.
+        expect(screen.getByRole('button', { name: /Re-running with color-contrast auto-fix/ })).toBeDisabled();
+
+        await act(async () => {
+          resolvePost({ data: { data: { status: 'processing', total: 5, message: 'started' } } });
+          // Flush the promise chain's remaining microtasks (the .then
+          // continuation after the manually-resolved mock) under fake-timer
+          // control — a bare microtask tick isn't reliably enough here.
+          await vi.advanceTimersByTimeAsync(0);
+        });
+
+        // On success the handler sets isAnalyzingAi(true), which switches the
+        // AI Analysis card to its "Analyzing…" branch — the link legitimately
+        // disappears there rather than re-enabling, per its own render guard.
+        expect(screen.queryByRole('button', { name: /color-contrast auto-fix/ })).not.toBeInTheDocument();
+        expect(screen.getByText(/Analyzing/)).toBeInTheDocument();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('re-enables the link and does not crash if the trigger request fails', async () => {
+      mockCommonGets();
+      mockApi.post.mockRejectedValue(new Error('500'));
+
+      renderWithRouter(jobId);
+
+      const rerunLink = await screen.findByRole('button', { name: 'Re-run AI analysis with color-contrast auto-fix' });
+      await act(async () => {
+        fireEvent.click(rerunLink);
+      });
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole('button', { name: 'Re-run AI analysis with color-contrast auto-fix' })
+        ).not.toBeDisabled();
+      });
+    });
+  });
 });

--- a/src/pages/PdfAuditResultsPage.tsx
+++ b/src/pages/PdfAuditResultsPage.tsx
@@ -39,6 +39,7 @@ import { PdfStatsCards } from '@/components/pdf/PdfStatsCards';
 import { IssueCard, AiAnalysis } from '@/components/remediation/IssueCard';
 import { ApplyAllSuggestionsPanel } from '@/components/remediation/ApplyAllSuggestionsPanel';
 import { useRemediationTimer } from '@/hooks/useRemediationTimer';
+import { triggerAiAnalysis } from '@/services/api/pdfAiAnalysis.service';
 import type { ApplyAllAiSuggestionsResult } from '@/services/api/pdfAiAnalysis.service';
 import { api } from '@/services/api';
 
@@ -160,6 +161,7 @@ export const PdfAuditResultsPage: React.FC = () => {
   const [aiSuggestions, setAiSuggestions] = useState<Map<string, AiAnalysis>>(new Map());
   const [isAnalyzingAi, setIsAnalyzingAi] = useState(false);
   const [aiProgress, setAiProgress] = useState<{ analyzed: number; total: number } | null>(null);
+  const [isRerunningColorContrastFix, setIsRerunningColorContrastFix] = useState(false);
   const [aiStats, setAiStats] = useState<{
     gemini: { totalTokens: number; estimatedCostUsd: number };
     claude: { totalTokens: number; estimatedCostUsd: number };
@@ -521,6 +523,23 @@ export const PdfAuditResultsPage: React.FC = () => {
       // Non-fatal — silently ignore fetch errors during polling
     }
   }, [jobId]);
+
+  const handleRerunWithColorContrastFix = useCallback(async () => {
+    if (!jobId) return;
+    setIsRerunningColorContrastFix(true);
+    try {
+      await triggerAiAnalysis(jobId, { colorContrastMode: 'apply-to-pdf' });
+      toast.success('Re-running AI analysis with color-contrast auto-fix…');
+      setIsAnalyzingAi(true);
+      if (!aiPollingRef.current) {
+        aiPollingRef.current = setInterval(fetchAiSuggestions, 3000);
+      }
+    } catch {
+      toast.error('Failed to start AI re-analysis');
+    } finally {
+      setIsRerunningColorContrastFix(false);
+    }
+  }, [jobId, fetchAiSuggestions]);
 
   // Load existing AI suggestions on mount (in case analysis was already run)
   useEffect(() => {
@@ -934,6 +953,8 @@ export const PdfAuditResultsPage: React.FC = () => {
         onViewAutoTagReport={handleViewAutoTagReport}
         onRetryAutoTag={handleRetryAutoTag}
         isRetryingAutoTag={isRetryingAutoTag}
+        onRerunWithColorContrastFix={handleRerunWithColorContrastFix}
+        isRerunningColorContrastFix={isRerunningColorContrastFix}
         jobId={jobId!}
       />
 

--- a/src/services/api/pdfAiAnalysis.service.ts
+++ b/src/services/api/pdfAiAnalysis.service.ts
@@ -20,3 +20,24 @@ export async function applyAllAiSuggestions(
   );
   return res.data.data;
 }
+
+export interface AiRemediationOverrides {
+  colorContrastMode?: 'guidance-only' | 'disabled' | 'apply-to-pdf';
+}
+
+export interface TriggerAiAnalysisResult {
+  status: string;
+  total: number;
+  message: string;
+}
+
+export async function triggerAiAnalysis(
+  jobId: string,
+  overrides?: AiRemediationOverrides
+): Promise<TriggerAiAnalysisResult> {
+  const res = await api.post<{ data: TriggerAiAnalysisResult }>(
+    `/pdf/${encodeURIComponent(jobId)}/ai-analysis`,
+    overrides ? { overrides } : undefined
+  );
+  return res.data.data;
+}


### PR DESCRIPTION
## Summary
- Backend already supports a `colorContrastMode: 'apply-to-pdf'` session override on `POST /pdf/:jobId/ai-analysis` (deployed, verified end-to-end — no backend changes needed). There was previously no frontend way to trigger it — AI analysis only ever auto-runs server-side right after a PDF audit completes, using the default guidance-only mode.
- `pdfAiAnalysis.service.ts`: `triggerAiAnalysis(jobId, overrides?)`.
- `PdfAuditResultsPage.tsx`: `handleRerunWithColorContrastFix` — triggers the override, shows a toast, and resumes the existing 3s polling loop (reusing `aiPollingRef`/`fetchAiSuggestions`).
- `PdfStatsCards.tsx`: a link under the AI Analysis card's Provider breakdown, hidden while analysis is already running (naturally, since it only renders in the non-analyzing branch).
- No changes needed in `IssueCard.tsx` — the Approve/Apply/Dismiss UI is already generic, driven by `applyMode` rather than `suggestionType`, so `color-contrast-fix` suggestions render through the existing purple box automatically once they exist.

## Test plan
- [x] `npm run type-check` passes
- [x] `npm run lint` passes
- [x] New `PdfStatsCards.test.tsx` tests — link shows/hides correctly, disabled+spinner while re-running, hidden during analysis (4 tests, 8 total passing)
- [x] New `PdfAuditResultsPage.test.tsx` tests — POSTs the correct override body and resumes polling, disables while in flight then correctly hands off to the "Analyzing…" state on success, and re-enables cleanly on failure (3 tests, 26 total passing, full file run sequentially to rule out cross-test pollution from a leaked polling interval)
- [ ] Manual: open a completed PDF audit job (AI analysis already run once, guidance-only), click the new link, confirm the Fixes count increases and a color-contrast issue now shows the purple Approve/Apply/Dismiss box; apply one via the existing generic flow; reload and confirm state persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to re-run PDF AI analysis with automatic color-contrast fixes applied.
  * Added loading and disabled states while color-contrast analysis is being re-run.
  * Added success and failure notifications and progress tracking for re-analysis requests.

* **Bug Fixes**
  * Improved handling when color-contrast re-analysis requests fail or transition into active analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->