### PR TITLE
feat(pdf): add category chips and AI-action filter to audit results

### DIFF
--- a/src/pages/PdfAuditResultsPage.test.tsx
+++ b/src/pages/PdfAuditResultsPage.test.tsx
@@ -1020,4 +1020,187 @@ describe('PdfAuditResultsPage', () => {
       });
     });
   });
+
+  describe('Category and AI action filters', () => {
+    const jobId = 'job-123';
+    const auditUrl = `/pdf/job/${jobId}/audit/result`;
+    const statusUrl = `/pdf/${jobId}/auto-tag/status`;
+    const aiUrl = `/pdf/${jobId}/ai-analysis`;
+
+    type CategorizedIssue = PdfAuditIssue & { category: string };
+
+    const issueA: CategorizedIssue = { ...createMockIssueLike('a', 1, 'structure') };
+    const issueB: CategorizedIssue = { ...createMockIssueLike('b', 2, 'contrast') };
+    const issueC: CategorizedIssue = { ...createMockIssueLike('c', 3, 'table-structure') };
+    const issueD: CategorizedIssue = { ...createMockIssueLike('d', 4, 'contrast') };
+
+    function createMockIssueLike(id: string, pageNumber: number, category: string): CategorizedIssue {
+      return {
+        id,
+        ruleId: `RULE-${id}`,
+        severity: 'moderate',
+        message: `Test issue ${id}`,
+        description: `Test description for issue ${id}`,
+        pageNumber,
+        category,
+      } as CategorizedIssue;
+    }
+
+    function mockAiSuggestion(issueId: string, applyMode: string, status: string) {
+      return {
+        id: `sugg-${issueId}`,
+        jobId,
+        issueId,
+        suggestionType: 'alt-text',
+        value: 'A description',
+        guidance: null,
+        confidence: 0.9,
+        rationale: 'because',
+        model: 'gemini',
+        applyMode,
+        status,
+        createdAt: '2024-01-15T10:00:00Z',
+        updatedAt: '2024-01-15T10:00:00Z',
+      };
+    }
+
+    function setupMocks() {
+      // b: fixable now (apply-to-pdf, pending). c: guidance-only. d: already applied (apply-to-pdf, applied).
+      const mockResult = createMockAuditResult({ issues: [issueA, issueB, issueC, issueD] });
+      mockApi.get.mockImplementation((url: string) => {
+        if (url === auditUrl) return Promise.resolve({ data: { data: mockResult } });
+        if (url === statusUrl) return Promise.resolve({ data: { data: { status: 'complete', taggerSource: 'adobe' } } });
+        if (url === aiUrl) {
+          return Promise.resolve({
+            data: {
+              data: {
+                suggestions: [
+                  mockAiSuggestion('b', 'apply-to-pdf', 'pending'),
+                  mockAiSuggestion('c', 'guidance-only', 'pending'),
+                  mockAiSuggestion('d', 'apply-to-pdf', 'applied'),
+                ],
+                analyzed: 3,
+                total: 3,
+                status: 'complete',
+              },
+            },
+          });
+        }
+        return Promise.resolve({ data: { data: {} } });
+      });
+    }
+
+    function visibleIssueIds(): string[] {
+      return screen.getAllByTestId(/^issue-card-/).map((el) => el.getAttribute('data-testid')!.replace('issue-card-', ''));
+    }
+
+    it('renders category chips with live counts, omitting categories with no issues', async () => {
+      setupMocks();
+      renderWithRouter(jobId);
+
+      await screen.findByText('test-document.pdf');
+
+      expect(await screen.findByRole('button', { name: 'Structure (1)' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Contrast (2)' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Tables (1)' })).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /^Metadata/ })).not.toBeInTheDocument();
+    });
+
+    it('multi-selects categories as a union, and toggling one off narrows back', async () => {
+      setupMocks();
+      renderWithRouter(jobId);
+      await screen.findByText('test-document.pdf');
+
+      const contrastChip = await screen.findByRole('button', { name: 'Contrast (2)' });
+      fireEvent.click(contrastChip);
+      await waitFor(() => {
+        expect(visibleIssueIds().sort()).toEqual(['b', 'd']);
+      });
+
+      const structureChip = screen.getByRole('button', { name: 'Structure (1)' });
+      fireEvent.click(structureChip);
+      await waitFor(() => {
+        expect(visibleIssueIds().sort()).toEqual(['a', 'b', 'd']);
+      });
+
+      fireEvent.click(contrastChip);
+      await waitFor(() => {
+        expect(visibleIssueIds().sort()).toEqual(['a']);
+      });
+    });
+
+    it('"Fixable now" shows only apply-to-pdf suggestions not yet applied/rejected', async () => {
+      setupMocks();
+      renderWithRouter(jobId);
+      await screen.findByText('test-document.pdf');
+
+      fireEvent.click(await screen.findByRole('button', { name: 'Fixable now' }));
+      await waitFor(() => {
+        expect(visibleIssueIds()).toEqual(['b']);
+      });
+    });
+
+    it('"Applied" and "Guidance only" each isolate the matching suggestions', async () => {
+      setupMocks();
+      renderWithRouter(jobId);
+      await screen.findByText('test-document.pdf');
+
+      fireEvent.click(await screen.findByRole('button', { name: 'Applied' }));
+      await waitFor(() => {
+        expect(visibleIssueIds()).toEqual(['d']);
+      });
+
+      fireEvent.click(screen.getByRole('button', { name: 'Guidance only' }));
+      await waitFor(() => {
+        expect(visibleIssueIds()).toEqual(['c']);
+      });
+    });
+
+    it('combines a category chip and the AI action filter with AND, not OR', async () => {
+      setupMocks();
+      renderWithRouter(jobId);
+      await screen.findByText('test-document.pdf');
+
+      fireEvent.click(await screen.findByRole('button', { name: 'Contrast (2)' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Fixable now' }));
+
+      await waitFor(() => {
+        // Contrast has b (pending) and d (applied) — only b is still fixable.
+        expect(visibleIssueIds()).toEqual(['b']);
+      });
+    });
+
+    it('shows a dismissible checkpoint pill when a Matterhorn checkpoint is clicked, unchanged mechanism', async () => {
+      setupMocks();
+      renderWithRouter(jobId);
+      await screen.findByText('test-document.pdf');
+
+      fireEvent.click(screen.getByText('Click Checkpoint'));
+
+      expect(await screen.findByText('Checkpoint 01')).toBeInTheDocument();
+
+      fireEvent.click(screen.getByLabelText('Clear checkpoint 01 filter'));
+      await waitFor(() => {
+        expect(screen.queryByText('Checkpoint 01')).not.toBeInTheDocument();
+      });
+    });
+
+    it('Clear resets categories and AI action along with the rest of the filters', async () => {
+      setupMocks();
+      renderWithRouter(jobId);
+      await screen.findByText('test-document.pdf');
+
+      fireEvent.click(await screen.findByRole('button', { name: 'Contrast (2)' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Fixable now' }));
+      await waitFor(() => {
+        expect(visibleIssueIds()).toEqual(['b']);
+      });
+
+      fireEvent.click(screen.getByRole('button', { name: 'Clear' }));
+
+      await waitFor(() => {
+        expect(visibleIssueIds().sort()).toEqual(['a', 'b', 'c', 'd']);
+      });
+    });
+  });
 });

--- a/src/pages/PdfAuditResultsPage.tsx
+++ b/src/pages/PdfAuditResultsPage.tsx
@@ -75,6 +75,28 @@ function getIssueCheckpoint(issue: PdfAuditIssue & { category?: string; code?: s
   if (match) return match[1];
   return undefined;
 }
+
+const CATEGORY_LABELS: Record<string, string> = {
+  structure: 'Structure',
+  metadata: 'Metadata',
+  language: 'Language',
+  headings: 'Headings',
+  'reading-order': 'Reading Order',
+  lists: 'Lists',
+  tables: 'Tables',
+  'alt-text': 'Alt Text',
+  contrast: 'Contrast',
+  links: 'Links',
+  forms: 'Forms',
+  bookmarks: 'Bookmarks',
+  formula: 'Formula',
+};
+const CATEGORY_ORDER = Object.keys(CATEGORY_LABELS);
+const TABLE_SUBCATEGORIES = new Set(['table-structure', 'table-headers', 'table-summary', 'layout-table']);
+function normalizeCategory(category: string | undefined): string | undefined {
+  if (!category) return undefined;
+  return TABLE_SUBCATEGORIES.has(category) ? 'tables' : category;
+}
 import { cn } from '@/utils/cn';
 import { validateJobId } from '@/utils/validation';
 import { useCreateRemediationPlan } from '@/hooks/usePdfRemediation';
@@ -87,6 +109,8 @@ interface IssueFilters {
   severity: IssueSeverity | 'all';
   wcagCriterion: string | 'all';
   matterhornCategory: string | 'all';
+  categories: Set<string>;
+  aiAction: 'all' | 'fixable' | 'guidance-only' | 'applied' | 'rejected';
   pageNumber: number | 'all';
   searchText: string;
   showMatterhornOnly: boolean;
@@ -96,6 +120,8 @@ const initialFilters: IssueFilters = {
   severity: 'all',
   wcagCriterion: 'all',
   matterhornCategory: 'all',
+  categories: new Set<string>(),
+  aiAction: 'all',
   pageNumber: 'all',
   searchText: '',
   showMatterhornOnly: false,
@@ -339,6 +365,34 @@ export const PdfAuditResultsPage: React.FC = () => {
       });
     }
 
+    // Filter by category (multi-select)
+    if (filters.categories.size > 0) {
+      issues = issues.filter((issue) => {
+        const category = normalizeCategory((issue as PdfAuditIssue & { category?: string }).category);
+        return category ? filters.categories.has(category) : false;
+      });
+    }
+
+    // Filter by AI action
+    if (filters.aiAction !== 'all') {
+      issues = issues.filter((issue) => {
+        const suggestion = aiSuggestions.get(issue.id);
+        switch (filters.aiAction) {
+          case 'fixable':
+            return suggestion?.applyMode === 'apply-to-pdf' &&
+              (suggestion.status === 'pending' || suggestion.status === 'approved');
+          case 'guidance-only':
+            return suggestion?.applyMode === 'guidance-only';
+          case 'applied':
+            return suggestion?.status === 'applied';
+          case 'rejected':
+            return suggestion?.status === 'rejected';
+          default:
+            return true;
+        }
+      });
+    }
+
     // Filter by page number
     if (filters.pageNumber !== 'all') {
       issues = issues.filter((issue) => issue.pageNumber === filters.pageNumber);
@@ -375,7 +429,7 @@ export const PdfAuditResultsPage: React.FC = () => {
     }
 
     return issues;
-  }, [auditResult, filters]);
+  }, [auditResult, filters, aiSuggestions]);
 
   // Count Matterhorn-related issues
   // Includes issues with explicit MATTERHORN codes and related codes that map to Matterhorn checkpoints
@@ -413,13 +467,15 @@ export const PdfAuditResultsPage: React.FC = () => {
     return Array.from(criteria).sort();
   }, [auditResult]);
 
-  // Get unique Matterhorn categories
-  const uniqueMatterhornCategories = useMemo(() => {
-    if (!auditResult || !auditResult.matterhornSummary?.categories) return [];
-    return auditResult.matterhornSummary.categories.map((cat) => ({
-      id: cat.id,
-      name: cat.name,
-    }));
+  const categoryCounts = useMemo(() => {
+    const counts = new Map<string, number>();
+    if (!auditResult?.issues) return counts;
+    for (const issue of auditResult.issues) {
+      const category = normalizeCategory((issue as PdfAuditIssue & { category?: string }).category);
+      if (!category) continue;
+      counts.set(category, (counts.get(category) ?? 0) + 1);
+    }
+    return counts;
   }, [auditResult]);
 
   // Handlers
@@ -755,6 +811,8 @@ export const PdfAuditResultsPage: React.FC = () => {
     filters.severity !== 'all' ||
     filters.wcagCriterion !== 'all' ||
     filters.matterhornCategory !== 'all' ||
+    filters.categories.size > 0 ||
+    filters.aiAction !== 'all' ||
     filters.pageNumber !== 'all' ||
     filters.searchText.trim() !== '';
 
@@ -1122,6 +1180,90 @@ export const PdfAuditResultsPage: React.FC = () => {
               </button>
             </div>
 
+            {/* Category filter chips */}
+            <div className="flex flex-wrap items-center gap-2 mb-3">
+              <span className="text-sm text-gray-600 mr-1">Category:</span>
+              {CATEGORY_ORDER.map((cat) => {
+                const count = categoryCounts.get(cat) ?? 0;
+                if (count === 0) return null;
+                const selected = filters.categories.has(cat);
+                return (
+                  <button
+                    key={cat}
+                    type="button"
+                    onClick={() =>
+                      setFilters((prev) => {
+                        const next = new Set(prev.categories);
+                        if (next.has(cat)) next.delete(cat);
+                        else next.add(cat);
+                        return { ...prev, categories: next };
+                      })
+                    }
+                    className={cn(
+                      'px-2.5 py-1 text-xs font-medium rounded-full border transition-colors',
+                      selected
+                        ? 'bg-primary-100 text-primary-700 border-primary-300'
+                        : 'bg-white text-gray-600 border-gray-300 hover:bg-gray-50'
+                    )}
+                  >
+                    {CATEGORY_LABELS[cat] ?? cat} ({count})
+                  </button>
+                );
+              })}
+              {filters.categories.size > 0 && (
+                <button
+                  type="button"
+                  onClick={() => setFilters((prev) => ({ ...prev, categories: new Set() }))}
+                  className="text-xs text-gray-500 hover:text-gray-700 underline"
+                >
+                  Clear categories
+                </button>
+              )}
+              {filters.matterhornCategory !== 'all' && (
+                <span className="inline-flex items-center gap-1 px-2.5 py-1 text-xs font-medium rounded-full bg-blue-100 text-blue-700 border border-blue-300">
+                  Checkpoint {filters.matterhornCategory}
+                  <button
+                    type="button"
+                    onClick={() => setFilters((prev) => ({ ...prev, matterhornCategory: 'all' }))}
+                    className="hover:text-blue-900"
+                    aria-label={`Clear checkpoint ${filters.matterhornCategory} filter`}
+                  >
+                    <X className="h-3 w-3" />
+                  </button>
+                </span>
+              )}
+            </div>
+
+            {/* AI action filter */}
+            <div className="flex flex-wrap items-center gap-2 mb-3">
+              <span className="text-sm text-gray-600 mr-1">AI:</span>
+              {(
+                [
+                  ['all', 'All'],
+                  ['fixable', 'Fixable now'],
+                  ['guidance-only', 'Guidance only'],
+                  ['applied', 'Applied'],
+                  ['rejected', 'Rejected'],
+                ] as const
+              ).map(([value, label]) => (
+                <button
+                  key={value}
+                  type="button"
+                  onClick={() => setFilters((prev) => ({ ...prev, aiAction: value }))}
+                  className={cn(
+                    'px-2.5 py-1 text-xs font-medium rounded-full border transition-colors',
+                    filters.aiAction === value
+                      ? value === 'fixable'
+                        ? 'bg-green-100 text-green-800 border-green-300'
+                        : 'bg-primary-100 text-primary-700 border-primary-300'
+                      : 'bg-white text-gray-600 border-gray-300 hover:bg-gray-50'
+                  )}
+                >
+                  {label}
+                </button>
+              ))}
+            </div>
+
             {hasActiveFilters && (
               <div className="flex items-center gap-2">
                 <span className="text-sm text-gray-600">Active filters:</span>
@@ -1177,22 +1319,6 @@ export const PdfAuditResultsPage: React.FC = () => {
                   {uniqueWcagCriteria.map((criterion) => (
                     <option key={criterion} value={criterion}>
                       WCAG {criterion}
-                    </option>
-                  ))}
-                </select>
-
-                {/* Matterhorn category filter */}
-                <select
-                  value={filters.matterhornCategory}
-                  onChange={(e) =>
-                    setFilters((prev) => ({ ...prev, matterhornCategory: e.target.value }))
-                  }
-                  className="w-full px-3 py-2 text-sm border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-primary-500"
-                >
-                  <option value="all">All Matterhorn Categories</option>
-                  {uniqueMatterhornCategories.map((cat) => (
-                    <option key={cat.id} value={cat.id}>
-                      {cat.id}: {cat.name}
                     </option>
                   ))}
                 </select>


### PR DESCRIPTION
## Summary
- Replaces the narrow Matterhorn-category dropdown (only 8 of 13 real category values, with `contrast`/`links`/`forms`/`bookmarks`/`formula` uncovered entirely) with an always-visible, multi-select category chip row covering all 13 categories with live counts (the four `table-*` sub-kinds fold into a single `Tables` bucket, matching existing backend-code treatment).
- Adds an AI-action filter (`All` / `Fixable now` / `Guidance only` / `Applied` / `Rejected`) — the primary driving use case is "quickly filter to issues where an AI fix is available to apply."
- **Scope correction from the original spec** (caught during implementation, confirmed with the requester): the spec's Change 1 said to remove the `matterhornCategory` field/mechanism entirely, but `handleMatterhornCheckpointClick` (wired to `MatterhornSummary`'s `onCheckpointClick` — clicking a checkpoint chip in the compliance summary jumps to filtered issues) depends on that exact field, and its primary checkpoint matching comes from `issue.matterhornCheckpoint`/code prefix, not the `category` field — rerouting it through the new chips would have been a real, silent coverage regression. So only the `<select>` dropdown control (and the now-truly-unused `uniqueMatterhornCategories`) came out; `getIssueCheckpoint`/`CATEGORY_TO_MATTERHORN`/the filter block/the checkpoint-click handler are untouched. A small dismissible "Checkpoint NN ×" pill was added next to the category chips so the active checkpoint filter — previously only visible via the removed dropdown — stays visible and clearable.

## Test plan
- [x] `npm run type-check` passes
- [x] `npm run lint` passes
- [x] New "Category and AI action filters" suite: chip counts (and omission when zero), multi-select union + toggle-off, each AI-action state in isolation, category+AI-action combined with AND semantics, the checkpoint pill's show/dismiss (unchanged click mechanism), and Clear resetting both new filters alongside the existing ones (7 new tests, 33 total passing in the full file)
- [ ] Manual: open a comprehensive-scan job with mixed issue categories, click through chips/AI-action combos, apply a fix and confirm it live-moves from "Fixable now" to "Applied" without a reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added category filters for PDF audit issues, including issue counts and table-related categories.
  * Added AI suggestion filters for fixable, guidance-only, applied, and rejected suggestions.
  * Enabled combining category and AI filters, with options to clear individual selections or reset all filters.
  * Preserved Matterhorn filtering through checkpoint interactions and the Matterhorn toggle.

* **Tests**
  * Added coverage for category counts, multi-selection, AI filtering, combined filters, and filter reset behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->