### PR TITLE
fix(pdf): un-gate bulk-apply trigger, add counts to AI action chips

### DIFF
--- a/src/pages/PdfAuditResultsPage.test.tsx
+++ b/src/pages/PdfAuditResultsPage.test.tsx
@@ -824,7 +824,7 @@ describe('PdfAuditResultsPage', () => {
     });
   });
 
-  describe('Apply All Approved bulk action', () => {
+  describe('Apply Fixes bulk-apply trigger', () => {
     const jobId = 'job-123';
     const auditUrl = `/pdf/job/${jobId}/audit/result`;
     const statusUrl = `/pdf/${jobId}/auto-tag/status`;
@@ -855,7 +855,7 @@ describe('PdfAuditResultsPage', () => {
       },
     });
 
-    it('only counts approved, apply-to-pdf suggestions toward the bulk-apply button', async () => {
+    it('counts both approved and pending apply-to-pdf suggestions toward the bulk-apply button, excluding guidance-only', async () => {
       const mockResult = createMockAuditResult();
 
       mockApi.get.mockImplementation((url: string) => {
@@ -872,10 +872,10 @@ describe('PdfAuditResultsPage', () => {
 
       renderWithRouter(jobId);
 
-      expect(await screen.findByRole('button', { name: /Apply All Approved \(2\)/ })).toBeInTheDocument();
+      expect(await screen.findByRole('button', { name: /Apply Fixes \(3\)/ })).toBeInTheDocument();
     });
 
-    it('hides the bulk-apply button when there are no approved apply-to-pdf suggestions', async () => {
+    it('shows the bulk-apply button for a freshly-analyzed job where nothing has been individually approved yet (regression: was unreachable)', async () => {
       const mockResult = createMockAuditResult();
 
       mockApi.get.mockImplementation((url: string) => {
@@ -889,10 +889,27 @@ describe('PdfAuditResultsPage', () => {
 
       renderWithRouter(jobId);
 
+      expect(await screen.findByRole('button', { name: /Apply Fixes \(1\)/ })).toBeInTheDocument();
+    });
+
+    it('hides the bulk-apply button when there are no eligible apply-to-pdf suggestions at all', async () => {
+      const mockResult = createMockAuditResult();
+
+      mockApi.get.mockImplementation((url: string) => {
+        if (url === auditUrl) return Promise.resolve({ data: { data: mockResult } });
+        if (url === statusUrl) return Promise.resolve({ data: { data: { status: 'complete', taggerSource: 'adobe' } } });
+        if (url === aiUrl) return Promise.resolve(mockAiResponse([
+          { issueId: '1', applyMode: 'guidance-only', status: 'pending' },
+        ]));
+        return Promise.resolve({ data: { data: {} } });
+      });
+
+      renderWithRouter(jobId);
+
       await waitFor(() => {
         expect(screen.getByText('test-document.pdf')).toBeInTheDocument();
       });
-      expect(screen.queryByRole('button', { name: /Apply All Approved/ })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /Apply Fixes/ })).not.toBeInTheDocument();
     });
   });
 
@@ -1106,6 +1123,19 @@ describe('PdfAuditResultsPage', () => {
       expect(screen.queryByRole('button', { name: /^Metadata/ })).not.toBeInTheDocument();
     });
 
+    it('renders live counts on every AI action chip', async () => {
+      setupMocks();
+      renderWithRouter(jobId);
+      await screen.findByText('test-document.pdf');
+
+      // b: apply-to-pdf/pending (fixable). c: guidance-only. d: apply-to-pdf/applied.
+      expect(await screen.findByRole('button', { name: 'All (3)' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Fixable now (1)' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Guidance only (1)' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Applied (1)' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Rejected (0)' })).toBeInTheDocument();
+    });
+
     it('multi-selects categories as a union, and toggling one off narrows back', async () => {
       setupMocks();
       renderWithRouter(jobId);
@@ -1134,7 +1164,7 @@ describe('PdfAuditResultsPage', () => {
       renderWithRouter(jobId);
       await screen.findByText('test-document.pdf');
 
-      fireEvent.click(await screen.findByRole('button', { name: 'Fixable now' }));
+      fireEvent.click(await screen.findByRole('button', { name: 'Fixable now (1)' }));
       await waitFor(() => {
         expect(visibleIssueIds()).toEqual(['b']);
       });
@@ -1145,12 +1175,12 @@ describe('PdfAuditResultsPage', () => {
       renderWithRouter(jobId);
       await screen.findByText('test-document.pdf');
 
-      fireEvent.click(await screen.findByRole('button', { name: 'Applied' }));
+      fireEvent.click(await screen.findByRole('button', { name: 'Applied (1)' }));
       await waitFor(() => {
         expect(visibleIssueIds()).toEqual(['d']);
       });
 
-      fireEvent.click(screen.getByRole('button', { name: 'Guidance only' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Guidance only (1)' }));
       await waitFor(() => {
         expect(visibleIssueIds()).toEqual(['c']);
       });
@@ -1162,7 +1192,7 @@ describe('PdfAuditResultsPage', () => {
       await screen.findByText('test-document.pdf');
 
       fireEvent.click(await screen.findByRole('button', { name: 'Contrast (2)' }));
-      fireEvent.click(screen.getByRole('button', { name: 'Fixable now' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Fixable now (1)' }));
 
       await waitFor(() => {
         // Contrast has b (pending) and d (applied) — only b is still fixable.
@@ -1191,7 +1221,7 @@ describe('PdfAuditResultsPage', () => {
       await screen.findByText('test-document.pdf');
 
       fireEvent.click(await screen.findByRole('button', { name: 'Contrast (2)' }));
-      fireEvent.click(screen.getByRole('button', { name: 'Fixable now' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Fixable now (1)' }));
       await waitFor(() => {
         expect(visibleIssueIds()).toEqual(['b']);
       });

--- a/src/pages/PdfAuditResultsPage.tsx
+++ b/src/pages/PdfAuditResultsPage.tsx
@@ -478,6 +478,21 @@ export const PdfAuditResultsPage: React.FC = () => {
     return counts;
   }, [auditResult]);
 
+  // Mirrors the "fixable" definition used in the filteredIssues filter logic
+  // below — keep both in sync if that logic ever changes.
+  const aiActionCounts = useMemo(() => {
+    let fixable = 0, guidanceOnly = 0, applied = 0, rejected = 0;
+    for (const suggestion of aiSuggestions.values()) {
+      if (suggestion.applyMode === 'apply-to-pdf' && (suggestion.status === 'pending' || suggestion.status === 'approved')) {
+        fixable++;
+      }
+      if (suggestion.applyMode === 'guidance-only') guidanceOnly++;
+      if (suggestion.status === 'applied') applied++;
+      if (suggestion.status === 'rejected') rejected++;
+    }
+    return { fixable, guidanceOnly, applied, rejected };
+  }, [aiSuggestions]);
+
   // Handlers
   const handlePageChange = useCallback((page: number) => {
     setCurrentPage(page);
@@ -1126,14 +1141,14 @@ export const PdfAuditResultsPage: React.FC = () => {
                 >
                   {isFullscreen ? <Minimize2 className="h-4 w-4" /> : <Maximize2 className="h-4 w-4" />}
                 </button>
-              {eligibleForApplyAll > 0 && (
+              {(eligibleForApplyAll + pendingEligible) > 0 && (
                 <Button
                   variant="primary"
                   size="sm"
                   onClick={() => setShowApplyAllPanel(true)}
                 >
                   <Zap className="h-4 w-4 mr-1" />
-                  Apply All Approved ({eligibleForApplyAll})
+                  Apply Fixes ({eligibleForApplyAll + pendingEligible})
                 </Button>
               )}
               <Button
@@ -1239,13 +1254,13 @@ export const PdfAuditResultsPage: React.FC = () => {
               <span className="text-sm text-gray-600 mr-1">AI:</span>
               {(
                 [
-                  ['all', 'All'],
-                  ['fixable', 'Fixable now'],
-                  ['guidance-only', 'Guidance only'],
-                  ['applied', 'Applied'],
-                  ['rejected', 'Rejected'],
+                  ['all', 'All', aiSuggestions.size],
+                  ['fixable', 'Fixable now', aiActionCounts.fixable],
+                  ['guidance-only', 'Guidance only', aiActionCounts.guidanceOnly],
+                  ['applied', 'Applied', aiActionCounts.applied],
+                  ['rejected', 'Rejected', aiActionCounts.rejected],
                 ] as const
-              ).map(([value, label]) => (
+              ).map(([value, label, count]) => (
                 <button
                   key={value}
                   type="button"
@@ -1259,7 +1274,7 @@ export const PdfAuditResultsPage: React.FC = () => {
                       : 'bg-white text-gray-600 border-gray-300 hover:bg-gray-50'
                   )}
                 >
-                  {label}
+                  {label} ({count})
                 </button>
               ))}
             </div>


### PR DESCRIPTION
## Summary
- Live UAT on staging surfaced two gaps in the filters/bulk-apply work from PR #299/#300.
- **Fix 1**: the "Apply All Approved" button gated on `eligibleForApplyAll > 0`, which only counts `status === 'approved'` suggestions. A freshly-analyzed job has every apply-to-pdf suggestion sitting at `pending` (nothing individually approved yet), so the button never rendered — even though `ApplyAllSuggestionsPanel` already fully supports bulk-applying pending suggestions via its own "include pending" checkbox. Now gates on `eligibleForApplyAll + pendingEligible > 0` and relabels to "Apply Fixes (N)" since the count includes pending too. `ApplyAllSuggestionsPanel` itself needed no changes — it already renders the approved/pending split correctly and defaults to approved-only.
- **Fix 2**: the AI action chips (`All`/`Fixable now`/`Guidance only`/`Applied`/`Rejected`) didn't show counts, unlike the category chips right above them. Added an `aiActionCounts` useMemo and wired counts into all five.

## Test plan
- [x] `npm run type-check` passes
- [x] `npm run lint` passes
- [x] Updated the two existing bulk-apply tests whose premises the fix invalidated — one now directly confirms the regression this fixes (a pending-only job shows "Apply Fixes (1)", where it previously showed nothing)
- [x] Fixed count-suffix mismatches in the newer category/AI-action filter tests and added a dedicated test asserting all five AI-action chip counts render correctly together
- [x] Full file: 35 tests passing
- [ ] Manual: open a job with AI analysis run but nothing individually approved, confirm "Apply Fixes (N)" appears and applying via the panel's "include pending" checkbox actually applies suggestions; spot-check the mixed approved+pending case still works too

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added live counts to AI action filters, including fixable, guidance-only, applied, and rejected suggestions.
  - Updated the bulk action to “Apply Fixes” and displayed the combined number of pending and approved PDF fixes.
  - The bulk action now appears whenever eligible fixes are available.

- **Bug Fixes**
  - Guidance-only suggestions are excluded from fix counts and bulk actions.
  - The bulk action is hidden when no eligible fixes exist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->