### PR TITLE
feat(pdf): surface strip-and-retag outcome on the Auto Tag card

### DIFF
--- a/src/components/pdf/PdfStatsCards.test.tsx
+++ b/src/components/pdf/PdfStatsCards.test.tsx
@@ -68,6 +68,87 @@ describe('PdfStatsCards — Auto Tag card status display', () => {
   });
 });
 
+describe('PdfStatsCards — strip-and-retag empty-shell indicator', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('a genuinely well-tagged skip (no completeness data) looks exactly as before — no regression', () => {
+    renderCard({ status: 'skipped', skipReason: 'already-tagged' });
+
+    expect(screen.getByText('Document already tagged — audited existing structure')).toBeInTheDocument();
+    expect(screen.queryByText(/Existing structure incomplete/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/none carry real content types/)).not.toBeInTheDocument();
+  });
+
+  it('a well-tagged skip with completeness data confirming it is NOT an empty shell still looks normal', () => {
+    renderCard({
+      status: 'skipped',
+      skipReason: 'already-tagged',
+      structureTreeCompleteness: { totalElements: 40, semanticElements: 12, isEmptyShell: false },
+    });
+
+    expect(screen.getByText('Document already tagged — audited existing structure')).toBeInTheDocument();
+    expect(screen.queryByText(/Existing structure incomplete/)).not.toBeInTheDocument();
+  });
+
+  it('an unresolved empty-shell skip shows the amber warning with the element count, not the calm blue message', () => {
+    renderCard({
+      status: 'skipped',
+      skipReason: 'already-tagged',
+      structureTreeCompleteness: { totalElements: 40, semanticElements: 0, isEmptyShell: true },
+    });
+
+    // Detail section (with the element count) is visible by default — expanded.
+    expect(screen.getByText(/Existing structure has 40 element\(s\) but none carry real content types/)).toBeInTheDocument();
+    expect(screen.queryByText('Document already tagged — audited existing structure')).not.toBeInTheDocument();
+
+    collapseAutoTagCard();
+    expect(screen.getByText('Existing structure incomplete')).toBeInTheDocument();
+  });
+
+  it('appends the retag-attempted-but-failed note only for failed-retag-error, not failed-strip-bailed', () => {
+    const { unmount } = renderCard({
+      status: 'skipped',
+      skipReason: 'already-tagged',
+      structureTreeCompleteness: { totalElements: 10, semanticElements: 0, isEmptyShell: true },
+      retagOutcome: 'failed-strip-bailed',
+    });
+    expect(screen.queryByText(/Automatic re-tagging was attempted but failed/)).not.toBeInTheDocument();
+    unmount();
+
+    renderCard({
+      status: 'skipped',
+      skipReason: 'already-tagged',
+      structureTreeCompleteness: { totalElements: 10, semanticElements: 0, isEmptyShell: true },
+      retagOutcome: 'failed-retag-error',
+    });
+    expect(screen.getByText(/Automatic re-tagging was attempted but failed/)).toBeInTheDocument();
+  });
+
+  it('a successful retag shows the normal green complete state plus "(retagged)" and the strip-and-retag note', () => {
+    renderCard({
+      status: 'complete',
+      taggerSource: 'seam-c',
+      elementCounts: { figure: 3 },
+      retagOutcome: 'success',
+    });
+
+    // Detail section (with the strip-and-retag note) is visible by default — expanded.
+    expect(screen.getByText(/stripped and re-tagged from scratch/)).toBeInTheDocument();
+
+    collapseAutoTagCard();
+    expect(screen.getByText(/Seam-C \(YOLO\)\s*\(retagged\)/)).toBeInTheDocument();
+  });
+
+  it('a normal first-time complete tag (no retagOutcome) shows no "(retagged)" suffix or strip note', () => {
+    renderCard({ status: 'complete', taggerSource: 'seam-c', elementCounts: { figure: 3 } });
+
+    expect(screen.queryByText(/retagged/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/stripped and re-tagged from scratch/)).not.toBeInTheDocument();
+  });
+});
+
 describe('PdfStatsCards — AI Analysis card color-contrast re-analysis link', () => {
   const emptyAiStats = {
     gemini: { totalTokens: 0, estimatedCostUsd: 0 },

--- a/src/components/pdf/PdfStatsCards.tsx
+++ b/src/components/pdf/PdfStatsCards.tsx
@@ -100,6 +100,12 @@ export interface AutoTagInfo {
     regressions: number;
     resolutionRate: number;
   };
+  structureTreeCompleteness?: {
+    totalElements: number;
+    semanticElements: number;
+    isEmptyShell: boolean;
+  } | null;
+  retagOutcome?: 'success' | 'failed-strip-bailed' | 'failed-retag-error' | null;
 }
 
 export interface AiStatsData {
@@ -294,6 +300,9 @@ export function PdfStatsCards({
   // ─── Card 1: Auto Tag ────────────────────────────────────────────────────────
 
   const atStatus = autoTagInfo?.status;
+  const isEmptyShellSkip = atStatus === 'skipped'
+    && autoTagInfo?.skipReason === 'already-tagged'
+    && autoTagInfo?.structureTreeCompleteness?.isEmptyShell === true;
   const elems = autoTagInfo?.elementCounts;
   const elemEntries = elems
     ? Object.entries(elems).filter(([, n]) => n > 0).sort(([, a], [, b]) => b - a)
@@ -305,14 +314,17 @@ export function PdfStatsCards({
       ? <AlertTriangle className="h-4 w-4 text-amber-500" />
       : atStatus === 'processing'
         ? <Loader2 className="h-4 w-4 text-blue-500 animate-spin" />
-        : atStatus === 'skipped' && autoTagInfo?.skipReason === 'already-tagged'
-          ? <Info className="h-4 w-4 text-blue-500" />
-          : <Tag className="h-4 w-4 text-gray-400" />;
+        : isEmptyShellSkip
+          ? <AlertTriangle className="h-4 w-4 text-amber-500" />
+          : atStatus === 'skipped' && autoTagInfo?.skipReason === 'already-tagged'
+            ? <Info className="h-4 w-4 text-blue-500" />
+            : <Tag className="h-4 w-4 text-gray-400" />;
 
   const autoTagSummary = atStatus === 'complete' ? (
     <>
       <span className="text-xs font-medium text-green-700">
         ✓ {autoTagInfo?.taggerSource === 'seam-c' ? 'Seam-C (YOLO)' : 'Adobe'}
+        {autoTagInfo?.retagOutcome === 'success' && ' (retagged)'}
       </span>
       {elemEntries.slice(0, 4).map(([key, n]) => (
         <SummaryMetric key={key} n={n} label={elementLabel(key, 'short')} />
@@ -322,6 +334,8 @@ export function PdfStatsCards({
     <span className="text-xs text-amber-700 font-medium">Auto-tagging failed</span>
   ) : atStatus === 'processing' ? (
     <span className="text-xs text-blue-700">Auto-tagging in progress…</span>
+  ) : isEmptyShellSkip ? (
+    <span className="text-xs text-amber-700 font-medium">Existing structure incomplete</span>
   ) : atStatus === 'skipped' && autoTagInfo?.skipReason === 'already-tagged' ? (
     <span className="text-xs text-gray-600 font-medium">Document already tagged</span>
   ) : atStatus === 'skipped' && autoTagInfo?.skipReason === 'no-tagger-configured' ? (
@@ -337,6 +351,12 @@ export function PdfStatsCards({
           {elemEntries.map(([key, n]) => (
             <DetailRow key={key} label={elementLabel(key, 'full')} value={n} />
           ))}
+        </div>
+      )}
+      {autoTagInfo?.retagOutcome === 'success' && (
+        <div className="flex items-center gap-2 text-xs text-blue-700 bg-blue-50 rounded px-3 py-2">
+          <Sparkles className="h-3.5 w-3.5 flex-shrink-0" />
+          The existing structure was an empty shell (tagged, but with no real content types) — it was stripped and re-tagged from scratch.
         </div>
       )}
       {autoTagInfo?.adobeFlags && autoTagInfo.adobeFlags.length > 0 && (
@@ -358,7 +378,14 @@ export function PdfStatsCards({
           </button>
         </div>
       )}
-      {atStatus === 'skipped' && autoTagInfo?.skipReason === 'already-tagged' && (
+      {isEmptyShellSkip && (
+        <div className="flex items-center gap-2 text-xs text-amber-700 bg-amber-50 rounded px-3 py-2">
+          <AlertTriangle className="h-3.5 w-3.5 flex-shrink-0" />
+          Existing structure has {autoTagInfo?.structureTreeCompleteness?.totalElements ?? 0} element(s) but none carry real content types (Figure/Paragraph/Heading/Table) — fixes like alt-text may fail to apply.
+          {autoTagInfo?.retagOutcome === 'failed-retag-error' && ' Automatic re-tagging was attempted but failed.'}
+        </div>
+      )}
+      {atStatus === 'skipped' && autoTagInfo?.skipReason === 'already-tagged' && !isEmptyShellSkip && (
         <div className="flex items-center gap-2 text-xs text-gray-600">
           <Info className="h-3.5 w-3.5 flex-shrink-0" />
           Document already tagged — audited existing structure

--- a/src/pages/PdfAuditResultsPage.tsx
+++ b/src/pages/PdfAuditResultsPage.tsx
@@ -207,6 +207,8 @@ export const PdfAuditResultsPage: React.FC = () => {
     adobeFlags?: Array<{ elementType?: string; page?: number; confidence?: string; reviewComment?: string }>;
     postRemediationStatus?: 'pending' | 'complete' | 'failed';
     postRemediationAudit?: { runAt: string; resolved: number; remaining: number; regressions: number; resolutionRate: number };
+    structureTreeCompleteness?: { totalElements: number; semanticElements: number; isEmptyShell: boolean } | null;
+    retagOutcome?: 'success' | 'failed-strip-bailed' | 'failed-retag-error' | null;
   } | null>(null);
   const [isRetryingAutoTag, setIsRetryingAutoTag] = useState(false);
   const [showPacReport, setShowPacReport] = useState(false);


### PR DESCRIPTION
## Summary
- Backend PR #478 (verified merged, sha `b3ab945`, plus its stack #476/#477) strips and re-tags from scratch when a PDF's existing structure tree turns out to be an "empty shell" (real `/StructTreeRoot`, but every element is a generic grouping type like `/Part`/`/Document` — zero `/Figure`/`/P`/`/Heading`/`/Table`), for jobs run with `forceAutoTag` (Comparison Study trials). Found via a real pilot document whose alt-text bulk-apply failed 9/9 times with "no Figure elements to attach to" — the structure tree existed but had nothing real in it.
- `GET /pdf/:jobId/auto-tag/status` now returns `structureTreeCompleteness` and `retagOutcome` — confirmed the exact shape against the merged controller source before implementing.
- The Auto Tag card previously had no way to distinguish "genuinely well-tagged, nothing to do" from "tagged, but the tags are unusable" — both rendered as the same blue "Document already tagged" message.
- **Genuinely good already-tagged skip**: unchanged, exactly as it looked before — this is still the vast majority of jobs, and staying calm/blue here matters.
- **Unresolved empty-shell skip**: amber warning icon/summary/detail with the element count, plus an extra note when an automatic re-tag was attempted but failed (`failed-retag-error`, not `failed-strip-bailed`).
- **Successful strip-and-retag**: normal green "complete" state (same as any first-time tag) with a `(retagged)` suffix next to the tagger name, plus a blue detail note explaining what happened.
- Also included the optional type-hygiene fix in `PdfAuditResultsPage.tsx` so the `autoTagInfo` state's declared type actually reflects the new fields it now carries at runtime.

## Test plan
- [x] `npm run type-check` passes
- [x] `npm run lint` passes
- [x] New `PdfStatsCards.test.tsx` tests covering every reachable scenario: no regression on a genuine already-tagged skip (with and without completeness data confirming it's not an empty shell), the unresolved empty-shell amber warning with element count, the `failed-strip-bailed` vs `failed-retag-error` distinction, a successful retag's `(retagged)` suffix + note, and no regression on a normal first-time complete tag (6 new tests, 14 total in the file, all passing)
- [x] Full regression suite: 90 tests passing across `PdfStatsCards`, `PdfAuditResultsPage`, `ApplyAllSuggestionsPanel`, `IssueCard`
- [ ] Manual (needs #478 live on staging + a real job): retag-success against the known empty-shell pilot doc (Math_Olszewski_PDF.pdf), confirm a normal already-tagged job shows no visual change, and confirm the amber warning path if/when a bailed or failed retag surfaces for real

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Auto Tag status reporting for PDFs with incomplete or empty tagging structures.
  * Added clear warnings when existing tags are insufficient.
  * Displays whether automatic re-tagging succeeded or failed.
  * Improved first-time completion messaging.

* **Tests**
  * Added coverage for empty-shell detection, skipped documents, re-tagging outcomes, and completion behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->