### PR TITLE
feat(pdf): use density-weighted Matterhorn compliance instead of flat count

### DIFF
--- a/src/components/pdf/MatterhornSummary.test.tsx
+++ b/src/components/pdf/MatterhornSummary.test.tsx
@@ -154,4 +154,71 @@ describe('MatterhornSummary', () => {
     expect(screen.getByText('Matterhorn Protocol Compliance')).toBeInTheDocument();
     expect(screen.getAllByText('0%')[0]).toBeInTheDocument();
   });
+
+  describe('weighted compliance (backend PR #479)', () => {
+    it('uses weightedCompliance for the headline percentage when present, instead of the flat passed/total count', () => {
+      // Flat calc would be 7/10 = 70%, same fixture as the top-level tests —
+      // weightedCompliance gives partial credit and should win instead.
+      const weightedSummary: MatterhornSummaryType = { ...mockSummary, weightedCompliance: 88 };
+
+      render(<MatterhornSummary summary={weightedSummary} />);
+
+      expect(screen.getAllByText('88%')[0]).toBeInTheDocument();
+      expect(screen.queryByText('70%')).not.toBeInTheDocument();
+    });
+
+    it('falls back to the flat passed/total calculation for older jobs with no weightedCompliance (no regression)', () => {
+      // mockSummary deliberately has no weightedCompliance field, simulating
+      // a job audited before backend PR #479 shipped.
+      render(<MatterhornSummary summary={mockSummary} />);
+
+      expect(screen.getAllByText('70%')[0]).toBeInTheDocument();
+    });
+
+    it('shows a "% clean" note on a failed checkpoint that is mostly clean (completionRatio >= 50)', () => {
+      const summaryWithRatio: MatterhornSummaryType = {
+        ...mockSummary,
+        categories: mockSummary.categories.map((cat) =>
+          cat.id === '01'
+            ? {
+                ...cat,
+                checkpoints: cat.checkpoints.map((cp) =>
+                  cp.id === '01-002' ? { ...cp, completionRatio: 95 } : cp
+                ),
+              }
+            : cat
+        ),
+      };
+
+      render(<MatterhornSummary summary={summaryWithRatio} />);
+
+      expect(screen.getByText('95% clean')).toBeInTheDocument();
+    });
+
+    it('does not show the "% clean" note when completionRatio is below the 50% threshold', () => {
+      const summaryWithRatio: MatterhornSummaryType = {
+        ...mockSummary,
+        categories: mockSummary.categories.map((cat) =>
+          cat.id === '01'
+            ? {
+                ...cat,
+                checkpoints: cat.checkpoints.map((cp) =>
+                  cp.id === '01-002' ? { ...cp, completionRatio: 12 } : cp
+                ),
+              }
+            : cat
+        ),
+      };
+
+      render(<MatterhornSummary summary={summaryWithRatio} />);
+
+      expect(screen.queryByText(/% clean/)).not.toBeInTheDocument();
+    });
+
+    it('does not show the "% clean" note when completionRatio is absent (older jobs)', () => {
+      render(<MatterhornSummary summary={mockSummary} />);
+
+      expect(screen.queryByText(/% clean/)).not.toBeInTheDocument();
+    });
+  });
 });

--- a/src/components/pdf/MatterhornSummary.tsx
+++ b/src/components/pdf/MatterhornSummary.tsx
@@ -80,6 +80,9 @@ const CheckpointItem: React.FC<{
               {checkpoint.issueCount} {checkpoint.issueCount === 1 ? 'issue' : 'issues'}
             </Badge>
           )}
+          {checkpoint.status === 'failed' && checkpoint.completionRatio !== undefined && checkpoint.completionRatio >= 50 && (
+            <span className="text-xs text-gray-500">{checkpoint.completionRatio}% clean</span>
+          )}
         </div>
         <p className="text-sm text-gray-700">{checkpoint.description}</p>
       </div>
@@ -156,9 +159,11 @@ export const MatterhornSummary: React.FC<MatterhornSummaryProps> = ({
     return null;
   }
 
-  const passedPercentage = summary.totalCheckpoints > 0
-    ? Math.round((summary.passed / summary.totalCheckpoints) * 100)
-    : 0;
+  const passedPercentage = summary.weightedCompliance ?? (
+    summary.totalCheckpoints > 0
+      ? Math.round((summary.passed / summary.totalCheckpoints) * 100)
+      : 0
+  );
 
   const totalIssues = summary.categories.reduce(
     (sum, category) => sum + category.checkpoints.reduce((s, c) => s + c.issueCount, 0),

--- a/src/types/pdf.types.ts
+++ b/src/types/pdf.types.ts
@@ -53,6 +53,8 @@ export interface MatterhornCheckpoint {
   status: MatterhornCheckpointStatus;
   /** Number of issues found for this checkpoint (0 if passed) */
   issueCount: number;
+  /** 0-100: how much of the document is actually clean of this checkpoint's issues (page-density-weighted). Complements `status`, which stays strict (any issue = failed). Undefined on jobs audited before this field existed. */
+  completionRatio?: number;
 }
 
 /**
@@ -83,6 +85,8 @@ export interface MatterhornSummary {
   notApplicable: number;
   /** Grouped checkpoint results by category */
   categories: MatterhornCategory[];
+  /** 0-100: page-density-weighted average compliance across all checkpoints — moves incrementally as issues are fixed, unlike passed/totalCheckpoints which only changes when a whole category hits zero issues. Undefined on jobs audited before this field existed. */
+  weightedCompliance?: number;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Backend PR #479 (verified merged, sha `f5e7304`) fixes a real problem found during a live Comparison Study walkthrough: "Matterhorn Protocol Compliance" showed 50% and never moved, even as AI Analysis made real progress. Each of the 8 implemented checkpoints is zero-tolerance (1 issue anywhere in a category fails it identically to a category that's 100% broken), and the flat `passed/totalCheckpoints` count can't distinguish "almost done" from "barely started" within a category — so it plateaus for most of a remediation journey.
- The backend now computes `weightedCompliance` server-side (page-density-weighted average across checkpoints) plus a per-checkpoint `completionRatio` — confirmed the exact computation and shape against the merged service source before implementing.
- `MatterhornSummary.tsx`'s headline percentage now prefers `weightedCompliance`, falling back to the old flat calculation when absent. Jobs audited before this backend change shipped won't have the field in their stored `job.output` — verified via the *existing* test fixtures, which already lack the field and still pass unchanged, confirming zero regression without touching a single pre-existing test.
- Also adds an "X% clean" note on failed checkpoints that are mostly clean (≥ 50%), so a checkpoint blocked by 1 remaining issue no longer looks identical to one that's barely started.

## Test plan
- [x] `npm run type-check` passes
- [x] `npm run lint` passes
- [x] All 11 pre-existing `MatterhornSummary.test.tsx` tests pass unchanged (their fixtures have no `weightedCompliance`, so they already exercise and confirm the fallback path)
- [x] 5 new tests: weighted percentage overrides the flat calc when present, explicit fallback confirmation, the "% clean" note showing above threshold / hidden below threshold / hidden when `completionRatio` is absent (16 total in the file, all passing)
- [x] Broader regression: 65 tests passing across `MatterhornSummary`, `PdfStatsCards`, `PdfAuditResultsPage`
- [ ] Manual (needs #479 live on staging): open the Math_Olszewski_PDF.pdf trial or a fresh Comparison Study trial, confirm "Overall Compliance" is a different (typically higher) number than the old flat calc and the progress bar matches; confirm an older already-completed job still renders correctly with the flat fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Overall compliance summaries now use weighted compliance percentages when available.
  - Failed checkpoints can display a “% clean” completion note when at least half complete.
- **Bug Fixes**
  - Compliance calculations retain accurate fallback behavior for older audit data.
  - “% clean” notes are hidden when completion data is unavailable or below 50%.
- **Tests**
  - Added coverage for weighted compliance, fallback calculations, and completion-note display rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->